### PR TITLE
Fix APK artifact path mismatch in GitHub Actions

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -72,13 +72,13 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: orionhealth-release
-          path: build/app/outputs/apk/release/app-release.apk
+          path: build/app/outputs/flutter-apk/app-release.apk
 
       - name: Create Release (on tag)
         if: startsWith(github.ref, 'refs/tags/v')
         uses: softprops/action-gh-release@v1
         with:
-          files: build/app/outputs/apk/release/app-release.apk
+          files: build/app/outputs/flutter-apk/app-release.apk
           generate_release_notes: true
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/APK_BUILD_STATUS.md
+++ b/APK_BUILD_STATUS.md
@@ -5,7 +5,7 @@
 The OrionHealth app APK has been successfully compiled for release.
 
 **APK Details:**
-- **Location**: `build/app/outputs/apk/release/app-release.apk`
+- **Location**: `build/app/outputs/flutter-apk/app-release.apk`
 - **Size**: ~82 MB
 - **Target SDK**: Android 15+ (API 36)
 - **Minimum SDK**: API 28 (Android 9.0+)
@@ -81,7 +81,7 @@ cd ..
 
 ### Install on Device
 ```bash
-adb install -r build/app/outputs/apk/release/app-release.apk
+adb install -r build/app/outputs/flutter-apk/app-release.apk
 ```
 
 ### Verify Installation

--- a/build_apk.ps1
+++ b/build_apk.ps1
@@ -37,7 +37,7 @@ $buildSuccess = $?
 Pop-Location
 
 if ($buildSuccess) {
-    $apkPath = "build/app/outputs/apk/release/app-release.apk"
+    $apkPath = "build/app/outputs/flutter-apk/app-release.apk"
     $file = Get-Item $apkPath -ErrorAction SilentlyContinue
     if ($file) {
         $sizeMB = [math]::Round($file.Length/1MB, 2)
@@ -47,7 +47,7 @@ if ($buildSuccess) {
         Write-Host "📊 APK Size: $sizeMB MB" -ForegroundColor Cyan
         Write-Host ""
         Write-Host "Next steps:" -ForegroundColor Yellow
-        Write-Host "1. Test on device: adb install -r build/app/outputs/apk/release/app-release.apk"
+        Write-Host "1. Test on device: adb install -r build/app/outputs/flutter-apk/app-release.apk"
         Write-Host "2. Create release: git tag v1.0.0 && git push --tags"
         Write-Host "3. Upload to Play Store or GitHub Releases"
     } else {

--- a/lib/features/health_record/application/bloc/health_record_state.dart
+++ b/lib/features/health_record/application/bloc/health_record_state.dart
@@ -3,6 +3,8 @@ part of 'health_record_cubit.dart';
 abstract class HealthRecordState extends Equatable {
   const HealthRecordState();
 
+  List<MedicalRecord> get records => [];
+
   @override
   List<Object?> get props => [];
 }


### PR DESCRIPTION
This PR fixes the mismatch between the APK output path of `flutter build apk` and the path used by GitHub Actions for artifact upload and release creation.

### Changes:
1.  **GitHub Actions**: Updated `.github/workflows/android_build.yml` to point to `build/app/outputs/flutter-apk/app-release.apk`.
2.  **Documentation**: Updated `APK_BUILD_STATUS.md` with the correct path.
3.  **Local Scripts**: Updated `build_apk.ps1` to reference the correct APK location.
4.  **Bug Fix**: Resolved a compilation error in `HealthRecordStagingPage` by adding a `records` getter to the base `HealthRecordState` class, ensuring consistent access across all BLoC states.

No other workflow files (like `release.yml`) were found in the repository.

Fixes #52

---
*PR created automatically by Jules for task [14245685691424803579](https://jules.google.com/task/14245685691424803579) started by @iberi22*