### PR TITLE
Wire real LLM adapter into chat

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -14,52 +14,56 @@ import 'package:isar/isar.dart' as _i6;
 import 'package:isar_agent_memory/isar_agent_memory.dart' as _i3;
 
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i27;
+    as _i29;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i19;
+    as _i21;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i20;
+    as _i22;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i4;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
     as _i5;
 import '../../features/health_record/infrastructure/services/ocr_service.dart'
-    as _i12;
-import '../../features/health_report/application/bloc/health_report_bloc.dart'
-    as _i28;
-import '../../features/health_report/domain/repositories/health_report_repository.dart'
-    as _i21;
-import '../../features/health_report/domain/services/report_generation_service.dart'
-    as _i13;
-import '../../features/health_report/infrastructure/repositories/isar_health_report_repository.dart'
-    as _i22;
-import '../../features/health_report/infrastructure/services/mock_report_generation_service.dart'
     as _i14;
+import '../../features/health_report/application/bloc/health_report_bloc.dart'
+    as _i30;
+import '../../features/health_report/domain/repositories/health_report_repository.dart'
+    as _i23;
+import '../../features/health_report/domain/services/report_generation_service.dart'
+    as _i15;
+import '../../features/health_report/infrastructure/repositories/isar_health_report_repository.dart'
+    as _i24;
+import '../../features/health_report/infrastructure/services/mock_report_generation_service.dart'
+    as _i16;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i25;
+    as _i27;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i7;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i17;
+    as _i19;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
     as _i9;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
     as _i8;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i23;
-import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i24;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i25;
+import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i26;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i18;
-import '../../features/medications/domain/repositories/medication_repository.dart'
+    as _i20;
+import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i10;
-import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+import '../../features/local_agent/infrastructure/services/model_download_service.dart'
+    as _i13;
+import '../../features/medications/domain/repositories/medication_repository.dart'
     as _i11;
+import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+    as _i12;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i26;
+    as _i28;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i15;
+    as _i17;
 import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
-    as _i16;
-import 'database_module.dart' as _i30;
-import 'memory_module.dart' as _i29;
+    as _i18;
+import 'database_module.dart' as _i32;
+import 'memory_module.dart' as _i31;
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -91,8 +95,9 @@ extension GetItInjectableX on _i1.GetIt {
       () => _i9.GeminiLlmAdapter(apiKey: gh<String>()),
       instanceName: 'gemini',
     );
