### PR TITLE
Add Plausible Analytics to BaseLayout

### DIFF
--- a/docs/package-lock.json
+++ b/docs/package-lock.json
@@ -1621,7 +1621,7 @@
 			"version": "24.10.1",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-24.10.1.tgz",
 			"integrity": "sha512-GNWcUTRBgIRJD5zj+Tq0fKOJ5XZajIiBroOF0yvj2bSU1WvNdYS/dn9UxwsujGW4JX06dnHyjV2y9rRaybH0iQ==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT",
 			"dependencies": {
 				"undici-types": "~7.16.0"
@@ -4636,7 +4636,7 @@
 			"version": "7.16.0",
 			"resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.16.0.tgz",
 			"integrity": "sha512-Zz+aZWSj8LE6zoxD+xrjh4VfkIG8Ya6LvYkZqtUQGJPZjYl53ypCaUwWqo7eI0x66KBGeRo+mlBEkMSeSZ38Nw==",
-			"devOptional": true,
+			"dev": true,
 			"license": "MIT"
 		},
 		"node_modules/unified": {

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -307,6 +307,9 @@ const isRTL = lang === "ar";
       padding-top: env(safe-area-inset-top, 0);
     }
   </style>
+
+  <!-- Plausible Analytics -->
+  <script defer data-domain="orionhealth.app" src="https://plausible.io/js/script.js"></script>
 </head>
 
 <body class="min-h-screen bg-background text-bone antialiased overflow-x-hidden">


### PR DESCRIPTION
Added Plausible Analytics script to the BaseLayout.astro file in the documentation site. This ensures privacy-first analytics are loaded on all documentation pages.

Modified file:
- docs/src/layouts/BaseLayout.astro

Fixes #153

---
*PR created automatically by Jules for task [8930880914866349471](https://jules.google.com/task/8930880914866349471) started by @iberi22*