### PR TITLE
[UX] Add page-level header hierarchy to navigation destinations

### DIFF
--- a/lib/core/widgets/page_header.dart
+++ b/lib/core/widgets/page_header.dart
@@ -1,0 +1,90 @@
+import 'package:flutter/material.dart';
+import '../theme/cyber_theme.dart';
+
+class PageHeader extends StatelessWidget {
+  final String title;
+  final String? subtitle;
+  final Widget? leading;
+  final Widget? trailing;
+  final bool showBackButton;
+  final IconData? backButtonIcon;
+  final VoidCallback? onBackPress;
+
+  const PageHeader({
+    super.key,
+    required this.title,
+    this.subtitle,
+    this.leading,
+    this.trailing,
+    this.showBackButton = false,
+    this.backButtonIcon,
+    this.onBackPress,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final theme = Theme.of(context);
+
+    return Container(
+      padding: const EdgeInsets.fromLTRB(16, 24, 16, 16),
+      width: double.infinity,
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          Row(
+            crossAxisAlignment: CrossAxisAlignment.center,
+            children: [
+              if (showBackButton) ...[
+                IconButton(
+                  onPressed: onBackPress ?? () => Navigator.of(context).pop(),
+                  icon: Icon(backButtonIcon ?? Icons.arrow_back_ios_new, size: 20),
+                  padding: EdgeInsets.zero,
+                  constraints: const BoxConstraints(),
+                  color: CyberTheme.secondary,
+                ),
+                const SizedBox(width: 12),
+              ] else if (leading != null) ...[
+                leading!,
+                const SizedBox(width: 12),
+              ],
+              Expanded(
+                child: Text(
+                  title,
+                  style: theme.textTheme.headlineMedium?.copyWith(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    letterSpacing: -0.5,
+                  ),
+                ),
+              ),
+              if (trailing != null) trailing!,
+            ],
+          ),
+          if (subtitle != null) ...[
+            const SizedBox(height: 8),
+            Text(
+              subtitle!,
+              style: theme.textTheme.bodyMedium?.copyWith(
+                color: Colors.white.withValues(alpha: 0.6),
+                height: 1.4,
+              ),
+            ),
+          ],
+          const SizedBox(height: 16),
+          Container(
+            height: 1,
+            width: 64,
+            decoration: BoxDecoration(
+              gradient: LinearGradient(
+                colors: [
+                  CyberTheme.primary,
+                  CyberTheme.primary.withValues(alpha: 0),
+                ],
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/health_record/presentation/pages/health_record_staging_page.dart
+++ b/lib/features/health_record/presentation/pages/health_record_staging_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../../../../core/di/injection.dart';
 import '../../../../core/theme/cyber_theme.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../../../core/widgets/page_header.dart';
 import '../../application/bloc/health_record_cubit.dart';
 import '../../domain/entities/medical_record.dart';
 
@@ -51,18 +52,22 @@ class _RecordHistoryView extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        leading: const Icon(Icons.security, color: CyberTheme.secondary),
-        title: const Text('Historial Médico'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.ios_share, color: CyberTheme.secondary),
-            onPressed: () {},
-          ),
-        ],
-      ),
       body: CustomScrollView(
         slivers: [
+          SliverToBoxAdapter(
+            child: SafeArea(
+              bottom: false,
+              child: PageHeader(
+                title: 'Historial Médico',
+                subtitle: 'Tus registros de salud protegidos por cifrado de extremo a extremo',
+                leading: const Icon(Icons.security, color: CyberTheme.secondary),
+                trailing: IconButton(
+                  icon: const Icon(Icons.ios_share, color: CyberTheme.secondary),
+                  onPressed: () {},
+                ),
+              ),
+            ),
+          ),
           SliverToBoxAdapter(
             child: Padding(
               padding: const EdgeInsets.all(16.0),

--- a/lib/features/health_report/presentation/pages/reports_page.dart
+++ b/lib/features/health_report/presentation/pages/reports_page.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import '../../../../core/di/injection.dart';
 import '../../../../core/theme/cyber_theme.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../../../core/widgets/page_header.dart';
 import '../../application/bloc/health_report_bloc.dart';
 import 'report_detail_page.dart';
 
@@ -14,10 +15,6 @@ class ReportsPage extends StatelessWidget {
     return BlocProvider(
       create: (context) => getIt<HealthReportBloc>()..add(LoadReports()),
       child: Scaffold(
-        appBar: AppBar(
-          automaticallyImplyLeading: false,
-          title: const Text('Programar Citas'),
-        ),
         body: RefreshIndicator(
           onRefresh: () async {
             context.read<HealthReportBloc>().add(LoadReports());
@@ -27,6 +24,15 @@ class ReportsPage extends StatelessWidget {
             builder: (context, state) {
               return CustomScrollView(
                 slivers: [
+                  const SliverToBoxAdapter(
+                    child: SafeArea(
+                      bottom: false,
+                      child: PageHeader(
+                        title: 'Citas Médicas',
+                        subtitle: 'Gestiona tus próximas consultas y seguimiento médico',
+                      ),
+                    ),
+                  ),
                   SliverToBoxAdapter(
                     child: Padding(
                       padding: const EdgeInsets.all(16.0),

--- a/lib/features/health_sharing/presentation/pages/receive_page.dart
+++ b/lib/features/health_sharing/presentation/pages/receive_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/widgets/page_header.dart';
 import '../../application/sharing_cubit.dart';
 import '../../domain/entities/shared_health_package.dart';
 
@@ -36,15 +37,6 @@ class _ReceivePageContentState extends State<_ReceivePageContent> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Recibir Datos'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.close),
-            onPressed: () => Navigator.of(context).pop(),
-          ),
-        ],
-      ),
       body: BlocConsumer<SharingCubit, SharingState>(
         listener: (context, state) {
           if (state is SharingReceiving && state.package != null) {
@@ -58,7 +50,20 @@ class _ReceivePageContentState extends State<_ReceivePageContent> {
           }
         },
         builder: (context, state) {
-          return _buildWaitingUI(state);
+          return SafeArea(
+            child: Column(
+              children: [
+                PageHeader(
+                  title: 'Recibir Datos',
+                  subtitle: 'Acepta transferencias de salud cifradas de otros dispositivos cercanos',
+                  showBackButton: true,
+                  backButtonIcon: Icons.close,
+                  onBackPress: () => Navigator.of(context).pop(),
+                ),
+                Expanded(child: _buildWaitingUI(state)),
+              ],
+            ),
+          );
         },
       ),
     );

--- a/lib/features/health_sharing/presentation/pages/share_page.dart
+++ b/lib/features/health_sharing/presentation/pages/share_page.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/widgets/page_header.dart';
 import '../../application/sharing_cubit.dart';
 import '../../domain/entities/shared_health_package.dart';
 
@@ -30,15 +31,6 @@ class _SharePageContentState extends State<_SharePageContent> {
   @override
   Widget build(BuildContext context) {
     return Scaffold(
-      appBar: AppBar(
-        title: const Text('Compartir Datos'),
-        actions: [
-          IconButton(
-            icon: const Icon(Icons.close),
-            onPressed: () => Navigator.of(context).pop(),
-          ),
-        ],
-      ),
       body: BlocConsumer<SharingCubit, SharingState>(
         listener: (context, state) {
           if (state is SharingComplete) {
@@ -54,12 +46,20 @@ class _SharePageContentState extends State<_SharePageContent> {
             return _buildTransferringUI(state);
           }
 
-          return SingleChildScrollView(
-            padding: const EdgeInsets.all(16),
-            child: Column(
-              crossAxisAlignment: CrossAxisAlignment.start,
-              children: [
-                _buildCategorySelector(),
+          return SafeArea(
+            child: SingleChildScrollView(
+              padding: const EdgeInsets.symmetric(horizontal: 16),
+              child: Column(
+                crossAxisAlignment: CrossAxisAlignment.start,
+                children: [
+                  PageHeader(
+                    title: 'Compartir Datos',
+                    subtitle: 'Transfiere de forma segura tu historial médico a otros nodos OrionHealth',
+                    showBackButton: true,
+                    backButtonIcon: Icons.close,
+                    onBackPress: () => Navigator.of(context).pop(),
+                  ),
+                  _buildCategorySelector(),
                 const SizedBox(height: 24),
                 _buildMethodSelector(),
                 const SizedBox(height: 24),

--- a/lib/features/user_profile/presentation/pages/user_profile_page.dart
+++ b/lib/features/user_profile/presentation/pages/user_profile_page.dart
@@ -7,6 +7,7 @@ import '../../../../features/settings/presentation/pages/llm_settings_page.dart'
 import '../../../../core/di/injection.dart';
 import '../../../../core/theme/cyber_theme.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../../../core/widgets/page_header.dart';
 import '../../application/bloc/user_profile_cubit.dart';
 import '../../domain/entities/user_profile.dart';
 
@@ -41,18 +42,23 @@ class _UserProfileView extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    final theme = Theme.of(context);
     return CustomScrollView(
       slivers: [
-        SliverAppBar(
+        const SliverAppBar(
           backgroundColor: Colors.transparent,
-          leading: const Icon(Icons.arrow_back_ios_new),
-          title: Text(
-            'Perfil del Usuario',
-            style: theme.textTheme.titleLarge?.copyWith(fontWeight: FontWeight.bold),
-          ),
-          centerTitle: true,
+          elevation: 0,
+          toolbarHeight: 0,
           pinned: true,
+          bottom: PreferredSize(
+            preferredSize: Size.fromHeight(100),
+            child: SafeArea(
+              bottom: false,
+              child: PageHeader(
+                title: 'Perfil del Usuario',
+                subtitle: 'Configura tu identidad digital y preferencias de privacidad',
+              ),
+            ),
+          ),
         ),
         SliverPadding(
           padding: const EdgeInsets.symmetric(horizontal: 16.0),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -5,6 +5,7 @@ import 'package:flutter/material.dart';
 import 'core/di/injection.dart';
 import 'core/theme/cyber_theme.dart';
 import 'core/widgets/floating_assistant_button.dart';
+import 'core/widgets/page_header.dart';
 import 'features/health_record/presentation/pages/health_record_staging_page.dart';
 import 'features/health_report/presentation/pages/reports_page.dart';
 import 'features/user_profile/presentation/pages/user_profile_page.dart';
@@ -15,7 +16,21 @@ class HomePage extends StatelessWidget {
   const HomePage({super.key});
   @override
   Widget build(BuildContext context) {
-    return const Scaffold(body: Center(child: Text('Home Page')));
+    return const Scaffold(
+      body: SafeArea(
+        child: SingleChildScrollView(
+          child: Column(
+            children: [
+              PageHeader(
+                title: 'Inicio',
+                subtitle: 'Gestiona tu salud y consulta tu asistente inteligente',
+              ),
+              // More content can be added here
+            ],
+          ),
+        ),
+      ),
+    );
   }
 }
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -969,18 +969,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1389,10 +1389,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR introduces a consistent page-level header hierarchy across the application's primary navigation destinations. 

Key changes:
- **New Widget**: `PageHeader` in `lib/core/widgets/page_header.dart` provides a standardized way to display titles and descriptive subtitles (supporting context).
- **Home Page**: Added header with 'Inicio' title and descriptive subtitle.
- **Reports Page**: Integrated header into `CustomScrollView`, providing context for medical appointments.
- **Health Records**: Added header with a security icon to emphasize end-to-end encryption.
- **User Profile**: Replaced `SliverAppBar` with a pinned `PageHeader` inside a `SliverAppBar` bottom slot to maintain UX while adding context.
- **Sharing/Receive Pages**: Added headers with 'Close' (X) icons for a more modal-like feel.

These changes address the issue of screens feeling empty or lacking context, especially on wider displays, by providing clear visual framing and identifying the purpose of each section at a glance.

Fixes #130

---
*PR created automatically by Jules for task [18393524187121529067](https://jules.google.com/task/18393524187121529067) started by @iberi22*