-    gh.lazySingleton<_i10.MedicationRepository>(
-        () => _i11.IsarMedicationRepository(gh<_i6.Isar>()));
+    gh.lazySingleton<_i10.LocalLlmService>(() => _i10.LocalLlmService());
+    gh.lazySingleton<_i11.MedicationRepository>(
+        () => _i12.IsarMedicationRepository(gh<_i6.Isar>()));
     await gh.lazySingletonAsync<_i3.MemoryGraph>(
       () => memoryModule.memoryGraph(
         gh<_i6.Isar>(),
@@ -100,38 +105,44 @@ extension GetItInjectableX on _i1.GetIt {
       ),
       preResolve: true,
     );
-    gh.lazySingleton<_i12.OcrService>(() => _i12.OcrServiceStub());
-    gh.lazySingleton<_i13.ReportGenerationService>(
-        () => _i14.MockReportGenerationService());
-    gh.lazySingleton<_i15.UserProfileRepository>(
-        () => _i16.UserProfileRepositoryImpl(gh<_i6.Isar>()));
-    gh.lazySingleton<_i17.VectorStoreService>(
-        () => _i18.IsarVectorStoreService(gh<_i3.MemoryGraph>()));
-    gh.lazySingleton<_i19.HealthRecordRepository>(
-        () => _i20.HealthRecordRepositoryImpl(gh<_i6.Isar>()));
-    gh.lazySingleton<_i21.HealthReportRepository>(
-        () => _i22.IsarHealthReportRepository(gh<_i6.Isar>()));
-    gh.lazySingleton<_i23.LlmService>(
-        () => _i24.RagLlmService(gh<_i17.VectorStoreService>()));
-    gh.lazySingleton<_i25.SmartSearchUseCase>(
-        () => _i25.SmartSearchUseCase(gh<_i17.VectorStoreService>()));
-    gh.factory<_i26.UserProfileCubit>(
-        () => _i26.UserProfileCubit(gh<_i15.UserProfileRepository>()));
-    gh.factory<_i27.HealthRecordCubit>(() => _i27.HealthRecordCubit(
-          gh<_i19.HealthRecordRepository>(),
+    gh.lazySingleton<_i13.ModelDownloadService>(
+        () => _i13.ModelDownloadService());
+    gh.lazySingleton<_i14.OcrService>(() => _i14.OcrServiceStub());
+    gh.lazySingleton<_i15.ReportGenerationService>(
+        () => _i16.MockReportGenerationService());
+    gh.lazySingleton<_i17.UserProfileRepository>(
+        () => _i18.UserProfileRepositoryImpl(gh<_i6.Isar>()));
+    gh.lazySingleton<_i19.VectorStoreService>(
+        () => _i20.IsarVectorStoreService(gh<_i3.MemoryGraph>()));
+    gh.lazySingleton<_i21.HealthRecordRepository>(
+        () => _i22.HealthRecordRepositoryImpl(gh<_i6.Isar>()));
+    gh.lazySingleton<_i23.HealthReportRepository>(
+        () => _i24.IsarHealthReportRepository(gh<_i6.Isar>()));
+    gh.lazySingleton<_i25.LlmService>(() => _i26.RagLlmService(
+          gh<_i19.VectorStoreService>(),
+          gh<_i17.UserProfileRepository>(),
+          gh<_i10.LocalLlmService>(),
+          gh<_i7.LlmAdapter>(instanceName: 'gemini'),
+        ));
+    gh.lazySingleton<_i27.SmartSearchUseCase>(
+        () => _i27.SmartSearchUseCase(gh<_i19.VectorStoreService>()));
+    gh.factory<_i28.UserProfileCubit>(
+        () => _i28.UserProfileCubit(gh<_i17.UserProfileRepository>()));
+    gh.factory<_i29.HealthRecordCubit>(() => _i29.HealthRecordCubit(
+          gh<_i21.HealthRecordRepository>(),
           gh<_i4.FilePickerService>(),
           gh<_i5.ImagePickerService>(),
-          gh<_i12.OcrService>(),
-          gh<_i17.VectorStoreService>(),
+          gh<_i14.OcrService>(),
+          gh<_i19.VectorStoreService>(),
         ));
-    gh.factory<_i28.HealthReportBloc>(() => _i28.HealthReportBloc(
-          gh<_i21.HealthReportRepository>(),
-          gh<_i13.ReportGenerationService>(),
+    gh.factory<_i30.HealthReportBloc>(() => _i30.HealthReportBloc(
+          gh<_i23.HealthReportRepository>(),
+          gh<_i15.ReportGenerationService>(),
         ));
     return this;
   }
 }
 
-class _$MemoryModule extends _i29.MemoryModule {}
+class _$MemoryModule extends _i31.MemoryModule {}
 
-class _$DatabaseModule extends _i30.DatabaseModule {}
+class _$DatabaseModule extends _i32.DatabaseModule {}

--- a/lib/features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart
+++ b/lib/features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart
@@ -9,12 +9,16 @@ import '../../domain/services/llm_adapter.dart';
 @LazySingleton(as: LlmAdapter)
 @Named('gemini')
 class GeminiLlmAdapter implements LlmAdapter {
-  final GenerativeModel? _model;
+  GenerativeModel? _model;
 
   GeminiLlmAdapter({String? apiKey})
     : _model = apiKey != null && apiKey.isNotEmpty
           ? GenerativeModel(model: 'gemini-pro', apiKey: apiKey)
           : null;
+
+  void updateApiKey(String apiKey) {
+    _model = GenerativeModel(model: 'gemini-pro', apiKey: apiKey);
+  }
 
   @override
   String get modelName => 'gemini-pro';
@@ -24,8 +28,7 @@ class GeminiLlmAdapter implements LlmAdapter {
     return _model != null;
   }
 
-  @override
-  Future<String> generate(String prompt) async {
+  Future<String> generateSummary(String prompt) async {
     if (_model == null) {
       throw StateError(
         'Gemini API key not configured. Cannot generate summaries.',
@@ -33,10 +36,34 @@ class GeminiLlmAdapter implements LlmAdapter {
     }
 
     try {
-      final response = await _model.generateContent([Content.text(prompt)]);
+      final response = await _model!.generateContent([Content.text(prompt)]);
       return response.text ?? '';
     } catch (e) {
       throw Exception('Failed to generate summary: $e');
     }
   }
+
+  Stream<String> generateStream(String prompt) async* {
+    if (_model == null) {
+      yield 'Error: Gemini API key not configured.';
+      return;
+    }
+
+    try {
+      final responses = _model!.generateContentStream([Content.text(prompt)]);
+      await for (final response in responses) {
+        if (response.text != null) {
+          yield response.text!;
+        }
+      }
+    } catch (e) {
+      yield 'Error calling Gemini: $e';
+    }
+  }
+
+  // Implementation for LlmService interface (via mixin or similar if needed, but here we just name them differently or use one for both if return types matched)
+  // Since they don't match, we have a conflict if we try to implement both as 'generate'
+
+  @override
+  Future<String> generate(String prompt) => generateSummary(prompt);
 }

--- a/lib/features/local_agent/infrastructure/rag_llm_service.dart
+++ b/lib/features/local_agent/infrastructure/rag_llm_service.dart
@@ -1,12 +1,28 @@
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:injectable/injectable.dart';
+import 'package:orionhealth_health/features/local_agent/domain/services/llm_adapter.dart';
 import 'package:orionhealth_health/features/local_agent/domain/services/vector_store_service.dart';
+import 'package:orionhealth_health/features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart';
 import 'package:orionhealth_health/features/local_agent/infrastructure/llm_service.dart';
+import 'package:orionhealth_health/features/local_agent/infrastructure/services/local_llm_service.dart';
+import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
+
+enum LlmProvider { mock, local, gemini }
 
 @LazySingleton(as: LlmService)
 class RagLlmService implements LlmService {
   final VectorStoreService _vectorStoreService;
+  final UserProfileRepository _userProfileRepository;
+  final LocalLlmService _localLlmService;
+  final GeminiLlmAdapter _geminiLlmAdapter;
+  final FlutterSecureStorage _secureStorage = const FlutterSecureStorage();
 
-  RagLlmService(this._vectorStoreService);
+  RagLlmService(
+    this._vectorStoreService,
+    this._userProfileRepository,
+    this._localLlmService,
+    @Named('gemini') LlmAdapter geminiLlmAdapter,
+  ) : _geminiLlmAdapter = geminiLlmAdapter as GeminiLlmAdapter;
 
   @override
   Stream<String> generate(String prompt) async* {
@@ -18,16 +34,61 @@ class RagLlmService implements LlmService {
       contextText = "\n\nContexto relevante encontrado:\n${contextDocs.map((d) => "- $d").join("\n")}";
     }
 
-    // 2. Simulate generation with context awareness
-    final response = "Entendido. Basado en tu consulta '$prompt' y en mi memoria:$contextText\n\n"
+    final fullPrompt = "Context: $contextText\n\nUser Question: $prompt";
+
+    // 2. Determine which provider to use
+    final profile = await _userProfileRepository.getUserProfile();
+    final providerStr = profile?.llmProvider;
+    LlmProvider provider = LlmProvider.mock;
+
+    if (providerStr != null) {
+      provider = LlmProvider.values.firstWhere(
+        (e) => e.name == providerStr,
+        orElse: () => LlmProvider.mock,
+      );
+    } else {
+      // Default logic: gemini if API key configured, else local, else mock
+      final apiKey = await _secureStorage.read(key: 'gemini_api_key');
+      if (apiKey != null && apiKey.isNotEmpty) {
+        provider = LlmProvider.gemini;
+      } else {
+        // We could check if local is available here, but let's stick to mock as safe default
+        provider = LlmProvider.mock;
+      }
+    }
+
+    // 3. Delegate to the selected provider
+    switch (provider) {
+      case LlmProvider.gemini:
+        final apiKey = await _secureStorage.read(key: 'gemini_api_key');
+        if (apiKey != null) {
+          _geminiLlmAdapter.updateApiKey(apiKey);
+          yield* _geminiLlmAdapter.generateStream(fullPrompt);
+        } else {
+          yield 'Error: Gemini API key not found in secure storage.';
+        }
+        break;
+      case LlmProvider.local:
+        if (profile?.localModelName != null) {
+          _localLlmService.setModel(profile!.localModelName!);
+        }
+        yield* _localLlmService.generate(fullPrompt);
+        break;
+      case LlmProvider.mock:
+        yield* _generateMockResponse(prompt, contextText, contextDocs.length);
+    }
+  }
+
+  Stream<String> _generateMockResponse(String prompt, String contextText, int contextCount) async* {
+    final response = "Entendido (MOCK). Basado en tu consulta '$prompt' y en mi memoria:$contextText\n\n"
         "Aquí está mi análisis:\n"
         "1. He consultado la base de conocimientos local.\n"
-        "2. He encontrado ${contextDocs.length} referencias relevantes.\n"
+        "2. He encontrado $contextCount referencias relevantes.\n"
         "3. Como soy un agente local seguro, tus datos no salen del dispositivo.\n\n"
         "¿Necesitas ayuda con algún registro médico específico?";
 
     for (var i = 0; i < response.length; i++) {
-      await Future.delayed(const Duration(milliseconds: 30));
+      await Future.delayed(const Duration(milliseconds: 10));
       yield response[i];
     }
   }

--- a/lib/features/local_agent/infrastructure/services/local_llm_service.dart
+++ b/lib/features/local_agent/infrastructure/services/local_llm_service.dart
@@ -1,0 +1,74 @@
+import 'dart:async';
+import 'dart:convert';
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:orionhealth_health/features/local_agent/infrastructure/llm_service.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+@lazySingleton
+class LocalLlmService implements LlmService {
+  final Dio _dio = Dio();
+  String _modelName = 'gemma:2b';
+  final String _baseUrl = 'http://localhost:11434';
+
+  @override
+  Stream<String> generate(String prompt) async* {
+    try {
+      final response = await _dio.post(
+        '$_baseUrl/api/generate',
+        data: {
+          'model': _modelName,
+          'prompt': prompt,
+          'stream': true,
+        },
+        options: Options(responseType: ResponseType.stream),
+      );
+
+      final stream = response.data.stream as Stream<List<int>>;
+
+      await for (final chunk in stream.transform(utf8.decoder).transform(const LineSplitter())) {
+        if (chunk.trim().isEmpty) continue;
+        try {
+          final json = jsonDecode(chunk);
+          final text = json['response'] as String?;
+          if (text != null) {
+            yield text;
+          }
+          if (json['done'] == true) {
+            break;
+          }
+        } catch (e) {
+          // Ignore parse errors for partial chunks
+        }
+      }
+    } catch (e) {
+      yield 'Error connecting to local LLM: $e';
+    }
+  }
+
+  void setModel(String modelName) {
+    _modelName = modelName;
+  }
+
+  Future<bool> isModelDownloaded(String modelName) async {
+    // For Ollama, we'd ideally check via tags API, but the task also mentions GGUF files.
+    // Let's check both if possible or stick to a simple check.
+    try {
+      final response = await _dio.get('$_baseUrl/api/tags');
+      if (response.statusCode == 200) {
+        final models = response.data['models'] as List;
+        return models.any((m) => m['name'] == modelName);
+      }
+    } catch (e) {
+      // If Ollama is not running or other error
+    }
+
+    // Also check local models directory for GGUF
+    final directory = await getApplicationDocumentsDirectory();
+    final modelsPath = p.join(directory.path, 'models');
+    final file = File(p.join(modelsPath, modelName));
+    return await file.exists();
+  }
+}

--- a/lib/features/local_agent/infrastructure/services/model_download_service.dart
+++ b/lib/features/local_agent/infrastructure/services/model_download_service.dart
@@ -1,0 +1,127 @@
+import 'dart:io';
+import 'package:dio/dio.dart';
+import 'package:injectable/injectable.dart';
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+
+class ModelInfo {
+  final String filename;
+  final int size;
+  final DateTime lastModified;
+  final String? parameters;
+
+  ModelInfo({
+    required this.filename,
+    required this.size,
+    required this.lastModified,
+    this.parameters,
+  });
+}
+
+@lazySingleton
+class ModelDownloadService {
+  final Dio _dio = Dio();
+
+  Future<String> get _localPath async {
+    final directory = await getApplicationDocumentsDirectory();
+    final modelsPath = p.join(directory.path, 'models');
+    final dir = Directory(modelsPath);
+    if (!await dir.exists()) {
+      await dir.create(recursive: true);
+    }
+    return modelsPath;
+  }
+
+  Future<void> downloadModel(
+    String hfUrl,
+    void Function(double progress, String speed, int downloadedMB, int totalMB) callback,
+  ) async {
+    final fileName = hfUrl.split('/').last;
+    final path = p.join(await _localPath, fileName);
+
+    int lastDownloaded = 0;
+    DateTime lastTime = DateTime.now();
+
+    await _dio.download(
+      hfUrl,
+      path,
+      onReceiveProgress: (received, total) {
+        if (total != -1) {
+          final progress = received / total;
+          final downloadedMB = received ~/ (1024 * 1024);
+          final totalMB = total ~/ (1024 * 1024);
+
+          final now = DateTime.now();
+          final duration = now.difference(lastTime).inMilliseconds;
+          if (duration >= 500) { // Update speed every 500ms
+            final bytesSinceLast = received - lastDownloaded;
+            final speedKBps = (bytesSinceLast / 1024) / (duration / 1000);
+            final speedMBps = speedKBps / 1024;
+            final speedString = "${speedMBps.toStringAsFixed(2)} MB/s";
+
+            callback(progress, speedString, downloadedMB, totalMB);
+
+            lastDownloaded = received;
+            lastTime = now;
+          } else if (received == total) {
+             callback(progress, "Done", downloadedMB, totalMB);
+          }
+        }
+      },
+      options: Options(
+        followRedirects: true,
+        maxRedirects: 5,
+      ),
+    );
+  }
+
+  Future<List<ModelInfo>> listDownloadedModels() async {
+    final path = await _localPath;
+    final dir = Directory(path);
+    if (!await dir.exists()) return [];
+
+    final List<ModelInfo> models = [];
+    await for (final entity in dir.list()) {
+      if (entity is File && entity.path.endsWith('.gguf')) {
+        final stat = await entity.stat();
+        models.add(ModelInfo(
+          filename: p.basename(entity.path),
+          size: stat.size,
+          lastModified: stat.modified,
+          parameters: _guessParameters(p.basename(entity.path)),
+        ));
+      }
+    }
+    return models;
+  }
+
+  String? _guessParameters(String filename) {
+    if (filename.contains('2b')) return '2B';
+    if (filename.contains('7b')) return '7B';
+    if (filename.contains('13b')) return '13B';
+    return null;
+  }
+
+  Future<void> deleteModel(String filename) async {
+    final path = p.join(await _localPath, filename);
+    final file = File(path);
+    if (await file.exists()) {
+      await file.delete();
+    }
+  }
+
+  Future<ModelInfo?> getModelInfo(String filename) async {
+    final path = p.join(await _localPath, filename);
+    final file = File(path);
+    if (await file.exists()) {
+      final stat = await file.stat();
+      return ModelInfo(
+        filename: filename,
+        size: stat.size,
+        lastModified: stat.modified,
+        parameters: _guessParameters(filename),
+      );
+    }
+    return null;
+  }
+}

--- a/lib/features/local_agent/main_preview.dart
+++ b/lib/features/local_agent/main_preview.dart
@@ -1,8 +1,12 @@
 import 'package:flutter/material.dart';
-import 'package:orionhealth_health/features/local_agent/infrastructure/mock_llm_service.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/core/di/injection.dart';
+import 'package:orionhealth_health/features/local_agent/infrastructure/llm_service.dart';
 import 'package:orionhealth_health/features/local_agent/presentation/chat_page.dart';
 
-void main() {
+void main() async {
+  WidgetsFlutterBinding.ensureInitialized();
+  await configureDependencies();
   runApp(const LocalAgentPreview());
 }
 
@@ -13,7 +17,7 @@ class LocalAgentPreview extends StatelessWidget {
   Widget build(BuildContext context) {
     return MaterialApp(
       home: ChatPage(
-        llmService: MockLlmService(),
+        llmService: GetIt.I<LlmService>(),
       ),
     );
   }

--- a/lib/features/local_agent/presentation/chat_page.dart
+++ b/lib/features/local_agent/presentation/chat_page.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:orionhealth_health/core/theme/cyber_theme.dart';
 import 'package:orionhealth_health/features/local_agent/domain/chat_message.dart';
 import 'package:orionhealth_health/features/local_agent/infrastructure/llm_service.dart';
+import 'package:orionhealth_health/features/local_agent/presentation/pages/llm_settings_page.dart';
 
 class ChatPage extends StatefulWidget {
   final LlmService llmService;
@@ -75,7 +76,11 @@ class _ChatPageState extends State<ChatPage> {
       actions: [
         IconButton(
           icon: const Icon(Icons.settings),
-          onPressed: () {},
+          onPressed: () {
+            Navigator.of(context).push(
+              MaterialPageRoute(builder: (context) => const LlmSettingsPage()),
+            );
+          },
         ),
       ],
       backgroundColor: Colors.black.withOpacity(0.3),

--- a/lib/features/local_agent/presentation/pages/llm_settings_page.dart
+++ b/lib/features/local_agent/presentation/pages/llm_settings_page.dart
@@ -1,0 +1,230 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/core/theme/cyber_theme.dart';
+import 'package:orionhealth_health/features/local_agent/infrastructure/rag_llm_service.dart';
+import 'package:orionhealth_health/features/local_agent/infrastructure/services/model_download_service.dart';
+import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
+import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
+
+class LlmSettingsPage extends StatefulWidget {
+  const LlmSettingsPage({super.key});
+
+  @override
+  State<LlmSettingsPage> createState() => _LlmSettingsPageState();
+}
+
+class _LlmSettingsPageState extends State<LlmSettingsPage> {
+  final _secureStorage = const FlutterSecureStorage();
+  final _userProfileRepository = GetIt.I<UserProfileRepository>();
+  final _modelDownloadService = GetIt.I<ModelDownloadService>();
+
+  LlmProvider _selectedProvider = LlmProvider.mock;
+  final _geminiApiKeyController = TextEditingController();
+  UserProfile? _profile;
+  List<ModelInfo> _downloadedModels = [];
+  bool _isLoading = true;
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSettings();
+  }
+
+  Future<void> _loadSettings() async {
+    setState(() => _isLoading = true);
+    _profile = await _userProfileRepository.getUserProfile();
+    final apiKey = await _secureStorage.read(key: 'gemini_api_key');
+
+    if (_profile?.llmProvider != null) {
+      _selectedProvider = LlmProvider.values.firstWhere(
+        (e) => e.name == _profile!.llmProvider,
+        orElse: () => LlmProvider.mock,
+      );
+    }
+
+    _geminiApiKeyController.text = apiKey ?? '';
+    _downloadedModels = await _modelDownloadService.listDownloadedModels();
+
+    setState(() => _isLoading = false);
+  }
+
+  Future<void> _saveProvider(LlmProvider provider) async {
+    if (_profile == null) return;
+    _profile!.llmProvider = provider.name;
+    await _userProfileRepository.saveUserProfile(_profile!);
+    setState(() => _selectedProvider = provider);
+  }
+
+  Future<void> _saveApiKey() async {
+    await _secureStorage.write(key: 'gemini_api_key', value: _geminiApiKeyController.text);
+    ScaffoldMessenger.of(context).showSnackBar(
+      const SnackBar(content: Text('Gemini API Key saved')),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('LLM Settings'),
+        backgroundColor: Colors.transparent,
+        elevation: 0,
+      ),
+      body: _isLoading
+        ? const Center(child: CircularProgressIndicator())
+        : ListView(
+            padding: const EdgeInsets.all(16),
+            children: [
+              _buildProviderSelection(),
+              const Divider(height: 32),
+              if (_selectedProvider == LlmProvider.gemini) _buildGeminiSettings(),
+              if (_selectedProvider == LlmProvider.local) _buildLocalSettings(),
+              if (_selectedProvider == LlmProvider.mock) _buildMockSettings(),
+            ],
+          ),
+    );
+  }
+
+  Widget _buildProviderSelection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('LLM Provider', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: CyberTheme.primary)),
+        const SizedBox(height: 16),
+        ...LlmProvider.values.map((provider) => RadioListTile<LlmProvider>(
+          title: Text(provider.name.toUpperCase()),
+          value: provider,
+          groupValue: _selectedProvider,
+          onChanged: (val) => val != null ? _saveProvider(val) : null,
+          activeColor: CyberTheme.primary,
+        )),
+      ],
+    );
+  }
+
+  Widget _buildGeminiSettings() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Gemini API Configuration', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: CyberTheme.secondary)),
+        const SizedBox(height: 16),
+        TextField(
+          controller: _geminiApiKeyController,
+          decoration: InputDecoration(
+            labelText: 'Gemini API Key',
+            border: OutlineInputBorder(borderRadius: BorderRadius.circular(8)),
+            suffixIcon: IconButton(
+              icon: const Icon(Icons.save),
+              onPressed: _saveApiKey,
+            ),
+          ),
+          obscureText: true,
+        ),
+      ],
+    );
+  }
+
+  Widget _buildLocalSettings() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Text('Local LLM (Ollama/GGUF)', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: CyberTheme.secondary)),
+        const SizedBox(height: 16),
+        const Text('Downloaded Models:', style: TextStyle(fontWeight: FontWeight.bold)),
+        if (_downloadedModels.isEmpty)
+          const Padding(
+            padding: EdgeInsets.symmetric(vertical: 8.0),
+            child: Text('No models downloaded yet.', style: TextStyle(fontStyle: FontStyle.italic, color: Colors.white54)),
+          ),
+        ..._downloadedModels.map((model) => ListTile(
+          title: Text(model.filename),
+          subtitle: Text('${(model.size / (1024 * 1024 * 1024)).toStringAsFixed(2)} GB - ${model.parameters ?? "Unknown"}'),
+          trailing: IconButton(
+            icon: const Icon(Icons.delete, color: Colors.red),
+            onPressed: () async {
+              await _modelDownloadService.deleteModel(model.filename);
+              _loadSettings();
+            },
+          ),
+          onTap: () async {
+            if (_profile != null) {
+              _profile!.localModelName = model.filename;
+              await _userProfileRepository.saveUserProfile(_profile!);
+              setState(() {});
+            }
+          },
+          selected: _profile?.localModelName == model.filename,
+          selectedTileColor: CyberTheme.primary.withOpacity(0.1),
+        )),
+        const SizedBox(height: 16),
+        ElevatedButton.icon(
+          onPressed: () {
+            // Placeholder for download dialog
+            _showDownloadDialog();
+          },
+          icon: const Icon(Icons.download),
+          label: const Text('Download Gemma 2B'),
+          style: ElevatedButton.styleFrom(backgroundColor: CyberTheme.primary, foregroundColor: Colors.black),
+        ),
+      ],
+    );
+  }
+
+  void _showDownloadDialog() {
+    double progress = 0;
+    String speed = "";
+    int downloadedMB = 0;
+    int totalMB = 0;
+
+    showDialog(
+      context: context,
+      barrierDismissible: false,
+      builder: (context) => StatefulBuilder(
+        builder: (context, setDialogState) => AlertDialog(
+          title: const Text('Downloading Gemma 2B'),
+          content: Column(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              LinearProgressIndicator(value: progress),
+              const SizedBox(height: 16),
+              Text('$downloadedMB MB / $totalMB MB'),
+              Text(speed),
+            ],
+          ),
+          actions: [
+            TextButton(
+              onPressed: () => Navigator.pop(context),
+              child: const Text('Close'),
+            )
+          ],
+        ),
+      ),
+    );
+
+    _modelDownloadService.downloadModel(
+      'https://huggingface.co/google/gemma-2-2b-it-GGUF/resolve/main/gemma-2-2b-it-Q4_K_M.gguf',
+      (p, s, d, t) {
+        setDialogState(() {
+          progress = p;
+          speed = s;
+          downloadedMB = d;
+          totalMB = t;
+        });
+      }
+    ).then((_) {
+      _loadSettings();
+    });
+  }
+
+  Widget _buildMockSettings() {
+    return const Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('Mock Provider', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: CyberTheme.secondary)),
+        SizedBox(height: 16),
+        Text('Uses a simulated response for testing without an internet connection or local setup.'),
+      ],
+    );
+  }
+}

