### PR TITLE
feat: add LLM configuration settings with device capability detection

### DIFF
--- a/android/app/src/main/kotlin/com/orionhealth/orionhealth_health/AicorePlugin.kt
+++ b/android/app/src/main/kotlin/com/orionhealth/orionhealth_health/AicorePlugin.kt
@@ -5,21 +5,28 @@ import io.flutter.plugin.common.MethodCall
 import io.flutter.plugin.common.MethodChannel
 import io.flutter.plugin.common.MethodChannel.MethodCallHandler
 import io.flutter.plugin.common.MethodChannel.Result
+import android.app.ActivityManager
+import android.content.Context
+import android.os.Build
 import kotlinx.coroutines.*
 
 class AicorePlugin : FlutterPlugin, MethodCallHandler {
     
+    private var context: Context? = null
+
     private lateinit var channel: MethodChannel
     private val engine = GemmaNativeEngine()
     private val scope = CoroutineScope(Dispatchers.Main + SupervisorJob())
     
     override fun onAttachedToEngine(binding: FlutterPlugin.FlutterPluginBinding) {
+        context = binding.applicationContext
         channel = MethodChannel(binding.binaryMessenger, "com.orionhealth/aicore")
         channel.setMethodCallHandler(this)
     }
     
     override fun onDetachedFromEngine(binding: FlutterPlugin.FlutterPluginBinding) {
         channel.setMethodCallHandler(null)
+        context = null
         scope.cancel()
         engine.close()
     }
@@ -79,6 +86,26 @@ class AicorePlugin : FlutterPlugin, MethodCallHandler {
                     engine.warmup()
                     result.success(true)
                 }
+            }
+
+            "getSystemInfo" -> {
+                val info = mutableMapOf<String, Any>()
+
+                // RAM Info
+                val activityManager = context?.getSystemService(Context.ACTIVITY_SERVICE) as? ActivityManager
+                val memoryInfo = ActivityManager.MemoryInfo()
+                activityManager?.getMemoryInfo(memoryInfo)
+
+                val totalRamGb = memoryInfo.totalMem.toDouble() / (1024 * 1024 * 1024)
+                info["totalRamGb"] = totalRamGb
+
+                // Processor/GPU Info (Simplified for now, focusing on device model/brand as proxy)
+                info["model"] = Build.MODEL
+                info["manufacturer"] = Build.MANUFACTURER
+                info["hardware"] = Build.HARDWARE
+                info["glEsVersion"] = activityManager?.deviceConfigurationInfo?.glEsVersion ?: "Unknown"
+
+                result.success(info)
             }
             
             else -> result.notImplemented()

--- a/lib/core/di/database_module.dart
+++ b/lib/core/di/database_module.dart
@@ -2,6 +2,7 @@ import 'package:injectable/injectable.dart';
 import 'package:isar/isar.dart';
 import 'package:path_provider/path_provider.dart';
 import '../../features/user_profile/domain/entities/user_profile.dart';
+import '../../features/settings/domain/entities/llm_config.dart';
 import '../../features/local_agent/domain/chat_message.dart';
 import '../../features/health_record/domain/entities/medical_record.dart';
 import '../../features/health_report/domain/entities/health_report.dart';
