### PR TITLE
[UX] AI Assistant Conversation Affordances

### DIFF
--- a/lib/core/widgets/floating_assistant_button.dart
+++ b/lib/core/widgets/floating_assistant_button.dart
@@ -1,5 +1,7 @@
 import 'package:flutter/material.dart';
-import '../../features/medical_assistant/presentation/pages/medical_assistant_page.dart';
+import '../../features/ai_assistant/presentation/pages/chat_page.dart';
+import '../../features/local_agent/infrastructure/llm_service.dart';
+import '../di/injection.dart';
 
 /// A floating action button with pulse animation for the AI medical assistant.
 /// 
@@ -94,7 +96,9 @@ class _FloatingAssistantButtonState extends State<FloatingAssistantButton>
   void _openAssistant() {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => const MedicalAssistantPage(),
+        builder: (context) => ChatPage(
+          llmService: getIt<LlmService>(),
+        ),
       ),
     );
   }

--- a/lib/features/ai_assistant/presentation/pages/chat_page.dart
+++ b/lib/features/ai_assistant/presentation/pages/chat_page.dart
@@ -1,0 +1,302 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/services.dart';
+import 'package:intl/intl.dart';
+import '../../../../core/theme/cyber_theme.dart';
+import '../../../local_agent/domain/chat_message.dart';
+import '../../../local_agent/infrastructure/llm_service.dart';
+import '../widgets/message_composer.dart';
+
+enum AssistantState { idle, thinking, responding }
+
+class ChatPage extends StatefulWidget {
+  final LlmService llmService;
+  const ChatPage({super.key, required this.llmService});
+
+  @override
+  State<ChatPage> createState() => _ChatPageState();
+}
+
+class _ChatPageState extends State<ChatPage> {
+  final TextEditingController _textController = TextEditingController();
+  final ScrollController _scrollController = ScrollController();
+  final List<ChatMessage> _messages = [];
+  AssistantState _assistantState = AssistantState.idle;
+
+  @override
+  void initState() {
+    super.initState();
+    // Add initial AI message
+    _messages.add(ChatMessage(
+      role: ChatRole.assistant,
+      content: "Welcome to OrionHealth. How can I assist you with your health data today?",
+      timestamp: DateTime.now(),
+    ));
+  }
+
+  @override
+  void dispose() {
+    _textController.dispose();
+    _scrollController.dispose();
+    super.dispose();
+  }
+
+  void _scrollToBottom() {
+    WidgetsBinding.instance.addPostFrameCallback((_) {
+      if (_scrollController.hasClients) {
+        _scrollController.animateTo(
+          _scrollController.position.maxScrollExtent,
+          duration: const Duration(milliseconds: 300),
+          curve: Curves.easeOut,
+        );
+      }
+    });
+  }
+
+  void _sendMessage([String? text]) {
+    final messageText = text ?? _textController.text.trim();
+    if (messageText.isEmpty) return;
+
+    HapticFeedback.lightImpact();
+
+    final userMessage = ChatMessage(
+      role: ChatRole.user,
+      content: messageText,
+      timestamp: DateTime.now(),
+    );
+
+    setState(() {
+      _messages.add(userMessage);
+      _assistantState = AssistantState.thinking;
+    });
+
+    if (text == null) _textController.clear();
+    _scrollToBottom();
+
+    final assistantMessage = ChatMessage(
+      role: ChatRole.assistant,
+      content: '',
+      timestamp: DateTime.now(),
+    );
+
+    setState(() => _messages.add(assistantMessage));
+
+    bool firstChunk = true;
+    widget.llmService.generate(messageText).listen(
+      (chunk) {
+        if (firstChunk) {
+          setState(() {
+            _assistantState = AssistantState.responding;
+            firstChunk = false;
+          });
+        }
+        setState(() {
+          _messages.last.content += chunk;
+        });
+        _scrollToBottom();
+      },
+      onDone: () {
+        setState(() => _assistantState = AssistantState.idle);
+        _scrollToBottom();
+      },
+      onError: (error) {
+        setState(() {
+          _messages.last.content = 'Error: ${error.toString()}';
+          _assistantState = AssistantState.idle;
+        });
+        _scrollToBottom();
+      },
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: _buildAppBar(),
+      body: Column(
+        children: [
+          Expanded(
+            child: ListView.builder(
+              controller: _scrollController,
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 20.0),
+              itemCount: _messages.length,
+              itemBuilder: (context, index) {
+                final message = _messages[index];
+                return _ChatMessageWidget(message: message);
+              },
+            ),
+          ),
+          if (_assistantState != AssistantState.idle)
+            _TypingIndicator(state: _assistantState),
+          MessageComposer(
+            controller: _textController,
+            onSend: _sendMessage,
+            onQuickPrompt: (prompt) => _sendMessage(prompt),
+            isEnabled: _assistantState == AssistantState.idle,
+          ),
+        ],
+      ),
+    );
+  }
+
+  AppBar _buildAppBar() {
+    return AppBar(
+      title: Column(
+        children: [
+          const Text('Orion Assistant', style: TextStyle(fontWeight: FontWeight.bold, fontSize: 18)),
+          Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(Icons.circle,
+                color: _assistantState == AssistantState.idle ? CyberTheme.primary : Colors.orange,
+                size: 8
+              ),
+              const SizedBox(width: 4),
+              Text(
+                _assistantState == AssistantState.idle ? 'Online' : 'Processing...',
+                style: TextStyle(
+                  fontSize: 12,
+                  color: _assistantState == AssistantState.idle ? CyberTheme.primary : Colors.orange
+                )
+              ),
+            ],
+          )
+        ],
+      ),
+      backgroundColor: Colors.black.withValues(alpha: 0.3),
+      elevation: 0,
+      centerTitle: true,
+    );
+  }
+}
+
+class _ChatMessageWidget extends StatelessWidget {
+  final ChatMessage message;
+  const _ChatMessageWidget({required this.message});
+
+  @override
+  Widget build(BuildContext context) {
+    final isUser = message.role == ChatRole.user;
+    final timeStr = DateFormat('HH:mm').format(message.timestamp);
+
+    return RepaintBoundary(
+      child: Align(
+        alignment: isUser ? Alignment.centerRight : Alignment.centerLeft,
+        child: Column(
+          crossAxisAlignment: isUser ? CrossAxisAlignment.end : CrossAxisAlignment.start,
+          children: [
+            Container(
+              margin: const EdgeInsets.symmetric(vertical: 4.0),
+              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 12.0),
+              constraints: BoxConstraints(
+                maxWidth: MediaQuery.of(context).size.width * 0.75,
+              ),
+              decoration: BoxDecoration(
+                color: isUser
+                  ? CyberTheme.primary.withValues(alpha: 0.15)
+                  : Colors.grey[850]?.withValues(alpha: 0.8),
+                borderRadius: BorderRadius.only(
+                  topLeft: const Radius.circular(20),
+                  topRight: const Radius.circular(20),
+                  bottomLeft: Radius.circular(isUser ? 20 : 0),
+                  bottomRight: Radius.circular(isUser ? 0 : 20),
+                ),
+                border: Border.all(
+                  color: isUser
+                    ? CyberTheme.primary.withValues(alpha: 0.3)
+                    : Colors.white.withValues(alpha: 0.1),
+                ),
+              ),
+              child: Text(
+                message.content,
+                style: const TextStyle(
+                  color: Colors.white,
+                  fontSize: 15,
+                  height: 1.4,
+                ),
+              ),
+            ),
+            Padding(
+              padding: const EdgeInsets.symmetric(horizontal: 4.0, vertical: 2.0),
+              child: Text(
+                timeStr,
+                style: TextStyle(
+                  fontSize: 10,
+                  color: Colors.white.withValues(alpha: 0.4),
+                ),
+              ),
+            ),
+            const SizedBox(height: 8),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _TypingIndicator extends StatefulWidget {
+  final AssistantState state;
+  const _TypingIndicator({required this.state});
+
+  @override
+  State<_TypingIndicator> createState() => _TypingIndicatorState();
+}
+
+class _TypingIndicatorState extends State<_TypingIndicator> with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      vsync: this,
+      duration: const Duration(milliseconds: 1000),
+    )..repeat(reverse: true);
+    _animation = Tween<double>(begin: 0.4, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final statusText = widget.state == AssistantState.thinking
+        ? 'Orion is thinking...'
+        : 'Orion is responding...';
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(vertical: 8.0, horizontal: 24.0),
+      child: Row(
+        children: [
+          SizedBox(
+            width: 16,
+            height: 16,
+            child: CircularProgressIndicator(
+              strokeWidth: 2,
+              valueColor: AlwaysStoppedAnimation<Color>(
+                widget.state == AssistantState.thinking ? CyberTheme.secondary : CyberTheme.primary
+              ),
+            ),
+          ),
+          const SizedBox(width: 12),
+          FadeTransition(
+            opacity: _animation,
+            child: Text(
+              statusText,
+              style: TextStyle(
+                color: Colors.white.withValues(alpha: 0.6),
+                fontSize: 13,
+                fontStyle: FontStyle.italic,
+              ),
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/lib/features/ai_assistant/presentation/widgets/message_composer.dart
+++ b/lib/features/ai_assistant/presentation/widgets/message_composer.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/cyber_theme.dart';
+
+class MessageComposer extends StatelessWidget {
+  final TextEditingController controller;
+  final VoidCallback onSend;
+  final VoidCallback? onAttach;
+  final Function(String)? onQuickPrompt;
+  final bool isEnabled;
+
+  const MessageComposer({
+    super.key,
+    required this.controller,
+    required this.onSend,
+    this.onAttach,
+    this.onQuickPrompt,
+    this.isEnabled = true,
+  });
+
+  static const List<String> _quickPrompts = [
+    'Analyze my last labs',
+    'Check blood pressure',
+    'Medication schedule',
+    'Symptom checker',
+  ];
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      mainAxisSize: MainAxisSize.min,
+      children: [
+        if (isEnabled) _buildQuickPrompts(),
+        Container(
+          padding: const EdgeInsets.symmetric(horizontal: 8.0, vertical: 8.0),
+          decoration: BoxDecoration(
+            color: Colors.black.withValues(alpha: 0.3),
+            border: Border(
+              top: BorderSide(color: Colors.white.withValues(alpha: 0.1)),
+            ),
+          ),
+          child: SafeArea(
+            top: false,
+            child: Row(
+              crossAxisAlignment: CrossAxisAlignment.end,
+              children: [
+                IconButton(
+                  icon: const Icon(Icons.add_circle_outline, color: CyberTheme.secondary),
+                  onPressed: isEnabled ? onAttach : null,
+                  tooltip: 'Attach file',
+                ),
+                Expanded(
+                  child: Container(
+                    margin: const EdgeInsets.symmetric(vertical: 4.0),
+                    decoration: BoxDecoration(
+                      color: Colors.grey[900]?.withValues(alpha: 0.5),
+                      borderRadius: BorderRadius.circular(20),
+                      border: Border.all(
+                        color: Colors.white.withValues(alpha: 0.1),
+                      ),
+                    ),
+                    child: TextField(
+                      controller: controller,
+                      enabled: isEnabled,
+                      maxLines: 5,
+                      minLines: 1,
+                      textInputAction: TextInputAction.newline,
+                      style: const TextStyle(color: Colors.white),
+                      decoration: const InputDecoration(
+                        hintText: 'Type a message...',
+                        hintStyle: TextStyle(color: Colors.white54),
+                        contentPadding: EdgeInsets.symmetric(
+                          horizontal: 16.0,
+                          vertical: 10.0,
+                        ),
+                        border: InputBorder.none,
+                      ),
+                    ),
+                  ),
+                ),
+                const SizedBox(width: 4),
+                IconButton(
+                  icon: const Icon(Icons.send_rounded, color: CyberTheme.primary),
+                  onPressed: isEnabled ? onSend : null,
+                  tooltip: 'Send message',
+                ),
+              ],
+            ),
+          ),
+        ),
+      ],
+    );
+  }
+
+  Widget _buildQuickPrompts() {
+    return SizedBox(
+      height: 50,
+      child: ListView.builder(
+        scrollDirection: Axis.horizontal,
+        padding: const EdgeInsets.symmetric(horizontal: 12.0, vertical: 8.0),
+        itemCount: _quickPrompts.length,
+        itemBuilder: (context, index) {
+          final prompt = _quickPrompts[index];
+          return Padding(
+            padding: const EdgeInsets.only(right: 8.0),
+            child: ActionChip(
+              label: Text(
+                prompt,
+                style: const TextStyle(
+                  fontSize: 12,
+                  color: CyberTheme.primary,
+                ),
+              ),
+              backgroundColor: CyberTheme.primary.withValues(alpha: 0.1),
+              side: const BorderSide(color: CyberTheme.primary, width: 0.5),
+              shape: RoundedRectangleBorder(
+                borderRadius: BorderRadius.circular(20),
+              ),
+              onPressed: () => onQuickPrompt?.call(prompt),
+            ),
+          );
+        },
+      ),
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -149,10 +149,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -969,18 +969,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1389,10 +1389,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/ai_assistant/presentation/pages/chat_page_test.dart
+++ b/test/features/ai_assistant/presentation/pages/chat_page_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/ai_assistant/presentation/pages/chat_page.dart';
+import 'package:orionhealth_health/features/ai_assistant/presentation/widgets/message_composer.dart';
+import 'package:orionhealth_health/features/local_agent/infrastructure/mock_llm_service.dart';
+
+void main() {
+  testWidgets('ChatPage renders initial message and composer', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChatPage(llmService: MockLlmService()),
+      ),
+    );
+
+    // Verify initial message
+    expect(find.textContaining('Welcome to OrionHealth'), findsOneWidget);
+
+    // Verify composer is present
+    expect(find.byType(MessageComposer), findsOneWidget);
+    expect(find.byType(TextField), findsOneWidget);
+    expect(find.byIcon(Icons.add_circle_outline), findsOneWidget);
+    expect(find.byIcon(Icons.send_rounded), findsOneWidget);
+  });
+
+  testWidgets('Sending a message updates the UI', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChatPage(llmService: MockLlmService()),
+      ),
+    );
+
+    final textField = find.byType(TextField);
+    await tester.enterText(textField, 'Hello Assistant');
+    await tester.tap(find.byIcon(Icons.send_rounded));
+    await tester.pump();
+
+    // Verify user message appears
+    expect(find.text('Hello Assistant'), findsOneWidget);
+
+    // Verify typing indicator appears (it should be in 'thinking' state initially)
+    expect(find.text('Orion is thinking...'), findsOneWidget);
+
+    // Pump to allow stream to start
+    await tester.pump(const Duration(milliseconds: 100));
+    // Now it should be 'responding'
+    expect(find.text('Orion is responding...'), findsOneWidget);
+
+    // Wait for mock service to complete (it usually sends a few chunks)
+    await tester.pumpAndSettle();
+
+    // Verify typing indicator is gone
+    expect(find.text('Orion is responding...'), findsNothing);
+  });
+
+  testWidgets('Quick prompt sends a message', (WidgetTester tester) async {
+    await tester.pumpWidget(
+      MaterialApp(
+        home: ChatPage(llmService: MockLlmService()),
+      ),
+    );
+
+    // Find a quick prompt chip
+    final chip = find.text('Analyze my last labs');
+    await tester.tap(chip);
+    await tester.pump();
+
+    // Verify message was sent
+    expect(find.text('Analyze my last labs'), findsOneWidget);
+    expect(find.text('Orion is thinking...'), findsOneWidget);
+
+    await tester.pumpAndSettle();
+  });
+}


### PR DESCRIPTION
The chat assistant's UX was improved by adding essential conversation affordances. A new `ai_assistant` feature structure was created, including a refined `ChatPage` and `MessageComposer`. 

Key enhancements include:
- **Timestamps**: Messages now show the time they were sent/received.
- **Improved Typing Indicator**: The assistant now provides specific feedback when 'thinking' (before first token) and 'responding' (during streaming).
- **Quick Prompts**: A horizontal list of action chips allows users to quickly send common queries.
- **Attachment Button**: A new icon in the composer provides the affordance for attaching files.
- **Architectural Cleanup**: Removed hardcoded service dependencies and switched to using the `getIt` DI container in `FloatingAssistantButton`.
- **Test Integrity**: Added a dedicated widget test for the new chat interface and removed pre-existing test failure artifacts from the repository.

Fixes #133

---
*PR created automatically by Jules for task [13419924304765581775](https://jules.google.com/task/13419924304765581775) started by @iberi22*