--- a/lib/features/user_profile/domain/entities/user_profile.dart
+++ b/lib/features/user_profile/domain/entities/user_profile.dart
@@ -16,6 +16,11 @@ class UserProfile {
 
   String? bloodType;
 
+  @Enumerated(EnumType.name)
+  String? llmProvider; // LlmProvider enum as string
+
+  String? localModelName;
+
   @override
   String toString() {
     return 'UserProfile(id: $id, name: $name, age: $age, weight: $weight, height: $height, bloodType: $bloodType)';

--- a/lib/features/user_profile/domain/entities/user_profile.g.dart
+++ b/lib/features/user_profile/domain/entities/user_profile.g.dart
@@ -32,13 +32,23 @@ const UserProfileSchema = CollectionSchema(
       name: r'height',
       type: IsarType.double,
     ),
-    r'name': PropertySchema(
+    r'llmProvider': PropertySchema(
       id: 3,
+      name: r'llmProvider',
+      type: IsarType.string,
+    ),
+    r'localModelName': PropertySchema(
+      id: 4,
+      name: r'localModelName',
+      type: IsarType.string,
+    ),
+    r'name': PropertySchema(
+      id: 5,
       name: r'name',
       type: IsarType.string,
     ),
     r'weight': PropertySchema(
-      id: 4,
+      id: 6,
       name: r'weight',
       type: IsarType.double,
     )
@@ -70,6 +80,18 @@ int _userProfileEstimateSize(
     }
   }
   {
+    final value = object.llmProvider;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.localModelName;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final value = object.name;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
@@ -87,8 +109,10 @@ void _userProfileSerialize(
   writer.writeLong(offsets[0], object.age);
   writer.writeString(offsets[1], object.bloodType);
   writer.writeDouble(offsets[2], object.height);
-  writer.writeString(offsets[3], object.name);
-  writer.writeDouble(offsets[4], object.weight);
+  writer.writeString(offsets[3], object.llmProvider);
+  writer.writeString(offsets[4], object.localModelName);
+  writer.writeString(offsets[5], object.name);
+  writer.writeDouble(offsets[6], object.weight);
 }
 
 UserProfile _userProfileDeserialize(
@@ -102,8 +126,10 @@ UserProfile _userProfileDeserialize(
   object.bloodType = reader.readStringOrNull(offsets[1]);
   object.height = reader.readDoubleOrNull(offsets[2]);
   object.id = id;
-  object.name = reader.readStringOrNull(offsets[3]);
-  object.weight = reader.readDoubleOrNull(offsets[4]);
+  object.llmProvider = reader.readStringOrNull(offsets[3]);
+  object.localModelName = reader.readStringOrNull(offsets[4]);
+  object.name = reader.readStringOrNull(offsets[5]);
+  object.weight = reader.readDoubleOrNull(offsets[6]);
   return object;
 }
 
@@ -123,6 +149,10 @@ P _userProfileDeserializeProp<P>(
     case 3:
       return (reader.readStringOrNull(offset)) as P;
     case 4:
+      return (reader.readStringOrNull(offset)) as P;
+    case 5:
+      return (reader.readStringOrNull(offset)) as P;
+    case 6:
       return (reader.readDoubleOrNull(offset)) as P;
     default:
       throw IsarError('Unknown property with id $propertyId');
@@ -578,6 +608,314 @@ extension UserProfileQueryFilter
     });
   }
 
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'llmProvider',
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'llmProvider',
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'llmProvider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'llmProvider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'llmProvider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'llmProvider',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'llmProvider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'llmProvider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'llmProvider',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'llmProvider',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'llmProvider',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      llmProviderIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'llmProvider',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'localModelName',
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'localModelName',
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localModelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'localModelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'localModelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'localModelName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'localModelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'localModelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'localModelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'localModelName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'localModelName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition>
+      localModelNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'localModelName',
+        value: '',
+      ));
+    });
+  }
+
   QueryBuilder<UserProfile, UserProfile, QAfterFilterCondition> nameIsNull() {
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(const FilterCondition.isNull(
@@ -851,6 +1189,31 @@ extension UserProfileQuerySortBy
     });
   }
 
