### PR TITLE
[UX] Redesign records upload into guided step-based flow

### DIFF
--- a/lib/features/health_record/presentation/pages/health_record_staging_page.dart
+++ b/lib/features/health_record/presentation/pages/health_record_staging_page.dart
@@ -6,6 +6,7 @@ import '../../../../core/theme/cyber_theme.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
 import '../../application/bloc/health_record_cubit.dart';
 import '../../domain/entities/medical_record.dart';
+import 'upload_page.dart';
 
 class HealthRecordStagingPage extends StatelessWidget {
   const HealthRecordStagingPage({super.key});
@@ -28,15 +29,6 @@ class HealthRecordStagingPage extends StatelessWidget {
           }
         },
         builder: (context, state) {
-          if (state is HealthRecordFilePicked) {
-            return Scaffold(
-              appBar: AppBar(title: const Text('Nuevo Registro Médico')),
-              body: _RecordForm(
-                filePath: state.filePath,
-                initialText: state.extractedText,
-              ),
-            );
-          }
           return _RecordHistoryView(state: state);
         },
       ),
@@ -84,22 +76,21 @@ class _RecordHistoryView extends StatelessWidget {
         ],
       ),
       floatingActionButton: FloatingActionButton.extended(
-        onPressed: () => _showSelectionModal(context),
+        onPressed: () {
+          Navigator.push(
+            context,
+            MaterialPageRoute(
+              builder: (innerContext) => BlocProvider.value(
+                value: context.read<HealthRecordCubit>(),
+                child: const UploadPage(),
+              ),
+            ),
+          );
+        },
         label: const Text('Añadir Registro'),
         icon: const Icon(Icons.add),
         backgroundColor: CyberTheme.primary,
         foregroundColor: Colors.black,
-      ),
-    );
-  }
-
-  void _showSelectionModal(BuildContext context) {
-    showModalBottomSheet(
-      context: context,
-      backgroundColor: Colors.transparent,
-      builder: (_) => BlocProvider.value(
-        value: BlocProvider.of<HealthRecordCubit>(context),
-        child: _SelectionView(),
       ),
     );
   }
@@ -225,154 +216,3 @@ class _TimelineItem extends StatelessWidget {
   }
 }
 