@@ -20,6 +21,7 @@ abstract class DatabaseModule {
     return Isar.open(
       [
         UserProfileSchema,
+        LlmConfigSchema,
         ChatMessageSchema,
         MedicalRecordSchema,
         MemoryNodeSchema,

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -8,100 +8,107 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:dio/dio.dart' as _i4;
+import 'package:dio/dio.dart' as _i6;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:isar/isar.dart' as _i10;
-import 'package:isar_agent_memory/isar_agent_memory.dart' as _i5;
-import 'package:medical_standards/medical_standards.dart' as _i15;
+import 'package:isar/isar.dart' as _i12;
+import 'package:isar_agent_memory/isar_agent_memory.dart' as _i7;
+import 'package:medical_standards/medical_standards.dart' as _i17;
 
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i33;
-import '../../features/allergies/infrastructure/repositories/allergy_repository_impl.dart'
-    as _i34;
-import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i35;
-import '../../features/appointments/infrastructure/repositories/appointment_repository_impl.dart'
-    as _i36;
-import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
     as _i37;
-import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i6;
-import '../../features/health_data_import/application/health_import_cubit.dart'
+import '../../features/allergies/infrastructure/repositories/allergy_repository_impl.dart'
     as _i38;
-import '../../features/health_data_import/domain/services/health_data_import_service.dart'
-    as _i8;
-import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i47;
-import '../../features/health_record/domain/repositories/health_record_repository.dart'
+import '../../features/appointments/domain/repositories/appointment_repository.dart'
     as _i39;
-import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+import '../../features/appointments/infrastructure/repositories/appointment_repository_impl.dart'
     as _i40;
-import '../../features/health_record/infrastructure/services/file_picker_service.dart'
-    as _i7;
-import '../../features/health_record/infrastructure/services/image_picker_service.dart'
-    as _i9;
-import '../../features/health_record/infrastructure/services/ocr_service.dart'
-    as _i24;
-import '../../features/health_report/application/bloc/health_report_bloc.dart'
-    as _i48;
-import '../../features/health_report/domain/repositories/health_report_repository.dart'
+import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
     as _i41;
-import '../../features/health_report/domain/services/report_generation_service.dart'
-    as _i25;
-import '../../features/health_report/infrastructure/repositories/isar_health_report_repository.dart'
+import '../../features/auth/infrastructure/services/encryption_service.dart'
+    as _i8;
+import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i42;
-import '../../features/health_report/infrastructure/services/mock_report_generation_service.dart'
-    as _i26;
-import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i45;
-import '../../features/local_agent/domain/services/llm_adapter.dart' as _i11;
-import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i29;
-import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i14;
-import '../../features/local_agent/infrastructure/adapters/gemma_llm_adapter.dart'
-    as _i13;
-import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i12;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i49;
-import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i50;
-import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i30;
-import '../../features/medical_research/domain/services/medical_scraper_service.dart'
-    as _i16;
-import '../../features/medical_research/domain/services/medical_standards_service.dart'
-    as _i18;
-import '../../features/medical_research/domain/services/medical_web_search_service.dart'
-    as _i20;
-import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
-    as _i3;
-import '../../features/medical_research/infrastructure/medical_research_service.dart'
+import '../../features/health_data_import/domain/services/health_data_import_service.dart'
+    as _i10;
+import '../../features/health_record/application/bloc/health_record_cubit.dart'
+    as _i52;
+import '../../features/health_record/domain/repositories/health_record_repository.dart'
     as _i43;
-import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
-    as _i17;
-import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
-    as _i19;
-import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
-    as _i21;
-import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i22;
-import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i23;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i44;
-import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i46;
-import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
+import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+    as _i44;
+import '../../features/health_record/infrastructure/services/file_picker_service.dart'
+    as _i9;
+import '../../features/health_record/infrastructure/services/image_picker_service.dart'
+    as _i11;
+import '../../features/health_record/infrastructure/services/ocr_service.dart'
+    as _i26;
+import '../../features/health_report/application/bloc/health_report_bloc.dart'
+    as _i53;
+import '../../features/health_report/domain/repositories/health_report_repository.dart'
+    as _i45;
+import '../../features/health_report/domain/services/report_generation_service.dart'
     as _i27;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+import '../../features/health_report/infrastructure/repositories/isar_health_report_repository.dart'
+    as _i46;
+import '../../features/health_report/infrastructure/services/mock_report_generation_service.dart'
     as _i28;
-import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
+    as _i50;
+import '../../features/local_agent/domain/services/llm_adapter.dart' as _i13;
+import '../../features/local_agent/domain/services/vector_store_service.dart'
+    as _i33;
+import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
+    as _i16;
+import '../../features/local_agent/infrastructure/adapters/gemma_llm_adapter.dart'
+    as _i15;
+import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+    as _i14;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i54;
+import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i55;
+import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
+    as _i34;
+import '../../features/medical_research/domain/services/medical_scraper_service.dart'
+    as _i18;
+import '../../features/medical_research/domain/services/medical_standards_service.dart'
+    as _i20;
+import '../../features/medical_research/domain/services/medical_web_search_service.dart'
+    as _i22;
+import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
+    as _i4;
+import '../../features/medical_research/infrastructure/medical_research_service.dart'
+    as _i47;
+import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
+    as _i19;
+import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
+    as _i21;
+import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
+    as _i23;
+import '../../features/medications/domain/repositories/medication_repository.dart'
+    as _i24;
+import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+    as _i25;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i48;
+import '../../features/settings/application/bloc/settings_cubit.dart' as _i49;
+import '../../features/settings/domain/repositories/settings_repository.dart'
+    as _i29;
+import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
+    as _i30;
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i51;
+import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
     as _i31;
-import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
     as _i32;
-import 'database_module.dart' as _i53;
-import 'memory_module.dart' as _i52;
-import 'network_module.dart' as _i51;
+import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+    as _i35;
+import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+    as _i36;
+import '../services/aicore_service.dart' as _i3;
+import '../services/device_info_service.dart' as _i5;
+import 'database_module.dart' as _i58;
+import 'memory_module.dart' as _i57;
+import 'network_module.dart' as _i56;
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -117,107 +124,113 @@ extension GetItInjectableX on _i1.GetIt {
     final networkModule = _$NetworkModule();
     final memoryModule = _$MemoryModule();
     final databaseModule = _$DatabaseModule();
-    gh.lazySingleton<_i3.BotBypassHandler>(() => _i3.BotBypassHandler());
-    gh.lazySingleton<_i4.Dio>(() => networkModule.dio);
-    gh.lazySingleton<_i5.EmbeddingsAdapter>(
+    gh.lazySingleton<_i3.AicoreService>(() => _i3.AicoreService());
+    gh.lazySingleton<_i4.BotBypassHandler>(() => _i4.BotBypassHandler());
+    gh.lazySingleton<_i5.DeviceInfoService>(() => _i5.DeviceInfoService());
+    gh.lazySingleton<_i6.Dio>(() => networkModule.dio);
+    gh.lazySingleton<_i7.EmbeddingsAdapter>(
         () => memoryModule.embeddingsAdapter);
-    gh.lazySingleton<_i6.EncryptionService>(() => _i6.EncryptionServiceImpl());
-    gh.lazySingleton<_i7.FilePickerService>(() => _i7.FilePickerServiceImpl());
-    gh.lazySingleton<_i8.HealthDataImportService>(
-        () => _i8.HealthDataImportService());
-    gh.lazySingleton<_i9.ImagePickerService>(
-        () => _i9.ImagePickerServiceImpl());
-    await gh.factoryAsync<_i10.Isar>(
+    gh.lazySingleton<_i8.EncryptionService>(() => _i8.EncryptionServiceImpl());
+    gh.lazySingleton<_i9.FilePickerService>(() => _i9.FilePickerServiceImpl());
+    gh.lazySingleton<_i10.HealthDataImportService>(
+        () => _i10.HealthDataImportService());
+    gh.lazySingleton<_i11.ImagePickerService>(
+        () => _i11.ImagePickerServiceImpl());
+    await gh.factoryAsync<_i12.Isar>(
       () => databaseModule.isar,
       preResolve: true,
     );
-    gh.factory<_i11.LlmAdapter>(
-      () => _i12.MockLlmAdapter(),
+    gh.factory<_i13.LlmAdapter>(
+      () => _i14.MockLlmAdapter(),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i11.LlmAdapter>(
-      () => _i13.GemmaLlmAdapter(),
+    gh.lazySingleton<_i13.LlmAdapter>(
+      () => _i15.GemmaLlmAdapter(aicoreService: gh<_i3.AicoreService>()),
       instanceName: 'gemma',
     );
-    gh.lazySingleton<_i11.LlmAdapter>(
-      () => _i14.GeminiLlmAdapter(apiKey: gh<String>()),
+    gh.lazySingleton<_i13.LlmAdapter>(
+      () => _i16.GeminiLlmAdapter(apiKey: gh<String>()),
       instanceName: 'gemini',
     );
-    gh.lazySingleton<_i15.MedicalContextProvider>(
+    gh.lazySingleton<_i17.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
-    gh.lazySingleton<_i16.MedicalScraperService>(
-        () => _i17.MedicalScraperServiceImpl(
-              gh<_i4.Dio>(),
-              gh<_i3.BotBypassHandler>(),
+    gh.lazySingleton<_i18.MedicalScraperService>(
+        () => _i19.MedicalScraperServiceImpl(
+              gh<_i6.Dio>(),
+              gh<_i4.BotBypassHandler>(),
             ));
-    gh.lazySingleton<_i18.MedicalStandardsService>(() =>
-        _i19.MedicalStandardsServiceImpl(gh<_i15.MedicalContextProvider>()));
-    gh.lazySingleton<_i20.MedicalWebSearchService>(
-        () => _i21.MedicalWebSearchServiceImpl(gh<_i4.Dio>()));
-    gh.lazySingleton<_i22.MedicationRepository>(
-        () => _i23.IsarMedicationRepository(gh<_i10.Isar>()));
-    await gh.lazySingletonAsync<_i5.MemoryGraph>(
+    gh.lazySingleton<_i20.MedicalStandardsService>(() =>
+        _i21.MedicalStandardsServiceImpl(gh<_i17.MedicalContextProvider>()));
+    gh.lazySingleton<_i22.MedicalWebSearchService>(
+        () => _i23.MedicalWebSearchServiceImpl(gh<_i6.Dio>()));
+    gh.lazySingleton<_i24.MedicationRepository>(
+        () => _i25.IsarMedicationRepository(gh<_i12.Isar>()));
+    await gh.lazySingletonAsync<_i7.MemoryGraph>(
       () => memoryModule.memoryGraph(
-        gh<_i10.Isar>(),
-        gh<_i5.EmbeddingsAdapter>(),
+        gh<_i12.Isar>(),
+        gh<_i7.EmbeddingsAdapter>(),
       ),
       preResolve: true,
     );
-    gh.lazySingleton<_i24.OcrService>(() => _i24.OcrServiceStub());
-    gh.lazySingleton<_i25.ReportGenerationService>(
-        () => _i26.MockReportGenerationService());
-    gh.lazySingleton<_i27.UserProfileRepository>(
-        () => _i28.UserProfileRepositoryImpl(gh<_i10.Isar>()));
-    gh.lazySingleton<_i29.VectorStoreService>(
-        () => _i30.IsarVectorStoreService(gh<_i5.MemoryGraph>()));
-    gh.lazySingleton<_i31.VitalSignRepository>(
-        () => _i32.VitalSignRepositoryImpl(gh<_i10.Isar>()));
-    gh.lazySingleton<_i33.AllergyRepository>(
-        () => _i34.AllergyRepositoryImpl(gh<_i10.Isar>()));
-    gh.lazySingleton<_i35.AppointmentRepository>(
-        () => _i36.AppointmentRepositoryImpl(gh<_i10.Isar>()));
-    gh.lazySingleton<_i37.BleMedicalSharingService>(
-        () => _i37.BleMedicalSharingService(gh<_i6.EncryptionService>()));
-    gh.factory<_i38.HealthImportCubit>(() => _i38.HealthImportCubit(
-          gh<_i8.HealthDataImportService>(),
-          gh<_i31.VitalSignRepository>(),
+    gh.lazySingleton<_i26.OcrService>(() => _i26.OcrServiceStub());
+    gh.lazySingleton<_i27.ReportGenerationService>(
+        () => _i28.MockReportGenerationService());
+    gh.lazySingleton<_i29.SettingsRepository>(
+        () => _i30.SettingsRepositoryImpl(gh<_i12.Isar>()));
+    gh.lazySingleton<_i31.UserProfileRepository>(
+        () => _i32.UserProfileRepositoryImpl(gh<_i12.Isar>()));
+    gh.lazySingleton<_i33.VectorStoreService>(
+        () => _i34.IsarVectorStoreService(gh<_i7.MemoryGraph>()));
+    gh.lazySingleton<_i35.VitalSignRepository>(
+        () => _i36.VitalSignRepositoryImpl(gh<_i12.Isar>()));
+    gh.lazySingleton<_i37.AllergyRepository>(
+        () => _i38.AllergyRepositoryImpl(gh<_i12.Isar>()));
+    gh.lazySingleton<_i39.AppointmentRepository>(
+        () => _i40.AppointmentRepositoryImpl(gh<_i12.Isar>()));
+    gh.lazySingleton<_i41.BleMedicalSharingService>(
+        () => _i41.BleMedicalSharingService(gh<_i8.EncryptionService>()));
+    gh.factory<_i42.HealthImportCubit>(() => _i42.HealthImportCubit(
+          gh<_i10.HealthDataImportService>(),
+          gh<_i35.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i39.HealthRecordRepository>(
-        () => _i40.HealthRecordRepositoryImpl(gh<_i10.Isar>()));
-    gh.lazySingleton<_i41.HealthReportRepository>(
-        () => _i42.IsarHealthReportRepository(gh<_i10.Isar>()));
-    gh.lazySingleton<_i43.MedicalResearchService>(
-        () => _i43.MedicalResearchService(
-              gh<_i20.MedicalWebSearchService>(),
-              gh<_i16.MedicalScraperService>(),
+    gh.lazySingleton<_i43.HealthRecordRepository>(
+        () => _i44.HealthRecordRepositoryImpl(gh<_i12.Isar>()));
+    gh.lazySingleton<_i45.HealthReportRepository>(
+        () => _i46.IsarHealthReportRepository(gh<_i12.Isar>()));
+    gh.lazySingleton<_i47.MedicalResearchService>(
+        () => _i47.MedicalResearchService(
+              gh<_i22.MedicalWebSearchService>(),
+              gh<_i18.MedicalScraperService>(),
             ));
-    gh.factory<_i44.OnboardingCubit>(
-        () => _i44.OnboardingCubit(gh<_i27.UserProfileRepository>()));
-    gh.lazySingleton<_i45.SmartSearchUseCase>(
-        () => _i45.SmartSearchUseCase(gh<_i29.VectorStoreService>()));
-    gh.factory<_i46.UserProfileCubit>(
-        () => _i46.UserProfileCubit(gh<_i27.UserProfileRepository>()));
-    gh.factory<_i47.HealthRecordCubit>(() => _i47.HealthRecordCubit(
-          gh<_i39.HealthRecordRepository>(),
-          gh<_i7.FilePickerService>(),
-          gh<_i9.ImagePickerService>(),
-          gh<_i24.OcrService>(),
-          gh<_i29.VectorStoreService>(),
+    gh.factory<_i48.OnboardingCubit>(
+        () => _i48.OnboardingCubit(gh<_i31.UserProfileRepository>()));
+    gh.factory<_i49.SettingsCubit>(
+        () => _i49.SettingsCubit(gh<_i29.SettingsRepository>()));
+    gh.lazySingleton<_i50.SmartSearchUseCase>(
+        () => _i50.SmartSearchUseCase(gh<_i33.VectorStoreService>()));
+    gh.factory<_i51.UserProfileCubit>(
+        () => _i51.UserProfileCubit(gh<_i31.UserProfileRepository>()));
+    gh.factory<_i52.HealthRecordCubit>(() => _i52.HealthRecordCubit(
+          gh<_i43.HealthRecordRepository>(),
+          gh<_i9.FilePickerService>(),
+          gh<_i11.ImagePickerService>(),
+          gh<_i26.OcrService>(),
+          gh<_i33.VectorStoreService>(),
         ));
-    gh.factory<_i48.HealthReportBloc>(() => _i48.HealthReportBloc(
-          gh<_i41.HealthReportRepository>(),
-          gh<_i25.ReportGenerationService>(),
+    gh.factory<_i53.HealthReportBloc>(() => _i53.HealthReportBloc(
+          gh<_i45.HealthReportRepository>(),
+          gh<_i27.ReportGenerationService>(),
         ));
-    gh.lazySingleton<_i49.LlmService>(() => _i50.RagLlmService(
-          gh<_i29.VectorStoreService>(),
-          gh<_i43.MedicalResearchService>(),
+    gh.lazySingleton<_i54.LlmService>(() => _i55.RagLlmService(
+          gh<_i33.VectorStoreService>(),
+          gh<_i47.MedicalResearchService>(),
         ));
     return this;
   }
 }
 
-class _$NetworkModule extends _i51.NetworkModule {}
+class _$NetworkModule extends _i56.NetworkModule {}
 
-class _$MemoryModule extends _i52.MemoryModule {}
+class _$MemoryModule extends _i57.MemoryModule {}
 
-class _$DatabaseModule extends _i53.DatabaseModule {}
+class _$DatabaseModule extends _i58.DatabaseModule {}

--- a/lib/core/services/aicore_service.dart
+++ b/lib/core/services/aicore_service.dart
@@ -1,7 +1,9 @@
 import 'package:flutter/services.dart';
+import 'package:injectable/injectable.dart';
 
 enum AicoreStatus { available, downloadable, unavailable, downloading }
 
+@lazySingleton
 class AicoreService {
   static const _channel = MethodChannel('com.orionhealth/aicore');
 
@@ -14,7 +16,7 @@ class AicoreService {
     void Function()? onComplete,
     void Function(String error)? onError,
   }) {
-    _channel.setMethodCallHandler((call) {
+    _channel.setMethodCallHandler((call) async {
       switch (call.method) {
         case 'onDownloadProgress':
           onDownloadProgress?.call(call.arguments['progress'] as int);

--- a/lib/core/services/device_info_service.dart
+++ b/lib/core/services/device_info_service.dart
@@ -1,0 +1,81 @@
+import 'package:flutter/services.dart';
+import 'dart:io';
+import 'package:injectable/injectable.dart';
+import 'package:device_info_plus/device_info_plus.dart';
+
+class SystemInfo {
+  final double totalRamGb;
+  final String model;
+  final String manufacturer;
+  final String gpuRenderer;
+
+  SystemInfo({
+    required this.totalRamGb,
+    required this.model,
+    required this.manufacturer,
+    required this.gpuRenderer,
+  });
+}
+
+@lazySingleton
+class DeviceInfoService {
+  static const _channel = MethodChannel('com.orionhealth/aicore');
+  final DeviceInfoPlugin _deviceInfo = DeviceInfoPlugin();
+
+  Future<SystemInfo> getSystemInfo() async {
+    if (Platform.isAndroid) {
+      try {
+        final Map<dynamic, dynamic>? info =
+            await _channel.invokeMethod<Map<dynamic, dynamic>>('getSystemInfo');
+
+        if (info != null) {
+          return SystemInfo(
+            totalRamGb: info['totalRamGb'] ?? 0.0,
+            model: info['model'] ?? 'Unknown',
+            manufacturer: info['manufacturer'] ?? 'Unknown',
+            gpuRenderer: info['glEsVersion'] ?? 'Unknown',
+          );
+        }
+      } catch (e) {
+        print('Error getting native system info: $e');
+      }
+    }
+
+    // Fallback using device_info_plus and reasonable defaults
+    if (Platform.isAndroid) {
+      final androidInfo = await _deviceInfo.androidInfo;
+      return SystemInfo(
+        totalRamGb: 0, // Cannot get RAM easily via device_info_plus
+        model: androidInfo.model,
+        manufacturer: androidInfo.manufacturer,
+        gpuRenderer: 'Unknown',
+      );
+    } else if (Platform.isIOS) {
+      final iosInfo = await _deviceInfo.iosInfo;
+      return SystemInfo(
+        totalRamGb: 0,
+        model: iosInfo.model,
+        manufacturer: 'Apple',
+        gpuRenderer: 'Unknown',
+      );
+    }
+
+    return SystemInfo(
+      totalRamGb: 0,
+      model: Platform.operatingSystem,
+      manufacturer: 'Unknown',
+      gpuRenderer: 'Unknown',
+    );
+  }
+
+  String getModelRecommendation(double ramGb) {
+    if (ramGb <= 0) return 'Se recomienda un modelo ligero (Gemma 2B) para dispositivos con RAM limitada.';
+    if (ramGb < 4) {
+      return 'Gemma 2B recomendado (Dispositivo con RAM limitada: ${ramGb.toStringAsFixed(1)}GB)';
+    } else if (ramGb < 8) {
+      return 'Gemma 2B o 7B recomendado (RAM media: ${ramGb.toStringAsFixed(1)}GB)';
+    } else {
+      return 'Gemma 7B o superior recomendado (Excelente capacidad: ${ramGb.toStringAsFixed(1)}GB)';
+    }
+  }
+}

--- a/lib/features/local_agent/infrastructure/adapters/gemma_llm_adapter.dart
+++ b/lib/features/local_agent/infrastructure/adapters/gemma_llm_adapter.dart
@@ -1,5 +1,5 @@
 import 'package:injectable/injectable.dart';
-import 'package:orionhealth/core/services/aicore_service.dart';
+import 'package:orionhealth_health/core/services/aicore_service.dart';
 import '../../domain/services/llm_adapter.dart';
 import 'dart:io';
 import 'package:google_generative_ai/google_generative_ai.dart';

--- a/lib/features/settings/application/bloc/settings_cubit.dart
+++ b/lib/features/settings/application/bloc/settings_cubit.dart
@@ -1,0 +1,57 @@
+import 'package:bloc/bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:injectable/injectable.dart';
+import '../../domain/entities/llm_config.dart';
+import '../../domain/repositories/settings_repository.dart';
+
+part 'settings_state.dart';
+
+@injectable
+class SettingsCubit extends Cubit<SettingsState> {
+  final SettingsRepository _repository;
+
+  SettingsCubit(this._repository) : super(SettingsInitial());
+
+  Future<void> loadSettings() async {
+    emit(SettingsLoading());
+    try {
+      final config = await _repository.getLlmConfig();
+      emit(SettingsLoaded(config));
+    } catch (e) {
+      emit(SettingsError(e.toString()));
+    }
+  }
+
+  Future<void> updateConfig(LlmConfig config) async {
+    try {
+      await _repository.saveLlmConfig(config);
+      emit(SettingsLoaded(config));
+    } catch (e) {
+      emit(SettingsError(e.toString()));
+    }
+  }
+
+  Future<void> setUseLocalModel(bool useLocal) async {
+    if (state is SettingsLoaded) {
+      final currentConfig = (state as SettingsLoaded).config;
+      final newConfig = currentConfig.copyWith(useLocalModel: useLocal);
+      await updateConfig(newConfig);
+    }
+  }
+
+  Future<void> setModelName(String modelName) async {
+    if (state is SettingsLoaded) {
+      final currentConfig = (state as SettingsLoaded).config;
+      final newConfig = currentConfig.copyWith(modelName: modelName);
+      await updateConfig(newConfig);
+    }
+  }
+
+  Future<void> setApiKey(String apiKey) async {
+    if (state is SettingsLoaded) {
+      final currentConfig = (state as SettingsLoaded).config;
+      final newConfig = currentConfig.copyWith(apiKey: apiKey);
+      await updateConfig(newConfig);
+    }
+  }
+}

--- a/lib/features/settings/application/bloc/settings_state.dart
+++ b/lib/features/settings/application/bloc/settings_state.dart
@@ -1,0 +1,30 @@
+part of 'settings_cubit.dart';
+
+abstract class SettingsState extends Equatable {
+  const SettingsState();
+
+  @override
+  List<Object> get props => [];
+}
+
+class SettingsInitial extends SettingsState {}
+
+class SettingsLoading extends SettingsState {}
+
+class SettingsLoaded extends SettingsState {
+  final LlmConfig config;
+
+  const SettingsLoaded(this.config);
+
+  @override
+  List<Object> get props => [config];
+}
+
+class SettingsError extends SettingsState {
+  final String message;
+
+  const SettingsError(this.message);
+
+  @override
+  List<Object> get props => [message];
+}

--- a/lib/features/settings/domain/entities/llm_config.dart
+++ b/lib/features/settings/domain/entities/llm_config.dart
@@ -1,0 +1,32 @@
+import 'package:isar/isar.dart';
+
+part 'llm_config.g.dart';
+
+@collection
+class LlmConfig {
+  Id id = Isar.autoIncrement;
+
+  String? modelName;
+
+  bool useLocalModel;
+
+  String? apiKey;
+
+  LlmConfig({
+    this.modelName = 'gemma-2b',
+    this.useLocalModel = true,
+    this.apiKey,
+  });
+
+  LlmConfig copyWith({
+    String? modelName,
+    bool? useLocalModel,
+    String? apiKey,
+  }) {
+    return LlmConfig(
+      modelName: modelName ?? this.modelName,
+      useLocalModel: useLocalModel ?? this.useLocalModel,
+      apiKey: apiKey ?? this.apiKey,
+    )..id = this.id;
+  }
+}

--- a/lib/features/settings/domain/entities/llm_config.g.dart
+++ b/lib/features/settings/domain/entities/llm_config.g.dart
@@ -1,0 +1,708 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'llm_config.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetLlmConfigCollection on Isar {
+  IsarCollection<LlmConfig> get llmConfigs => this.collection();
+}
+
+const LlmConfigSchema = CollectionSchema(
+  name: r'LlmConfig',
+  id: -1133713317419693239,
+  properties: {
+    r'apiKey': PropertySchema(
+      id: 0,
+      name: r'apiKey',
+      type: IsarType.string,
+    ),
+    r'modelName': PropertySchema(
+      id: 1,
+      name: r'modelName',
+      type: IsarType.string,
+    ),
+    r'useLocalModel': PropertySchema(
+      id: 2,
+      name: r'useLocalModel',
+      type: IsarType.bool,
+    )
+  },
+  estimateSize: _llmConfigEstimateSize,
+  serialize: _llmConfigSerialize,
+  deserialize: _llmConfigDeserialize,
+  deserializeProp: _llmConfigDeserializeProp,
+  idName: r'id',
+  indexes: {},
+  links: {},
+  embeddedSchemas: {},
+  getId: _llmConfigGetId,
+  getLinks: _llmConfigGetLinks,
+  attach: _llmConfigAttach,
+  version: '3.1.0+1',
+);
+
+int _llmConfigEstimateSize(
+  LlmConfig object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  {
+    final value = object.apiKey;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
+    final value = object.modelName;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _llmConfigSerialize(
+  LlmConfig object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.apiKey);
+  writer.writeString(offsets[1], object.modelName);
+  writer.writeBool(offsets[2], object.useLocalModel);
+}
+
+LlmConfig _llmConfigDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = LlmConfig(
+    apiKey: reader.readStringOrNull(offsets[0]),
+    modelName: reader.readStringOrNull(offsets[1]),
+    useLocalModel: reader.readBoolOrNull(offsets[2]) ?? true,
+  );
+  object.id = id;
+  return object;
+}
+
+P _llmConfigDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readStringOrNull(offset)) as P;
+    case 1:
+      return (reader.readStringOrNull(offset)) as P;
+    case 2:
+      return (reader.readBoolOrNull(offset) ?? true) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _llmConfigGetId(LlmConfig object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _llmConfigGetLinks(LlmConfig object) {
+  return [];
+}
+
+void _llmConfigAttach(IsarCollection<dynamic> col, Id id, LlmConfig object) {
+  object.id = id;
+}
+
+extension LlmConfigQueryWhereSort
+    on QueryBuilder<LlmConfig, LlmConfig, QWhere> {
+  QueryBuilder<LlmConfig, LlmConfig, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension LlmConfigQueryWhere
+    on QueryBuilder<LlmConfig, LlmConfig, QWhereClause> {
+  QueryBuilder<LlmConfig, LlmConfig, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+}
+
+extension LlmConfigQueryFilter
+    on QueryBuilder<LlmConfig, LlmConfig, QFilterCondition> {
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'apiKey',
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'apiKey',
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'apiKey',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'apiKey',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'apiKey',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'apiKey',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'apiKey',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'apiKey',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'apiKey',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'apiKey',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'apiKey',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> apiKeyIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'apiKey',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'modelName',
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition>
+      modelNameIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'modelName',
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'modelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition>
+      modelNameGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'modelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'modelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'modelName',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'modelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'modelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'modelName',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'modelName',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition> modelNameIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'modelName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition>
+      modelNameIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'modelName',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterFilterCondition>
+      useLocalModelEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'useLocalModel',
+        value: value,
+      ));
+    });
+  }
+}
+
+extension LlmConfigQueryObject
+    on QueryBuilder<LlmConfig, LlmConfig, QFilterCondition> {}
+
+extension LlmConfigQueryLinks
+    on QueryBuilder<LlmConfig, LlmConfig, QFilterCondition> {}
+
+extension LlmConfigQuerySortBy on QueryBuilder<LlmConfig, LlmConfig, QSortBy> {
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> sortByApiKey() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'apiKey', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> sortByApiKeyDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'apiKey', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> sortByModelName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modelName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> sortByModelNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modelName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> sortByUseLocalModel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'useLocalModel', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> sortByUseLocalModelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'useLocalModel', Sort.desc);
+    });
+  }
+}
+
+extension LlmConfigQuerySortThenBy
+    on QueryBuilder<LlmConfig, LlmConfig, QSortThenBy> {
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> thenByApiKey() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'apiKey', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> thenByApiKeyDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'apiKey', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> thenByModelName() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modelName', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> thenByModelNameDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'modelName', Sort.desc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> thenByUseLocalModel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'useLocalModel', Sort.asc);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QAfterSortBy> thenByUseLocalModelDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'useLocalModel', Sort.desc);
+    });
+  }
+}
+
+extension LlmConfigQueryWhereDistinct
+    on QueryBuilder<LlmConfig, LlmConfig, QDistinct> {
+  QueryBuilder<LlmConfig, LlmConfig, QDistinct> distinctByApiKey(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'apiKey', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QDistinct> distinctByModelName(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'modelName', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<LlmConfig, LlmConfig, QDistinct> distinctByUseLocalModel() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'useLocalModel');
+    });
+  }
+}
+
+extension LlmConfigQueryProperty
+    on QueryBuilder<LlmConfig, LlmConfig, QQueryProperty> {
+  QueryBuilder<LlmConfig, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<LlmConfig, String?, QQueryOperations> apiKeyProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'apiKey');
+    });
+  }
+
+  QueryBuilder<LlmConfig, String?, QQueryOperations> modelNameProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'modelName');
+    });
+  }
+
+  QueryBuilder<LlmConfig, bool, QQueryOperations> useLocalModelProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'useLocalModel');
+    });
+  }
+}

--- a/lib/features/settings/domain/repositories/settings_repository.dart
+++ b/lib/features/settings/domain/repositories/settings_repository.dart
@@ -1,0 +1,6 @@
+import '../entities/llm_config.dart';
+
+abstract class SettingsRepository {
+  Future<LlmConfig> getLlmConfig();
+  Future<void> saveLlmConfig(LlmConfig config);
+}

--- a/lib/features/settings/infrastructure/repositories/settings_repository_impl.dart
+++ b/lib/features/settings/infrastructure/repositories/settings_repository_impl.dart
@@ -1,0 +1,24 @@
+import 'package:injectable/injectable.dart';
+import 'package:isar/isar.dart';
+import '../../domain/entities/llm_config.dart';
+import '../../domain/repositories/settings_repository.dart';
+
+@LazySingleton(as: SettingsRepository)
+class SettingsRepositoryImpl implements SettingsRepository {
+  final Isar _isar;
+
+  SettingsRepositoryImpl(this._isar);
+
+  @override
+  Future<LlmConfig> getLlmConfig() async {
+    final config = await _isar.llmConfigs.where().findFirst();
+    return config ?? LlmConfig();
+  }
+
+  @override
+  Future<void> saveLlmConfig(LlmConfig config) async {
+    await _isar.writeTxn(() async {
+      await _isar.llmConfigs.put(config);
+    });
+  }
+}

--- a/lib/features/settings/presentation/pages/llm_settings_page.dart
+++ b/lib/features/settings/presentation/pages/llm_settings_page.dart
@@ -1,0 +1,290 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/di/injection.dart';
+import '../../../../core/theme/cyber_theme.dart';
+import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../../../core/services/device_info_service.dart';
+import '../application/bloc/settings_cubit.dart';
+import '../domain/entities/llm_config.dart';
+
+class LlmSettingsPage extends StatefulWidget {
+  const LlmSettingsPage({super.key});
+
+  @override
+  State<LlmSettingsPage> createState() => _LlmSettingsPageState();
+}
+
+class _LlmSettingsPageState extends State<LlmSettingsPage> {
+  SystemInfo? _systemInfo;
+  final _apiKeyController = TextEditingController();
+
+  @override
+  void initState() {
+    super.initState();
+    _loadSystemInfo();
+  }
+
+  Future<void> _loadSystemInfo() async {
+    final info = await getIt<DeviceInfoService>().getSystemInfo();
+    if (mounted) {
+      setState(() {
+        _systemInfo = info;
+      });
+    }
+  }
+
+  @override
+  void dispose() {
+    _apiKeyController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => getIt<SettingsCubit>()..loadSettings(),
+      child: Scaffold(
+        appBar: AppBar(
+          backgroundColor: Colors.transparent,
+          elevation: 0,
+          title: const Text('Configuración de LLM',
+              style: TextStyle(fontWeight: FontWeight.bold)),
+          centerTitle: true,
+        ),
+        body: BlocConsumer<SettingsCubit, SettingsState>(
+          listener: (context, state) {
+            if (state is SettingsLoaded) {
+              _apiKeyController.text = state.config.apiKey ?? '';
+            }
+          },
+          builder: (context, state) {
+            if (state is SettingsLoading) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (state is SettingsLoaded) {
+              return _buildContent(context, state.config);
+            } else if (state is SettingsError) {
+              return Center(child: Text('Error: ${state.message}'));
+            }
+            return const Center(child: Text('Iniciando...'));
+          },
+        ),
+      ),
+    );
+  }
+
+  Widget _buildContent(BuildContext context, LlmConfig config) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(16.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          _buildDeviceInfoSection(),
+          const SizedBox(height: 24),
+          _buildModelSelectionSection(context, config),
+          const SizedBox(height: 24),
+          _buildProviderSection(context, config),
+          const SizedBox(height: 32),
+          Center(
+            child: Text(
+              'OrionHealth utiliza modelos locales por defecto para máxima privacidad.',
+              textAlign: TextAlign.center,
+              style: TextStyle(
+                color: Colors.white.withOpacity(0.5),
+                fontSize: 12,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildDeviceInfoSection() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(left: 8.0, bottom: 8.0),
+          child: Text('Capacidad del Dispositivo',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+        ),
+        GlassmorphicCard(
+          child: Padding(
+            padding: const EdgeInsets.all(16.0),
+            child: Column(
+              children: [
+                _DeviceInfoRow(
+                  icon: Icons.memory,
+                  label: 'RAM Total',
+                  value: _systemInfo != null
+                      ? '${_systemInfo!.totalRamGb.toStringAsFixed(1)} GB'
+                      : 'Cargando...',
+                ),
+                const Divider(color: Colors.white10),
+                _DeviceInfoRow(
+                  icon: Icons.developer_board,
+                  label: 'GPU / Renderer',
+                  value: _systemInfo?.gpuRenderer ?? 'Cargando...',
+                ),
+                const SizedBox(height: 16),
+                Container(
+                  padding: const EdgeInsets.all(12),
+                  decoration: BoxDecoration(
+                    color: CyberTheme.primary.withOpacity(0.1),
+                    borderRadius: BorderRadius.circular(8),
+                    border: Border.all(color: CyberTheme.primary.withOpacity(0.3)),
+                  ),
+                  child: Row(
+                    children: [
+                      const Icon(Icons.recommend, color: CyberTheme.primary),
+                      const SizedBox(width: 12),
+                      Expanded(
+                        child: Text(
+                          getIt<DeviceInfoService>().getModelRecommendation(
+                              _systemInfo?.totalRamGb ?? 0.0),
+                          style: const TextStyle(
+                              color: CyberTheme.primary,
+                              fontWeight: FontWeight.w500),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildModelSelectionSection(BuildContext context, LlmConfig config) {
+    final models = [
+      'gemma-2b',
+      'gemma-7b',
+      'gemini-pro',
+      'gemini-1.5-flash',
+    ];
+
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(left: 8.0, bottom: 8.0),
+          child: Text('Modelo Seleccionado',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+        ),
+        GlassmorphicCard(
+          child: Padding(
+            padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+            child: DropdownButtonHideUnderline(
+              child: DropdownButton<String>(
+                value: config.modelName,
+                isExpanded: true,
+                dropdownColor: CyberTheme.backgroundDark,
+                items: models.map((String value) {
+                  return DropdownMenuItem<String>(
+                    value: value,
+                    child: Text(value.toUpperCase(),
+                        style: const TextStyle(color: Colors.white)),
+                  );
+                }).toList(),
+                onChanged: (newValue) {
+                  if (newValue != null) {
+                    context.read<SettingsCubit>().setModelName(newValue);
+                  }
+                },
+              ),
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildProviderSection(BuildContext context, LlmConfig config) {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        const Padding(
+          padding: EdgeInsets.only(left: 8.0, bottom: 8.0),
+          child: Text('Modo de Ejecución',
+              style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold)),
+        ),
+        GlassmorphicCard(
+          child: Column(
+            children: [
+              SwitchListTile(
+                title: const Text('Ejecución Local'),
+                subtitle: const Text('Privacidad total, sin internet'),
+                value: config.useLocalModel,
+                activeColor: CyberTheme.primary,
+                onChanged: (value) {
+                  context.read<SettingsCubit>().setUseLocalModel(value);
+                },
+              ),
+              if (!config.useLocalModel) ...[
+                const Divider(color: Colors.white10),
+                Padding(
+                  padding: const EdgeInsets.all(16.0),
+                  child: TextField(
+                    controller: _apiKeyController,
+                    decoration: InputDecoration(
+                      labelText: 'API Key de Gemini',
+                      border: const OutlineInputBorder(),
+                      suffixIcon: IconButton(
+                        icon: const Icon(Icons.save),
+                        onPressed: () {
+                          context
+                              .read<SettingsCubit>()
+                              .setApiKey(_apiKeyController.text);
+                          ScaffoldMessenger.of(context).showSnackBar(
+                            const SnackBar(content: Text('API Key guardada')),
+                          );
+                        },
+                      ),
+                    ),
+                    obscureText: true,
+                    onChanged: (value) {
+                      // We save on button press or we could debounce
+                    },
+                  ),
+                ),
+              ],
+            ],
+          ),
+        ),
+      ],
+    );
+  }
+}
+
+class _DeviceInfoRow extends StatelessWidget {
+  final IconData icon;
+  final String label;
+  final String value;
+
+  const _DeviceInfoRow({
+    required this.icon,
+    required this.label,
+    required this.value,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0),
+      child: Row(
+        children: [
+          Icon(icon, color: CyberTheme.secondary, size: 20),
+          const SizedBox(width: 12),
+          Text(label, style: const TextStyle(color: Colors.white70)),
+          const Spacer(),
+          Text(value,
+              style: const TextStyle(
+                  fontWeight: FontWeight.bold, color: Colors.white)),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/user_profile/presentation/pages/user_profile_page.dart
+++ b/lib/features/user_profile/presentation/pages/user_profile_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../../features/auth/presentation/pages/receive_medical_data_page.dart';
 import '../../../../features/auth/presentation/pages/share_medical_data_page.dart';
 import '../../../../features/about/presentation/pages/about_page.dart';
+import '../../../../features/settings/presentation/pages/llm_settings_page.dart';
 import '../../../../core/di/injection.dart';
 import '../../../../core/theme/cyber_theme.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
@@ -126,6 +127,19 @@ class _UserProfileView extends StatelessWidget {
                       icon: Icons.dark_mode,
                       title: 'Tema',
                       subtitle: 'Modo Oscuro',
+                    ),
+                    _InfoTile(
+                      icon: Icons.psychology,
+                      title: 'Configuración de LLM',
+                      subtitle: 'Modelos locales y nube',
+                      onTap: () {
+                        Navigator.push(
+                          context,
+                          MaterialPageRoute(
+                            builder: (context) => const LlmSettingsPage(),
+                          ),
+                        );
+                      },
                     ),
                     _InfoTile(
                       icon: Icons.info_outline,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -258,13 +258,13 @@ packages:
     source: hosted
     version: "0.7.11"
   device_info_plus:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: device_info_plus
-      sha256: dd0e8e02186b2196c7848c9d394a5fd6e5b57a43a546082c5820b1ec72317e33
+      sha256: b4fed1b2835da9d670d7bed7db79ae2a94b0f5ad6312268158a9b5479abbacdd
       url: "https://pub.dev"
     source: hosted
-    version: "12.2.0"
+    version: "12.4.0"
   device_info_plus_platform_interface:
     dependency: transitive
     description:
@@ -1017,18 +1017,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1445,10 +1445,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -72,6 +72,7 @@ dependencies:
   # Bluetooth Low Energy for medical data sharing
   flutter_blue_plus: ^1.35.2
   flutter_gemma: ^0.12.6
+  device_info_plus: ^12.4.0
 
 dev_dependencies:
   flutter_test:

--- a/test/features/local_agent/infrastructure/adapters/gemma_llm_adapter_test.dart
+++ b/test/features/local_agent/infrastructure/adapters/gemma_llm_adapter_test.dart
@@ -1,12 +1,11 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/local_agent/infrastructure/adapters/gemma_llm_adapter.dart';
-import 'package:orionhealth_health/features/local_agent/infrastructure/llama_inference_service.dart';
+import 'package:orionhealth_health/core/services/aicore_service.dart';
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
-import 'dart:io';
 
-class MockLlamaInferenceService extends Mock implements LlamaInferenceService {}
+class MockAicoreService extends Mock implements AicoreService {}
 
 class MockPathProviderPlatform extends Mock
     with MockPlatformInterfaceMixin
@@ -14,28 +13,29 @@ class MockPathProviderPlatform extends Mock
 
 void main() {
   late GemmaLlmAdapter adapter;
-  late MockLlamaInferenceService mockLlamaService;
+  late MockAicoreService mockAicoreService;
   late MockPathProviderPlatform mockPathProvider;
 
   setUp(() {
-    mockLlamaService = MockLlamaInferenceService();
+    mockAicoreService = MockAicoreService();
     mockPathProvider = MockPathProviderPlatform();
     PathProviderPlatform.instance = mockPathProvider;
 
     when(() => mockPathProvider.getApplicationDocumentsPath())
         .thenAnswer((_) async => '/tmp');
 
-    adapter = GemmaLlmAdapter(mockLlamaService);
+    adapter = GemmaLlmAdapter(aicoreService: mockAicoreService);
   });
 
-  test('generate calls llama service', () async {
-    // This test might be tricky because of File(path).exists() and rootBundle.load
-    // But we can at least check if it tries to use the service.
+  test('modelName returns local model name by default', () {
+    expect(adapter.modelName, 'gemma-4-e2b-aicore');
+  });
 
-    // In a real test environment /tmp/models/... won't exist unless we create it
-    // or mock the File class which is hard in Dart.
+  test('isAvailable returns true if AICore is available', () async {
+    when(() => mockAicoreService.checkAvailability())
+        .thenAnswer((_) async => AicoreStatus.available);
 
-    // For now, let's just verify the class can be instantiated and has the right model name.
-    expect(adapter.modelName, 'gemma-4-e2b');
+    final available = await adapter.isAvailable();
+    expect(available, true);
   });
 }


### PR DESCRIPTION
This change adds a new Settings feature that allows users to configure their LLM preferences, including model selection and local vs. cloud execution. It includes a native Android bridge for RAM/GPU detection and provides model recommendations based on device capacity.

Fixes #97

---
*PR created automatically by Jules for task [9559035837322730072](https://jules.google.com/task/9559035837322730072) started by @iberi22*