+  QueryBuilder<UserProfile, UserProfile, QAfterSortBy> sortByLlmProvider() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'llmProvider', Sort.asc);
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterSortBy> sortByLlmProviderDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'llmProvider', Sort.desc);
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterSortBy> sortByLocalModelName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localModelName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterSortBy>
+      sortByLocalModelNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localModelName', Sort.desc);
+    });
+  }
+
   QueryBuilder<UserProfile, UserProfile, QAfterSortBy> sortByName() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'name', Sort.asc);
@@ -926,6 +1289,31 @@ extension UserProfileQuerySortThenBy
     });
   }
 
+  QueryBuilder<UserProfile, UserProfile, QAfterSortBy> thenByLlmProvider() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'llmProvider', Sort.asc);
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterSortBy> thenByLlmProviderDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'llmProvider', Sort.desc);
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterSortBy> thenByLocalModelName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localModelName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QAfterSortBy>
+      thenByLocalModelNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'localModelName', Sort.desc);
+    });
+  }
+
   QueryBuilder<UserProfile, UserProfile, QAfterSortBy> thenByName() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'name', Sort.asc);
@@ -972,6 +1360,21 @@ extension UserProfileQueryWhereDistinct
     });
   }
 
+  QueryBuilder<UserProfile, UserProfile, QDistinct> distinctByLlmProvider(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'llmProvider', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<UserProfile, UserProfile, QDistinct> distinctByLocalModelName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'localModelName',
+          caseSensitive: caseSensitive);
+    });
+  }
+
   QueryBuilder<UserProfile, UserProfile, QDistinct> distinctByName(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
@@ -1009,6 +1412,19 @@ extension UserProfileQueryProperty
   QueryBuilder<UserProfile, double?, QQueryOperations> heightProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'height');
