### PR TITLE
Add missing dependencies to pubspec.yaml

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -61,10 +61,10 @@ packages:
     dependency: transitive
     description:
       name: bloc
-      sha256: a2cebb899f91d36eeeaa55c7b20b5915db5a9df1b8fd4a3c9c825e22e474537d
+      sha256: "106842ad6569f0b60297619e9e0b1885c2fb9bf84812935490e6c5275777804e"
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.0"
+    version: "8.1.4"
   bluez:
     dependency: transitive
     description:
@@ -289,6 +289,22 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "7.0.3"
+  dio:
+    dependency: "direct main"
+    description:
+      name: dio
+      sha256: aff32c08f92787a557dd5c0145ac91536481831a01b4648136373cddb0e64f8c
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.2"
+  dio_web_adapter:
+    dependency: transitive
+    description:
+      name: dio_web_adapter
+      sha256: "2f9e64323a7c3c7ef69567d5c800424a11f8337b8b228bad02524c9fb3c1f340"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.2"
   equatable:
     dependency: "direct main"
     description:
@@ -434,10 +450,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_bloc
-      sha256: cf51747952201a455a1c840f8171d273be009b932c75093020f9af64f2123e38
+      sha256: b594505eac31a0518bdcb4b5b79573b8d9117b193cc80cc12e17d639b10aa27a
       url: "https://pub.dev"
     source: hosted
-    version: "9.1.1"
+    version: "8.1.6"
   flutter_blue_plus:
     dependency: "direct main"
     description:
@@ -627,7 +643,7 @@ packages:
     source: hosted
     version: "6.3.2"
   google_generative_ai:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: google_generative_ai
       sha256: "71f613d0247968992ad87a0eb21650a566869757442ba55a31a81be6746e0d1f"
@@ -690,6 +706,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "13.2.1"
+  hex:
+    dependency: "direct main"
+    description:
+      name: hex
+      sha256: "4e7cd54e4b59ba026432a6be2dd9d96e4c5205725194997193bf871703b82c4a"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.2.0"
   hooks:
     dependency: transitive
     description:
@@ -1087,7 +1111,7 @@ packages:
     source: hosted
     version: "2.2.0"
   path:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: path
       sha256: "75cca69d1490965be98c73ceaea117e8a04dd21217b37b292c9ddbec0d955bc5"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -38,7 +38,11 @@ dependencies:
   image_picker: ^1.2.1
   uuid: ^4.5.2
   intl: ^0.20.2
-  flutter_bloc: ^9.1.1
+  flutter_bloc: ^8.1.0
+  hex: ^0.2.0
+  path: ^1.8.0
+  google_generative_ai: ^0.4.7
+  dio: ^5.0.0
   get_it: ^9.1.0
   injectable: ^2.6.0
   isar: ^3.1.0+1


### PR DESCRIPTION
This PR adds missing dependencies to `pubspec.yaml` that are used in the codebase but were not declared.

Specifically, it adds:
- `hex: ^0.2.0`
- `path: ^1.8.0`
- `google_generative_ai: ^0.4.7` (adjusted from ^0.2.0 to resolve a conflict with the local `isar_agent_memory` package)
- `dio: ^5.0.0`

It also updates `flutter_bloc` to `^8.1.0` as requested.
The changes have been verified by running `flutter pub get`, `dart pub deps`, and `flutter analyze`.

Fixes #51

---
*PR created automatically by Jules for task [15129483980668189418](https://jules.google.com/task/15129483980668189418) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated project dependencies including a downgrade of flutter_bloc and additions of new packages (hex, path, google_generative_ai, dio) to enable enhanced functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->