-class _SelectionView extends StatelessWidget {
-  @override
-  Widget build(BuildContext context) {
-    return GlassmorphicCard(
-      child: Padding(
-        padding: const EdgeInsets.all(16.0),
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            ListTile(
-              leading: const Icon(Icons.picture_as_pdf, color: CyberTheme.secondary),
-              title: const Text('Subir PDF'),
-              onTap: () {
-                Navigator.pop(context);
-                context.read<HealthRecordCubit>().pickPdf();
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.camera_alt, color: CyberTheme.secondary),
-              title: const Text('Tomar Foto'),
-              onTap: () {
-                Navigator.pop(context);
-                context.read<HealthRecordCubit>().pickImage(true);
-              },
-            ),
-            ListTile(
-              leading: const Icon(Icons.image, color: CyberTheme.secondary),
-              title: const Text('Galería'),
-              onTap: () {
-                Navigator.pop(context);
-                context.read<HealthRecordCubit>().pickImage(false);
-              },
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}
-
-class _RecordForm extends StatefulWidget {
-  final String filePath;
-  final String initialText;
-  const _RecordForm({required this.filePath, required this.initialText});
-  @override
-  State<_RecordForm> createState() => _RecordFormState();
-}
-
-class _RecordFormState extends State<_RecordForm> {
-  final _formKey = GlobalKey<FormState>();
-  late TextEditingController _textController;
-  late TextEditingController _summaryController;
-  late DateTime _selectedDate;
-  RecordType _selectedType = RecordType.clinicalNote;
-
-  @override
-  void initState() {
-    super.initState();
-    _textController = TextEditingController(text: widget.initialText);
-    _summaryController = TextEditingController();
-    _selectedDate = DateTime.now();
-  }
-
-  @override
-  void dispose() {
-    _textController.dispose();
-    _summaryController.dispose();
-    super.dispose();
-  }
-
-  @override
-  Widget build(BuildContext context) {
-    return SingleChildScrollView(
-      padding: const EdgeInsets.all(16.0),
-      child: Form(
-        key: _formKey,
-        child: Column(
-          crossAxisAlignment: CrossAxisAlignment.start,
-          children: [
-            Text('Archivo: ${widget.filePath.split('/').last}'),
-            const SizedBox(height: 16),
-            GlassmorphicCard(
-              child: Padding(
-                padding: const EdgeInsets.symmetric(horizontal: 12.0),
-                child: DropdownButtonFormField<RecordType>(
-                  initialValue: _selectedType,
-                  decoration: const InputDecoration(labelText: 'Tipo de Documento', border: InputBorder.none),
-                  items: RecordType.values.map((type) => DropdownMenuItem(value: type, child: Text(type.name))).toList(),
-                  onChanged: (val) => setState(() => _selectedType = val!),
-                ),
-              ),
-            ),
-            const SizedBox(height: 16),
-             GlassmorphicCard(
-               child: InkWell(
-                onTap: () async {
-                  final date = await showDatePicker(
-                    context: context,
-                    initialDate: _selectedDate,
-                    firstDate: DateTime(2000),
-                    lastDate: DateTime.now(),
-                  );
-                  if (date != null) setState(() => _selectedDate = date);
-                },
-                child: InputDecorator(
-                  decoration: const InputDecoration(labelText: 'Fecha del Documento', border: InputBorder.none, contentPadding: EdgeInsets.all(12)),
-                  child: Text(DateFormat('yyyy-MM-dd').format(_selectedDate)),
-                ),
-                         ),
-             ),
-            const SizedBox(height: 16),
-             GlassmorphicCard(child: TextFormField(
-              controller: _summaryController,
-              decoration: const InputDecoration(labelText: 'Resumen Breve', border: InputBorder.none, contentPadding: EdgeInsets.all(12)),
-              validator: (v) => v?.isEmpty == true ? 'Requerido' : null,
-            )),
-            const SizedBox(height: 16),
-            GlassmorphicCard(child: TextFormField(
-              controller: _textController,
-              decoration: const InputDecoration(labelText: 'Texto Extraído (Editable)', border: InputBorder.none, contentPadding: EdgeInsets.all(12)),
-              maxLines: 10,
-            )),
-            const SizedBox(height: 24),
-            Row(
-              children: [
-                Expanded(child: OutlinedButton(onPressed: () => context.read<HealthRecordCubit>().reset(), child: const Text('Cancelar'))),
-                const SizedBox(width: 16),
-                Expanded(
-                  child: ElevatedButton(
-                    onPressed: () {
-                      if (_formKey.currentState!.validate()) {
-                        context.read<HealthRecordCubit>().saveRecord(
-                              filePath: widget.filePath,
-                              extractedText: _textController.text,
-                              summary: _summaryController.text,
-                              type: _selectedType,
-                              date: _selectedDate,
-                            );
-                      }
-                    },
-                    child: const Text('Guardar'),
-                  ),
-                ),
-              ],
-            ),
-          ],
-        ),
-      ),
-    );
-  }
-}

--- a/lib/features/health_record/presentation/pages/upload_page.dart
+++ b/lib/features/health_record/presentation/pages/upload_page.dart
@@ -1,0 +1,390 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/theme/cyber_theme.dart';
+import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../application/bloc/health_record_cubit.dart';
+import '../../domain/entities/medical_record.dart';
+
+class UploadPage extends StatelessWidget {
+  const UploadPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocConsumer<HealthRecordCubit, HealthRecordState>(
+      listener: (context, state) {
+        if (state is HealthRecordError) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            SnackBar(content: Text('Error: ${state.message}')),
+          );
+        } else if (state is HealthRecordSaved) {
+          ScaffoldMessenger.of(context).showSnackBar(
+            const SnackBar(content: Text('¡Registro guardado con éxito!')),
+          );
+          Navigator.of(context).pop();
+        }
+      },
+      builder: (context, state) {
+        return Scaffold(
+          appBar: AppBar(
+            title: const Text('Subir Registro'),
+            leading: IconButton(
+              icon: const Icon(Icons.close),
+              onPressed: () {
+                context.read<HealthRecordCubit>().reset();
+                Navigator.of(context).pop();
+              },
+            ),
+          ),
+          body: _buildBody(context, state),
+        );
+      },
+    );
+  }
+
+  Widget _buildBody(BuildContext context, HealthRecordState state) {
+    if (state is HealthRecordLoading) {
+      return const Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            CircularProgressIndicator(color: CyberTheme.primary),
+            SizedBox(height: 24),
+            Text('Procesando documento...',
+                style: TextStyle(color: CyberTheme.secondary, fontSize: 18)),
+            SizedBox(height: 8),
+            Text('Extrayendo información médica con IA',
+                style: TextStyle(color: Colors.white70)),
+          ],
+        ),
+      );
+    }
+
+    if (state is HealthRecordFilePicked) {
+      return _UploadDetailsStep(
+        filePath: state.filePath,
+        extractedText: state.extractedText,
+      );
+    }
+
+    return _SourceSelectionStep();
+  }
+}
+
+class _SourceSelectionStep extends StatelessWidget {
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24.0),
+      child: Column(
+        crossAxisAlignment: CrossAxisAlignment.start,
+        children: [
+          const Text(
+            'Selecciona el origen',
+            style: TextStyle(
+              fontSize: 24,
+              fontWeight: FontWeight.bold,
+              color: CyberTheme.primary,
+            ),
+          ),
+          const SizedBox(height: 8),
+          const Text(
+            'Sube tus documentos médicos para que nuestra IA pueda analizarlos y organizarlos por ti.',
+            style: TextStyle(color: Colors.white70),
+          ),
+          const SizedBox(height: 32),
+
+          // Primary CTA: PDF
+          _OptionCard(
+            title: 'Subir Documento PDF',
+            description: 'Ideal para informes de laboratorio, recetas digitales y epicrisis.',
+            icon: Icons.picture_as_pdf,
+            isPrimary: true,
+            onTap: () => context.read<HealthRecordCubit>().pickPdf(),
+          ),
+
+          const SizedBox(height: 16),
+          const Row(
+            children: [
+              Expanded(child: Divider(color: Colors.white24)),
+              Padding(
+                padding: EdgeInsets.symmetric(horizontal: 16),
+                child: Text('O OTRAS OPCIONES', style: TextStyle(color: Colors.white38, fontSize: 12)),
+              ),
+              Expanded(child: Divider(color: Colors.white24)),
+            ],
+          ),
+          const SizedBox(height: 16),
+
+          // Secondary: Camera
+          _OptionCard(
+            title: 'Tomar Foto',
+            description: 'Captura una imagen de un documento físico usando tu cámara.',
+            icon: Icons.camera_alt,
+            onTap: () => context.read<HealthRecordCubit>().pickImage(true),
+          ),
+
+          const SizedBox(height: 16),
+
+          // Secondary: Gallery
+          _OptionCard(
+            title: 'Elegir de la Galería',
+            description: 'Selecciona una foto de un documento que ya tengas en tu dispositivo.',
+            icon: Icons.image,
+            onTap: () => context.read<HealthRecordCubit>().pickImage(false),
+          ),
+        ],
+      ),
+    );
+  }
+}
+
+class _OptionCard extends StatelessWidget {
+  final String title;
+  final String description;
+  final IconData icon;
+  final VoidCallback onTap;
+  final bool isPrimary;
+
+  const _OptionCard({
+    required this.title,
+    required this.description,
+    required this.icon,
+    required this.onTap,
+    this.isPrimary = false,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: onTap,
+      borderRadius: BorderRadius.circular(16),
+      child: GlassmorphicCard(
+        borderColor: isPrimary ? CyberTheme.primary.withValues(alpha: 0.5) : Colors.white10,
+        child: Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: Row(
+            children: [
+              Container(
+                padding: const EdgeInsets.all(12),
+                decoration: BoxDecoration(
+                  color: (isPrimary ? CyberTheme.primary : CyberTheme.secondary).withValues(alpha: 0.1),
+                  borderRadius: BorderRadius.circular(12),
+                ),
+                child: Icon(
+                  icon,
+                  color: isPrimary ? CyberTheme.primary : CyberTheme.secondary,
+                  size: 32,
+                ),
+              ),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      title,
+                      style: TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: isPrimary ? CyberTheme.primary : Colors.white,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      description,
+                      style: const TextStyle(color: Colors.white70, fontSize: 13),
+                    ),
+                  ],
+                ),
+              ),
+              const Icon(Icons.chevron_right, color: Colors.white24),
+            ],
+          ),
+        ),
+      ),
+    );
+  }
+}
+
+class _UploadDetailsStep extends StatefulWidget {
+  final String filePath;
+  final String extractedText;
+
+  const _UploadDetailsStep({
+    required this.filePath,
+    required this.extractedText,
+  });
+
+  @override
+  State<_UploadDetailsStep> createState() => _UploadDetailsStepState();
+}
+
+class _UploadDetailsStepState extends State<_UploadDetailsStep> {
+  final _formKey = GlobalKey<FormState>();
+  // We'll just use a simple form here, but ideally we'd reuse the logic from the other page
+  // For now, I'll implement a clean version here.
+
+  // NOTE: In a real app, I'd refactor the RecordForm into a shared widget.
+  // But to satisfy the "Redesign records upload into guided step-based flow"
+  // I will make this part of the new flow.
+
+  late TextEditingController _summaryController;
+  late TextEditingController _textController;
+  late DateTime _selectedDate;
+  RecordType _selectedType = RecordType.clinicalNote;
+
+  @override
+  void initState() {
+    super.initState();
+    _summaryController = TextEditingController();
+    _textController = TextEditingController(text: widget.extractedText);
+    _selectedDate = DateTime.now();
+  }
+
+  @override
+  void dispose() {
+    _summaryController.dispose();
+    _textController.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return SingleChildScrollView(
+      padding: const EdgeInsets.all(24.0),
+      child: Form(
+        key: _formKey,
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Text(
+              'Verificar Información',
+              style: TextStyle(
+                fontSize: 24,
+                fontWeight: FontWeight.bold,
+                color: CyberTheme.primary,
+              ),
+            ),
+            const SizedBox(height: 8),
+            const Text(
+              'Revisa y completa los detalles extraídos del documento.',
+              style: TextStyle(color: Colors.white70),
+            ),
+            const SizedBox(height: 24),
+
+            Text('Archivo: ${widget.filePath.split('/').last}',
+                style: const TextStyle(color: CyberTheme.secondary, fontSize: 12)),
+            const SizedBox(height: 16),
+
+            GlassmorphicCard(
+              child: Padding(
+                padding: const EdgeInsets.all(16.0),
+                child: Column(
+                  children: [
+                    TextFormField(
+                      controller: _summaryController,
+                      decoration: const InputDecoration(
+                        labelText: 'Resumen o Título',
+                        labelStyle: TextStyle(color: CyberTheme.secondary),
+                        enabledBorder: UnderlineInputBorder(borderSide: BorderSide(color: Colors.white24)),
+                      ),
+                      validator: (v) => v?.isEmpty == true ? 'Requerido' : null,
+                    ),
+                    const SizedBox(height: 16),
+                    DropdownButtonFormField<RecordType>(
+                      value: _selectedType,
+                      dropdownColor: CyberTheme.surfaceDark,
+                      decoration: const InputDecoration(
+                        labelText: 'Tipo de Documento',
+                        labelStyle: TextStyle(color: CyberTheme.secondary),
+                        enabledBorder: UnderlineInputBorder(borderSide: BorderSide(color: Colors.white24)),
+                      ),
+                      items: RecordType.values
+                          .map((type) => DropdownMenuItem(
+                                value: type,
+                                child: Text(type.name, style: const TextStyle(color: Colors.white)),
+                              ))
+                          .toList(),
+                      onChanged: (val) => setState(() => _selectedType = val!),
+                    ),
+                    const SizedBox(height: 16),
+                    InkWell(
+                      onTap: () async {
+                        final date = await showDatePicker(
+                          context: context,
+                          initialDate: _selectedDate,
+                          firstDate: DateTime(2000),
+                          lastDate: DateTime.now(),
+                        );
+                        if (date != null) setState(() => _selectedDate = date);
+                      },
+                      child: InputDecorator(
+                        decoration: const InputDecoration(
+                          labelText: 'Fecha del Documento',
+                          labelStyle: TextStyle(color: CyberTheme.secondary),
+                          enabledBorder: UnderlineInputBorder(borderSide: BorderSide(color: Colors.white24)),
+                        ),
+                        child: Text('${_selectedDate.toLocal()}'.split(' ')[0]),
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+
+            const Text('Texto Extraído', style: TextStyle(color: CyberTheme.secondary, fontWeight: FontWeight.bold)),
+            const SizedBox(height: 8),
+            GlassmorphicCard(
+              child: TextFormField(
+                controller: _textController,
+                maxLines: 8,
+                decoration: const InputDecoration(
+                  contentPadding: EdgeInsets.all(12),
+                  border: InputBorder.none,
+                ),
+                style: const TextStyle(fontSize: 13, color: Colors.white70),
+              ),
+            ),
+
+            const SizedBox(height: 32),
+
+            SizedBox(
+              width: double.infinity,
+              height: 56,
+              child: ElevatedButton(
+                onPressed: () {
+                  if (_formKey.currentState!.validate()) {
+                    context.read<HealthRecordCubit>().saveRecord(
+                      filePath: widget.filePath,
+                      extractedText: _textController.text,
+                      summary: _summaryController.text,
+                      type: _selectedType,
+                      date: _selectedDate,
+                    );
+                  }
+                },
+                style: ElevatedButton.styleFrom(
+                  backgroundColor: CyberTheme.primary,
+                  foregroundColor: Colors.black,
+                  shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(16)),
+                ),
+                child: const Text('GUARDAR REGISTRO', style: TextStyle(fontWeight: FontWeight.bold, letterSpacing: 1.2)),
+              ),
+            ),
+
+            const SizedBox(height: 16),
+            Center(
+              child: TextButton(
+                onPressed: () => context.read<HealthRecordCubit>().reset(),
+                child: const Text('Cancelar', style: TextStyle(color: Colors.white54)),
+              ),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -969,18 +969,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1389,10 +1389,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
I have redesigned the health records upload process into a guided, step-based flow as requested. 

Key changes include:
- **New `UploadPage`**: Replaced the simple bottom modal with a dedicated, multi-step page.
- **Prioritization**: 'Subir Documento PDF' is now the primary call to action with a distinct visual style, while 'Tomar Foto' and 'Elegir de la Galería' are secondary options.
- **Guidance**: Each intake option now includes a clear description to help users choose the best method.
- **Feedback**: Added a dedicated loading state with informative text ("Procesando documento...") and success/error feedback via SnackBars and navigation.
- **Integration**: Updated the FAB in `HealthRecordStagingPage` to launch the new flow and removed redundant code from the original page.
- **Metadata Preservation**: Ensured that users can still select the `RecordType` and verify extracted text before saving.

All changes adhere to the project's 'Cyber-Minimalism' design system using `GlassmorphicCard` and `CyberTheme` constants.

Fixes #131

---
*PR created automatically by Jules for task [704408014919593739](https://jules.google.com/task/704408014919593739) started by @iberi22*