+    });
+  }
+
+  QueryBuilder<UserProfile, String?, QQueryOperations> llmProviderProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'llmProvider');
+    });
+  }
+
+  QueryBuilder<UserProfile, String?, QQueryOperations>
+      localModelNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'localModelName');
     });
   }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -257,6 +257,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   equatable:
     dependency: "direct main"
     description:
@@ -435,6 +451,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.0.33"
+  flutter_secure_storage:
+    dependency: "direct main"
+    description:
+      name: flutter_secure_storage
+      sha256: "9cad52d75ebc511adfae3d447d5d13da15a55a92c9410e50f67335b6d21d16ea"
+      url: "https://pub.dev"
+    source: hosted
+    version: "9.2.4"
+  flutter_secure_storage_linux:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_linux
+      sha256: be76c1d24a97d0b98f8b54bce6b481a380a6590df992d0098f868ad54dc8f688
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.3"
+  flutter_secure_storage_macos:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_macos
+      sha256: "6c0a2795a2d1de26ae202a0d78527d163f4acbb11cde4c75c670f3a0fc064247"
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.3"
+  flutter_secure_storage_platform_interface:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_platform_interface
+      sha256: cf91ad32ce5adef6fba4d736a542baca9daf3beac4db2d04be350b87f69ac4a8
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.2"
+  flutter_secure_storage_web:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_web
+      sha256: f4ebff989b4f07b2656fb16b47852c0aab9fed9b4ec1c70103368337bc1886a9
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.2.1"
+  flutter_secure_storage_windows:
+    dependency: transitive
+    description:
+      name: flutter_secure_storage_windows
+      sha256: b20b07cb5ed4ed74fc567b78a72936203f587eba460af1df11281c9326cd3709
+      url: "https://pub.dev"
+    source: hosted
+    version: "3.1.2"
   flutter_test:
     dependency: "direct dev"
     description: flutter
@@ -491,7 +555,7 @@ packages:
     source: hosted
     version: "6.3.2"
   google_generative_ai:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: google_generative_ai
       sha256: "71f613d0247968992ad87a0eb21650a566869757442ba55a31a81be6746e0d1f"
@@ -863,7 +927,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -45,6 +45,10 @@ dependencies:
   isar_flutter_libs: ^3.1.0+1
   objectbox_flutter_libs: any
   path_provider: ^2.1.5
+  path: ^1.8.3
+  google_generative_ai: ^0.4.7
+  dio: ^5.7.0
+  flutter_secure_storage: ^9.2.2
   flutter_markdown: ^0.7.7+1
   equatable: ^2.0.7
   isar_agent_memory:

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
 #include <objectbox_flutter_libs/objectbox_flutter_libs_plugin.h>
 #include <permission_handler_windows/permission_handler_windows_plugin.h>
@@ -17,6 +18,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FlutterSecureStorageWindowsPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterSecureStorageWindowsPlugin"));
   IsarFlutterLibsPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("IsarFlutterLibsPlugin"));
   ObjectboxFlutterLibsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   firebase_core
+  flutter_secure_storage_windows
   isar_flutter_libs
   objectbox_flutter_libs
   permission_handler_windows


### PR DESCRIPTION
Successfully integrated real LLM adapters into the chat feature, replacing the initial mock implementation. Users can now choose between Gemini, Local (Ollama/GGUF), or Mock providers. The solution includes a model download service for local inference, secure storage for API keys, and a dedicated settings page for configuration. Code generation was updated to support new fields in UserProfile and dependency injection for new services.

Fixes #38

---
*PR created automatically by Jules for task [8689528702951781263](https://jules.google.com/task/8689528702951781263) started by @iberi22*