### PR TITLE
SSI Isar Persistence Migration

### DIFF
--- a/lib/core/di/database_module.dart
+++ b/lib/core/di/database_module.dart
@@ -10,6 +10,8 @@ import '../../features/medications/domain/entities/medication.dart';
 import '../../features/vitals/domain/entities/vital_sign.dart';
 import '../../features/appointments/domain/entities/appointment.dart';
 import '../../features/allergies/domain/entities/allergy.dart';
+import '../../features/ssi/infrastructure/persistence/isar_did.dart';
+import '../../features/ssi/infrastructure/persistence/isar_credential.dart';
 import 'package:isar_agent_memory/isar_agent_memory.dart';
 import 'package:health_wallet/health_wallet.dart' hide HealthRecord, LabResult, VitalSign, VitalSignSchema, MedicationEntry, MedicalDocument, MedicalEvent;
 
@@ -36,6 +38,8 @@ abstract class DatabaseModule {
         MedicationEntrySchema,
         MedicalDocumentSchema,
         MedicalEventSchema,
+        IsarDidSchema,
+        IsarCredentialSchema,
       ],
       directory: dir.path,
     );

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -8,138 +8,141 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:dio/dio.dart' as _i6;
+import 'package:dio/dio.dart' as _i7;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:isar/isar.dart' as _i12;
-import 'package:isar_agent_memory/isar_agent_memory.dart' as _i7;
-import 'package:medical_standards/medical_standards.dart' as _i18;
+import 'package:isar/isar.dart' as _i13;
+import 'package:isar_agent_memory/isar_agent_memory.dart' as _i8;
+import 'package:medical_standards/medical_standards.dart' as _i19;
 
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i42;
+    as _i46;
 import '../../features/allergies/infrastructure/repositories/allergy_repository_impl.dart'
-    as _i43;
-import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i44;
-import '../../features/appointments/infrastructure/repositories/appointment_repository_impl.dart'
-    as _i45;
-import '../../features/auth/application/auth_cubit.dart' as _i68;
-import '../../features/auth/domain/auth_service.dart' as _i46;
-import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
     as _i47;
+import '../../features/appointments/domain/repositories/appointment_repository.dart'
+    as _i48;
+import '../../features/appointments/infrastructure/repositories/appointment_repository_impl.dart'
+    as _i49;
+import '../../features/auth/application/auth_cubit.dart' as _i72;
+import '../../features/auth/domain/auth_service.dart' as _i50;
+import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
+    as _i3;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i8;
-import '../../features/health_data_import/application/health_import_cubit.dart'
-    as _i52;
-import '../../features/health_data_import/domain/services/health_data_import_service.dart'
-    as _i10;
-import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i69;
-import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i53;
-import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i54;
-import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i9;
-import '../../features/health_record/infrastructure/services/image_picker_service.dart'
-    as _i11;
-import '../../features/health_record/infrastructure/services/ocr_service.dart'
-    as _i30;
-import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i65;
-import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
-    as _i19;
-import '../../features/local_agent/domain/services/llm_adapter.dart' as _i13;
-import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i38;
-import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i14;
-import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
+import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i55;
-import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+import '../../features/health_data_import/domain/services/health_data_import_service.dart'
+    as _i11;
+import '../../features/health_record/application/bloc/health_record_cubit.dart'
+    as _i73;
+import '../../features/health_record/domain/repositories/health_record_repository.dart'
     as _i56;
+import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+    as _i57;
+import '../../features/health_record/infrastructure/services/file_picker_service.dart'
+    as _i10;
+import '../../features/health_record/infrastructure/services/image_picker_service.dart'
+    as _i12;
+import '../../features/health_record/infrastructure/services/ocr_service.dart'
+    as _i32;
+import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
+    as _i69;
+import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
+    as _i20;
+import '../../features/local_agent/domain/services/llm_adapter.dart' as _i14;
+import '../../features/local_agent/domain/services/vector_store_service.dart'
+    as _i42;
+import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
+    as _i16;
+import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
+    as _i59;
+import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+    as _i58;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
     as _i15;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i58;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i57;
-import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i70;
+    as _i61;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i60;
+import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i74;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
     as _i21;
 import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
-    as _i20;
-import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i39;
-import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i60;
-import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
-    as _i48;
-import '../../features/medical_assistant/domain/services/health_context_service.dart'
-    as _i50;
-import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
-    as _i64;
-import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
-    as _i49;
-import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
-    as _i51;
-import '../../features/medical_research/domain/services/medical_scraper_service.dart'
     as _i22;
-import '../../features/medical_research/domain/services/medical_standards_service.dart'
-    as _i24;
-import '../../features/medical_research/domain/services/medical_web_search_service.dart'
-    as _i26;
-import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
-    as _i3;
-import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i61;
-import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
+import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
+    as _i43;
+import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
+    as _i63;
+import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
+    as _i51;
+import '../../features/medical_assistant/domain/services/health_context_service.dart'
+    as _i53;
+import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
+    as _i68;
+import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
+    as _i52;
+import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
+    as _i54;
+import '../../features/medical_research/domain/services/medical_scraper_service.dart'
     as _i23;
-import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
+import '../../features/medical_research/domain/services/medical_standards_service.dart'
     as _i25;
-import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
+import '../../features/medical_research/domain/services/medical_web_search_service.dart'
     as _i27;
-import '../../features/medications/domain/repositories/medication_repository.dart'
+import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
+    as _i4;
+import '../../features/medical_research/infrastructure/medical_research_service.dart'
+    as _i64;
+import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
+    as _i24;
+import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
+    as _i26;
+import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
     as _i28;
-import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+import '../../features/medications/domain/repositories/medication_repository.dart'
     as _i29;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i62;
-import '../../features/onboarding/application/sync_cubit.dart' as _i66;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i63;
+import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+    as _i30;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i65;
+import '../../features/onboarding/application/sync_cubit.dart' as _i70;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i75;
 import '../../features/reports/domain/repositories/report_repository.dart'
     as _i34;
 import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i32;
+    as _i66;
 import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i35;
 import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i100;
-import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
-    as _i101;
-import '../../features/ssi/domain/services/ssi_service.dart' as _i102;
-import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
-    as _i103;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i59;
-import '../../features/settings/domain/repositories/llm_settings_repository.dart'
-    as _i16;
-import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i4;
-import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
-    as _i17;
-import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
     as _i67;
-import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i36;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
+    as _i31;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i62;
+import '../../features/settings/domain/repositories/llm_settings_repository.dart'
+    as _i17;
+import '../../features/settings/domain/services/device_capability_service.dart'
+    as _i5;
+import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
+    as _i18;
+import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i36;
+import '../../features/ssi/domain/services/ssi_service.dart' as _i38;
+import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
     as _i37;
-import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
+    as _i39;
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i71;
+import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
     as _i40;
-import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
     as _i41;
-import '../services/device_capability_service.dart' as _i5;
-import '../services/privacy_anonymizer.dart' as _i31;
-import 'database_module.dart' as _i73;
-import 'memory_module.dart' as _i72;
-import 'network_module.dart' as _i71;
+import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+    as _i44;
+import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+    as _i45;
+import '../services/device_capability_service.dart' as _i6;
+import '../services/privacy_anonymizer.dart' as _i33;
+import 'database_module.dart' as _i78;
+import 'memory_module.dart' as _i77;
+import 'network_module.dart' as _i76;
 
 const String _mobile = 'mobile';
 const String _desktop = 'desktop';
@@ -159,190 +162,193 @@ extension GetItInjectableX on _i1.GetIt {
     final networkModule = _$NetworkModule();
     final memoryModule = _$MemoryModule();
     final databaseModule = _$DatabaseModule();
-    gh.lazySingleton<_i3.BotBypassHandler>(() => _i3.BotBypassHandler());
-    gh.lazySingleton<_i4.DeviceCapabilityService>(
-        () => _i4.DeviceCapabilityService());
+    gh.lazySingleton<_i3.BleMedicalSharingService>(
+        () => _i3.BleMedicalSharingService());
+    gh.lazySingleton<_i4.BotBypassHandler>(() => _i4.BotBypassHandler());
     gh.lazySingleton<_i5.DeviceCapabilityService>(
         () => _i5.DeviceCapabilityService());
-    gh.lazySingleton<_i6.Dio>(() => networkModule.dio);
-    gh.lazySingleton<_i7.EmbeddingsAdapter>(
+    gh.lazySingleton<_i6.DeviceCapabilityService>(
+        () => _i6.DeviceCapabilityService());
+    gh.lazySingleton<_i7.Dio>(() => networkModule.dio);
+    gh.lazySingleton<_i8.EmbeddingsAdapter>(
         () => memoryModule.embeddingsAdapter);
-    gh.lazySingleton<_i8.EncryptionService>(() => _i8.EncryptionServiceImpl());
-    gh.lazySingleton<_i9.FilePickerService>(() => _i9.FilePickerServiceImpl());
-    gh.lazySingleton<_i10.HealthDataImportService>(
-        () => _i10.HealthDataImportService());
-    gh.lazySingleton<_i11.ImagePickerService>(
-        () => _i11.ImagePickerServiceImpl());
-    await gh.factoryAsync<_i12.Isar>(
+    gh.lazySingleton<_i9.EncryptionService>(() => _i9.EncryptionServiceImpl());
+    gh.lazySingleton<_i10.FilePickerService>(
+        () => _i10.FilePickerServiceImpl());
+    gh.lazySingleton<_i11.HealthDataImportService>(
+        () => _i11.HealthDataImportService());
+    gh.lazySingleton<_i12.ImagePickerService>(
+        () => _i12.ImagePickerServiceImpl());
+    await gh.factoryAsync<_i13.Isar>(
       () => databaseModule.isar,
       preResolve: true,
     );
-    gh.lazySingleton<_i13.LlmAdapter>(
-      () => _i14.FlutterGemmaAdapter(),
-      instanceName: 'gemma',
-    );
-    gh.lazySingleton<_i13.LlmAdapter>(
+    gh.lazySingleton<_i14.LlmAdapter>(
       () => _i15.OpenaiCompatibleAdapter(),
       instanceName: 'openai',
     );
-    gh.lazySingleton<_i16.LlmSettingsRepository>(
-        () => _i17.LlmSettingsRepositoryImpl(gh<_i12.Isar>()));
-    gh.lazySingleton<_i18.MedicalContextProvider>(
+    gh.lazySingleton<_i14.LlmAdapter>(
+      () => _i16.FlutterGemmaAdapter(),
+      instanceName: 'gemma',
+    );
+    gh.lazySingleton<_i17.LlmSettingsRepository>(
+        () => _i18.LlmSettingsRepositoryImpl(gh<_i13.Isar>()));
+    gh.lazySingleton<_i19.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
-    gh.factory<_i19.MedicalKnowledgeRepository>(
-      () => _i20.JsonMedicalKnowledgeRepository(),
+    gh.factory<_i20.MedicalKnowledgeRepository>(
+      () => _i21.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
+    );
+    gh.factory<_i20.MedicalKnowledgeRepository>(
+      () => _i22.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
     );
-    gh.factory<_i19.MedicalKnowledgeRepository>(
-      () => _i21.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
-    );
-    gh.lazySingleton<_i22.MedicalScraperService>(
-        () => _i23.MedicalScraperServiceImpl(
-              gh<_i6.Dio>(),
-              gh<_i3.BotBypassHandler>(),
+    gh.lazySingleton<_i23.MedicalScraperService>(
+        () => _i24.MedicalScraperServiceImpl(
+              gh<_i7.Dio>(),
+              gh<_i4.BotBypassHandler>(),
             ));
-    gh.lazySingleton<_i24.MedicalStandardsService>(() =>
-        _i25.MedicalStandardsServiceImpl(gh<_i18.MedicalContextProvider>()));
-    gh.lazySingleton<_i26.MedicalWebSearchService>(
-        () => _i27.MedicalWebSearchServiceImpl(gh<_i6.Dio>()));
-    gh.lazySingleton<_i28.MedicationRepository>(
-        () => _i29.IsarMedicationRepository(gh<_i12.Isar>()));
-    await gh.lazySingletonAsync<_i7.MemoryGraph>(
+    gh.lazySingleton<_i25.MedicalStandardsService>(() =>
+        _i26.MedicalStandardsServiceImpl(gh<_i19.MedicalContextProvider>()));
+    gh.lazySingleton<_i27.MedicalWebSearchService>(
+        () => _i28.MedicalWebSearchServiceImpl(gh<_i7.Dio>()));
+    gh.lazySingleton<_i29.MedicationRepository>(
+        () => _i30.IsarMedicationRepository(gh<_i13.Isar>()));
+    await gh.lazySingletonAsync<_i8.MemoryGraph>(
       () => memoryModule.memoryGraph(
-        gh<_i12.Isar>(),
-        gh<_i7.EmbeddingsAdapter>(),
+        gh<_i13.Isar>(),
+        gh<_i8.EmbeddingsAdapter>(),
       ),
       preResolve: true,
     );
-    gh.lazySingleton<_i30.OcrService>(() => _i30.MlKitOcrService());
-    gh.lazySingleton<_i31.PromptScrubber>(
-        () => _i31.PromptScrubber(gh<_i12.Isar>()));
-    gh.lazySingleton<_i32.ReportGenerationService>(
-        () => _i100.GemmaReportGenerationService(
-          gh<_i13.LlmAdapter>(instanceName: 'gemma'),
-          gh<_i38.VectorStoreService>(),
-          gh<_i36.UserProfileRepository>(),
-          gh<_i31.PromptScrubber>(),
-        ));
-    gh.lazySingleton<_i34.ReportRepository>(
-        () => _i35.IsarReportRepository(gh<_i12.Isar>()));
-    gh.lazySingleton<_i32.ReportGenerationService>(
-      () => _i101.MockReportGenerationService(),
+    gh.lazySingleton<_i31.MockReportGenerationService>(
+      () => _i31.MockReportGenerationService(),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i102.SsiService>(
-        () => _i103.SsiServiceImpl());
-    gh.lazySingleton<_i18.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i36.UserProfileRepository>(
-        () => _i37.UserProfileRepositoryImpl(gh<_i12.Isar>()));
-    await gh.lazySingletonAsync<_i38.VectorStoreService>(
+    gh.lazySingleton<_i32.OcrService>(() => _i32.MlKitOcrService());
+    gh.lazySingleton<_i33.PromptScrubber>(
+        () => _i33.PromptScrubber(gh<_i13.Isar>()));
+    gh.lazySingleton<_i34.ReportRepository>(
+        () => _i35.IsarReportRepository(gh<_i13.Isar>()));
+    gh.lazySingleton<_i36.SsiRepository>(
+        () => _i37.IsarSsiRepository(gh<_i13.Isar>()));
+    gh.lazySingleton<_i38.SsiService>(
+        () => _i39.SsiServiceImpl(gh<_i36.SsiRepository>()));
+    gh.lazySingleton<_i19.SyncService>(() => networkModule.syncService);
+    gh.lazySingleton<_i40.UserProfileRepository>(
+        () => _i41.UserProfileRepositoryImpl(gh<_i13.Isar>()));
+    await gh.lazySingletonAsync<_i42.VectorStoreService>(
       () {
-        final i = _i39.IsarVectorStoreService(
-          gh<_i7.MemoryGraph>(),
-          gh<_i19.MedicalKnowledgeRepository>(),
+        final i = _i43.IsarVectorStoreService(
+          gh<_i8.MemoryGraph>(),
+          gh<_i20.MedicalKnowledgeRepository>(),
         );
         return i.indexMedicalStandards().then((_) => i);
       },
       preResolve: true,
     );
-    gh.lazySingleton<_i40.VitalSignRepository>(
-        () => _i41.VitalSignRepositoryImpl(gh<_i12.Isar>()));
-    gh.lazySingleton<_i42.AllergyRepository>(
-        () => _i43.AllergyRepositoryImpl(gh<_i12.Isar>()));
-    gh.lazySingleton<_i44.AppointmentRepository>(
-        () => _i45.AppointmentRepositoryImpl(gh<_i12.Isar>()));
-    gh.lazySingleton<_i46.AuthService>(
-        () => _i46.AuthServiceImpl(gh<_i8.EncryptionService>()));
-    gh.lazySingleton<_i47.BleMedicalSharingService>(
-        () => _i47.BleMedicalSharingService());
-    gh.lazySingleton<_i48.ClinicalReasonerService>(() =>
-        _i49.SymphonyClinicalReasonerService(
-            gh<_i19.MedicalKnowledgeRepository>()));
-    gh.lazySingleton<_i50.HealthContextService>(
-        () => _i51.IsarHealthContextService(
-              gh<_i40.VitalSignRepository>(),
-              gh<_i28.MedicationRepository>(),
-              gh<_i7.MemoryGraph>(),
+    gh.lazySingleton<_i44.VitalSignRepository>(
+        () => _i45.VitalSignRepositoryImpl(gh<_i13.Isar>()));
+    gh.lazySingleton<_i46.AllergyRepository>(
+        () => _i47.AllergyRepositoryImpl(gh<_i13.Isar>()));
+    gh.lazySingleton<_i48.AppointmentRepository>(
+        () => _i49.AppointmentRepositoryImpl(gh<_i13.Isar>()));
+    gh.lazySingleton<_i50.AuthService>(
+        () => _i50.AuthServiceImpl(gh<_i9.EncryptionService>()));
+    gh.lazySingleton<_i51.ClinicalReasonerService>(() =>
+        _i52.SymphonyClinicalReasonerService(
+            gh<_i20.MedicalKnowledgeRepository>()));
+    gh.lazySingleton<_i53.HealthContextService>(
+        () => _i54.IsarHealthContextService(
+              gh<_i44.VitalSignRepository>(),
+              gh<_i29.MedicationRepository>(),
+              gh<_i8.MemoryGraph>(),
             ));
-    gh.factory<_i52.HealthImportCubit>(() => _i52.HealthImportCubit(
-          gh<_i10.HealthDataImportService>(),
-          gh<_i40.VitalSignRepository>(),
+    gh.factory<_i55.HealthImportCubit>(() => _i55.HealthImportCubit(
+          gh<_i11.HealthDataImportService>(),
+          gh<_i44.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i53.HealthRecordRepository>(
-        () => _i54.HealthRecordRepositoryImpl(gh<_i12.Isar>()));
-    gh.lazySingleton<_i13.LlmAdapter>(
-      () => _i55.GeminiLlmAdapter(
-        scrubber: gh<_i31.PromptScrubber>(),
-        userProfileRepository: gh<_i36.UserProfileRepository>(),
+    gh.lazySingleton<_i56.HealthRecordRepository>(
+        () => _i57.HealthRecordRepositoryImpl(gh<_i13.Isar>()));
+    gh.factory<_i14.LlmAdapter>(
+      () => _i58.MockLlmAdapter(gh<_i33.PromptScrubber>()),
+      instanceName: 'mock',
+    );
+    gh.lazySingleton<_i14.LlmAdapter>(
+      () => _i59.GeminiLlmAdapter(
+        scrubber: gh<_i33.PromptScrubber>(),
+        userProfileRepository: gh<_i40.UserProfileRepository>(),
       ),
       instanceName: 'gemini',
     );
-    gh.factory<_i13.LlmAdapter>(
-      () => _i56.MockLlmAdapter(gh<_i31.PromptScrubber>()),
-      instanceName: 'mock',
-    );
-    gh.lazySingleton<_i57.LlmService>(() => _i58.GemmaLlmService(
-          gh<_i38.VectorStoreService>(),
-          gh<_i36.UserProfileRepository>(),
-          gh<_i13.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i60.LlmService>(() => _i61.GemmaLlmService(
+          gh<_i42.VectorStoreService>(),
+          gh<_i40.UserProfileRepository>(),
+          gh<_i14.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i59.LlmSettingsCubit>(() => _i59.LlmSettingsCubit(
-          gh<_i16.LlmSettingsRepository>(),
-          gh<_i4.DeviceCapabilityService>(),
+    gh.factory<_i62.LlmSettingsCubit>(() => _i62.LlmSettingsCubit(
+          gh<_i17.LlmSettingsRepository>(),
+          gh<_i5.DeviceCapabilityService>(),
         ));
-    gh.lazySingleton<_i60.MedicalIndexingService>(
-        () => _i60.MedicalIndexingService(
-              gh<_i19.MedicalKnowledgeRepository>(),
-              gh<_i38.VectorStoreService>(),
+    gh.lazySingleton<_i63.MedicalIndexingService>(
+        () => _i63.MedicalIndexingService(
+              gh<_i20.MedicalKnowledgeRepository>(),
+              gh<_i42.VectorStoreService>(),
             ));
-    gh.lazySingleton<_i61.MedicalResearchService>(
-        () => _i61.MedicalResearchService(
-              gh<_i26.MedicalWebSearchService>(),
-              gh<_i22.MedicalScraperService>(),
+    gh.lazySingleton<_i64.MedicalResearchService>(
+        () => _i64.MedicalResearchService(
+              gh<_i27.MedicalWebSearchService>(),
+              gh<_i23.MedicalScraperService>(),
             ));
-    gh.factory<_i62.OnboardingCubit>(
-        () => _i62.OnboardingCubit(gh<_i36.UserProfileRepository>()));
-    gh.factory<_i63.ReportBloc>(() => _i63.ReportBloc(
-          gh<_i34.ReportRepository>(),
-          gh<_i32.ReportGenerationService>(),
+    gh.factory<_i65.OnboardingCubit>(
+        () => _i65.OnboardingCubit(gh<_i40.UserProfileRepository>()));
+    gh.lazySingleton<_i66.ReportGenerationService>(
+        () => _i67.GemmaReportGenerationService(
+              gh<_i14.LlmAdapter>(instanceName: 'gemma'),
+              gh<_i42.VectorStoreService>(),
+              gh<_i40.UserProfileRepository>(),
+              gh<_i33.PromptScrubber>(),
+            ));
+    gh.lazySingleton<_i68.RiskCalculator>(
+        () => _i68.RiskCalculator(gh<_i40.UserProfileRepository>()));
+    gh.lazySingleton<_i69.SmartSearchUseCase>(
+        () => _i69.SmartSearchUseCase(gh<_i42.VectorStoreService>()));
+    gh.factory<_i70.SyncCubit>(() => _i70.SyncCubit(
+          gh<_i19.SyncService>(),
+          gh<_i42.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i64.RiskCalculator>(
-        () => _i64.RiskCalculator(gh<_i36.UserProfileRepository>()));
-    gh.lazySingleton<_i65.SmartSearchUseCase>(
-        () => _i65.SmartSearchUseCase(gh<_i38.VectorStoreService>()));
-    gh.factory<_i66.SyncCubit>(() => _i66.SyncCubit(
-          gh<_i18.SyncService>(),
-          gh<_i38.VectorStoreService>(),
+    gh.factory<_i71.UserProfileCubit>(
+        () => _i71.UserProfileCubit(gh<_i40.UserProfileRepository>()));
+    gh.factory<_i72.AuthCubit>(() => _i72.AuthCubit(gh<_i50.AuthService>()));
+    gh.factory<_i73.HealthRecordCubit>(() => _i73.HealthRecordCubit(
+          gh<_i56.HealthRecordRepository>(),
+          gh<_i10.FilePickerService>(),
+          gh<_i12.ImagePickerService>(),
+          gh<_i32.OcrService>(),
+          gh<_i42.VectorStoreService>(),
         ));
-    gh.factory<_i67.UserProfileCubit>(
-        () => _i67.UserProfileCubit(gh<_i36.UserProfileRepository>()));
-    gh.factory<_i68.AuthCubit>(() => _i68.AuthCubit(gh<_i46.AuthService>()));
-    gh.factory<_i69.HealthRecordCubit>(() => _i69.HealthRecordCubit(
-          gh<_i53.HealthRecordRepository>(),
-          gh<_i9.FilePickerService>(),
-          gh<_i11.ImagePickerService>(),
-          gh<_i30.OcrService>(),
-          gh<_i38.VectorStoreService>(),
-        ));
-    gh.lazySingleton<_i57.LlmService>(
-      () => _i70.RagLlmService(
-        gh<_i38.VectorStoreService>(),
-        gh<_i61.MedicalResearchService>(),
-        gh<_i36.UserProfileRepository>(),
-        gh<_i13.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i60.LlmService>(
+      () => _i74.RagLlmService(
+        gh<_i42.VectorStoreService>(),
+        gh<_i64.MedicalResearchService>(),
+        gh<_i40.UserProfileRepository>(),
+        gh<_i14.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
+    gh.factory<_i75.ReportBloc>(() => _i75.ReportBloc(
+          gh<_i34.ReportRepository>(),
+          gh<_i66.ReportGenerationService>(),
+        ));
     return this;
   }
 }
 
-class _$NetworkModule extends _i71.NetworkModule {}
+class _$NetworkModule extends _i76.NetworkModule {}
 
-class _$MemoryModule extends _i72.MemoryModule {}
+class _$MemoryModule extends _i77.MemoryModule {}
 
-class _$DatabaseModule extends _i73.DatabaseModule {}
+class _$DatabaseModule extends _i78.DatabaseModule {}

--- a/lib/features/settings/presentation/pages/llm_settings_page.dart
+++ b/lib/features/settings/presentation/pages/llm_settings_page.dart
@@ -1626,10 +1626,5 @@ class _InfoRow extends StatelessWidget {
   }
 }
 
-      ],
-    );
-  }
-}
-
 
 

--- a/lib/features/ssi/domain/repositories/ssi_repository.dart
+++ b/lib/features/ssi/domain/repositories/ssi_repository.dart
@@ -1,0 +1,25 @@
+import '../../domain/entities/did.dart';
+import '../../domain/entities/verifiable_credential.dart';
+
+abstract class SsiRepository {
+  /// Save a DID and its document
+  Future<void> saveDid(Did did, Map<String, dynamic> didDocument);
+
+  /// Get all DIDs
+  Future<List<Did>> getDids();
+
+  /// Get a DID Document by DID string
+  Future<Map<String, dynamic>?> getDidDocument(String did);
+
+  /// Save a Verifiable Credential
+  Future<void> saveCredential(VerifiableCredential credential);
+
+  /// Get all credentials
+  Future<List<VerifiableCredential>> getCredentials();
+
+  /// Get a credential by ID
+  Future<VerifiableCredential?> getCredentialById(String credentialId);
+
+  /// Remove a credential
+  Future<void> deleteCredential(String credentialId);
+}

--- a/lib/features/ssi/infrastructure/persistence/isar_credential.dart
+++ b/lib/features/ssi/infrastructure/persistence/isar_credential.dart
@@ -1,0 +1,32 @@
+import 'package:isar/isar.dart';
+
+part 'isar_credential.g.dart';
+
+@collection
+class IsarCredential {
+  Id id = Isar.autoIncrement;
+
+  @Index(unique: true, replace: true)
+  late String credentialId;
+
+  late String issuer;
+
+  late String subject;
+
+  late String type;
+
+  late String schemaId;
+
+  /// Claims stored as JSON string for maximum flexibility
+  late String claimsJson;
+
+  late DateTime issuanceDate;
+
+  DateTime? expirationDate;
+
+  String? proof;
+
+  bool isRevoked = false;
+
+  IsarCredential();
+}

--- a/lib/features/ssi/infrastructure/persistence/isar_credential.g.dart
+++ b/lib/features/ssi/infrastructure/persistence/isar_credential.g.dart
@@ -1,0 +1,1986 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'isar_credential.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetIsarCredentialCollection on Isar {
+  IsarCollection<IsarCredential> get isarCredentials => this.collection();
+}
+
+const IsarCredentialSchema = CollectionSchema(
+  name: r'IsarCredential',
+  id: -170141991681670357,
+  properties: {
+    r'claimsJson': PropertySchema(
+      id: 0,
+      name: r'claimsJson',
+      type: IsarType.string,
+    ),
+    r'credentialId': PropertySchema(
+      id: 1,
+      name: r'credentialId',
+      type: IsarType.string,
+    ),
+    r'expirationDate': PropertySchema(
+      id: 2,
+      name: r'expirationDate',
+      type: IsarType.dateTime,
+    ),
+    r'isRevoked': PropertySchema(
+      id: 3,
+      name: r'isRevoked',
+      type: IsarType.bool,
+    ),
+    r'issuanceDate': PropertySchema(
+      id: 4,
+      name: r'issuanceDate',
+      type: IsarType.dateTime,
+    ),
+    r'issuer': PropertySchema(
+      id: 5,
+      name: r'issuer',
+      type: IsarType.string,
+    ),
+    r'proof': PropertySchema(
+      id: 6,
+      name: r'proof',
+      type: IsarType.string,
+    ),
+    r'schemaId': PropertySchema(
+      id: 7,
+      name: r'schemaId',
+      type: IsarType.string,
+    ),
+    r'subject': PropertySchema(
+      id: 8,
+      name: r'subject',
+      type: IsarType.string,
+    ),
+    r'type': PropertySchema(
+      id: 9,
+      name: r'type',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _isarCredentialEstimateSize,
+  serialize: _isarCredentialSerialize,
+  deserialize: _isarCredentialDeserialize,
+  deserializeProp: _isarCredentialDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'credentialId': IndexSchema(
+      id: 7147664887779844858,
+      name: r'credentialId',
+      unique: true,
+      replace: true,
+      properties: [
+        IndexPropertySchema(
+          name: r'credentialId',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {},
+  getId: _isarCredentialGetId,
+  getLinks: _isarCredentialGetLinks,
+  attach: _isarCredentialAttach,
+  version: '3.1.0+1',
+);
+
+int _isarCredentialEstimateSize(
+  IsarCredential object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.claimsJson.length * 3;
+  bytesCount += 3 + object.credentialId.length * 3;
+  bytesCount += 3 + object.issuer.length * 3;
+  {
+    final value = object.proof;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.schemaId.length * 3;
+  bytesCount += 3 + object.subject.length * 3;
+  bytesCount += 3 + object.type.length * 3;
+  return bytesCount;
+}
+
+void _isarCredentialSerialize(
+  IsarCredential object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeString(offsets[0], object.claimsJson);
+  writer.writeString(offsets[1], object.credentialId);
+  writer.writeDateTime(offsets[2], object.expirationDate);
+  writer.writeBool(offsets[3], object.isRevoked);
+  writer.writeDateTime(offsets[4], object.issuanceDate);
+  writer.writeString(offsets[5], object.issuer);
+  writer.writeString(offsets[6], object.proof);
+  writer.writeString(offsets[7], object.schemaId);
+  writer.writeString(offsets[8], object.subject);
+  writer.writeString(offsets[9], object.type);
+}
+
+IsarCredential _isarCredentialDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = IsarCredential();
+  object.claimsJson = reader.readString(offsets[0]);
+  object.credentialId = reader.readString(offsets[1]);
+  object.expirationDate = reader.readDateTimeOrNull(offsets[2]);
+  object.id = id;
+  object.isRevoked = reader.readBool(offsets[3]);
+  object.issuanceDate = reader.readDateTime(offsets[4]);
+  object.issuer = reader.readString(offsets[5]);
+  object.proof = reader.readStringOrNull(offsets[6]);
+  object.schemaId = reader.readString(offsets[7]);
+  object.subject = reader.readString(offsets[8]);
+  object.type = reader.readString(offsets[9]);
+  return object;
+}
+
+P _isarCredentialDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readString(offset)) as P;
+    case 1:
+      return (reader.readString(offset)) as P;
+    case 2:
+      return (reader.readDateTimeOrNull(offset)) as P;
+    case 3:
+      return (reader.readBool(offset)) as P;
+    case 4:
+      return (reader.readDateTime(offset)) as P;
+    case 5:
+      return (reader.readString(offset)) as P;
+    case 6:
+      return (reader.readStringOrNull(offset)) as P;
+    case 7:
+      return (reader.readString(offset)) as P;
+    case 8:
+      return (reader.readString(offset)) as P;
+    case 9:
+      return (reader.readString(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _isarCredentialGetId(IsarCredential object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _isarCredentialGetLinks(IsarCredential object) {
+  return [];
+}
+
+void _isarCredentialAttach(
+    IsarCollection<dynamic> col, Id id, IsarCredential object) {
+  object.id = id;
+}
+
+extension IsarCredentialByIndex on IsarCollection<IsarCredential> {
+  Future<IsarCredential?> getByCredentialId(String credentialId) {
+    return getByIndex(r'credentialId', [credentialId]);
+  }
+
+  IsarCredential? getByCredentialIdSync(String credentialId) {
+    return getByIndexSync(r'credentialId', [credentialId]);
+  }
+
+  Future<bool> deleteByCredentialId(String credentialId) {
+    return deleteByIndex(r'credentialId', [credentialId]);
+  }
+
+  bool deleteByCredentialIdSync(String credentialId) {
+    return deleteByIndexSync(r'credentialId', [credentialId]);
+  }
+
+  Future<List<IsarCredential?>> getAllByCredentialId(
+      List<String> credentialIdValues) {
+    final values = credentialIdValues.map((e) => [e]).toList();
+    return getAllByIndex(r'credentialId', values);
+  }
+
+  List<IsarCredential?> getAllByCredentialIdSync(
+      List<String> credentialIdValues) {
+    final values = credentialIdValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'credentialId', values);
+  }
+
+  Future<int> deleteAllByCredentialId(List<String> credentialIdValues) {
+    final values = credentialIdValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'credentialId', values);
+  }
+
+  int deleteAllByCredentialIdSync(List<String> credentialIdValues) {
+    final values = credentialIdValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'credentialId', values);
+  }
+
+  Future<Id> putByCredentialId(IsarCredential object) {
+    return putByIndex(r'credentialId', object);
+  }
+
+  Id putByCredentialIdSync(IsarCredential object, {bool saveLinks = true}) {
+    return putByIndexSync(r'credentialId', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByCredentialId(List<IsarCredential> objects) {
+    return putAllByIndex(r'credentialId', objects);
+  }
+
+  List<Id> putAllByCredentialIdSync(List<IsarCredential> objects,
+      {bool saveLinks = true}) {
+    return putAllByIndexSync(r'credentialId', objects, saveLinks: saveLinks);
+  }
+}
+
+extension IsarCredentialQueryWhereSort
+    on QueryBuilder<IsarCredential, IsarCredential, QWhere> {
+  QueryBuilder<IsarCredential, IsarCredential, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension IsarCredentialQueryWhere
+    on QueryBuilder<IsarCredential, IsarCredential, QWhereClause> {
+  QueryBuilder<IsarCredential, IsarCredential, QAfterWhereClause> idEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterWhereClause> idNotEqualTo(
+      Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterWhereClause> idGreaterThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterWhereClause> idLessThan(
+      Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterWhereClause>
+      credentialIdEqualTo(String credentialId) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'credentialId',
+        value: [credentialId],
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterWhereClause>
+      credentialIdNotEqualTo(String credentialId) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'credentialId',
+              lower: [],
+              upper: [credentialId],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'credentialId',
+              lower: [credentialId],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'credentialId',
+              lower: [credentialId],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'credentialId',
+              lower: [],
+              upper: [credentialId],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension IsarCredentialQueryFilter
+    on QueryBuilder<IsarCredential, IsarCredential, QFilterCondition> {
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'claimsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'claimsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'claimsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'claimsJson',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'claimsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'claimsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'claimsJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'claimsJson',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'claimsJson',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      claimsJsonIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'claimsJson',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'credentialId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'credentialId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'credentialId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'credentialId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'credentialId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'credentialId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'credentialId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'credentialId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'credentialId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      credentialIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'credentialId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      expirationDateIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'expirationDate',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      expirationDateIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'expirationDate',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      expirationDateEqualTo(DateTime? value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'expirationDate',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      expirationDateGreaterThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'expirationDate',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      expirationDateLessThan(
+    DateTime? value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'expirationDate',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      expirationDateBetween(
+    DateTime? lower,
+    DateTime? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'expirationDate',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition> idEqualTo(
+      Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      isRevokedEqualTo(bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isRevoked',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuanceDateEqualTo(DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'issuanceDate',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuanceDateGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'issuanceDate',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuanceDateLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'issuanceDate',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuanceDateBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'issuanceDate',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'issuer',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'issuer',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'issuer',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'issuer',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'issuer',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'issuer',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'issuer',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'issuer',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'issuer',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      issuerIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'issuer',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'proof',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'proof',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'proof',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'proof',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'proof',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'proof',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'proof',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'proof',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'proof',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'proof',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'proof',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      proofIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'proof',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'schemaId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'schemaId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'schemaId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'schemaId',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'schemaId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'schemaId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'schemaId',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'schemaId',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'schemaId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      schemaIdIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'schemaId',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'subject',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'subject',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'subject',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'subject',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'subject',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'subject',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'subject',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'subject',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'subject',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      subjectIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'subject',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'type',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'type',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'type',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'type',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterFilterCondition>
+      typeIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'type',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension IsarCredentialQueryObject
+    on QueryBuilder<IsarCredential, IsarCredential, QFilterCondition> {}
+
+extension IsarCredentialQueryLinks
+    on QueryBuilder<IsarCredential, IsarCredential, QFilterCondition> {}
+
+extension IsarCredentialQuerySortBy
+    on QueryBuilder<IsarCredential, IsarCredential, QSortBy> {
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByClaimsJson() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'claimsJson', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByClaimsJsonDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'claimsJson', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByCredentialId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'credentialId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByCredentialIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'credentialId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByExpirationDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'expirationDate', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByExpirationDateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'expirationDate', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> sortByIsRevoked() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isRevoked', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByIsRevokedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isRevoked', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByIssuanceDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'issuanceDate', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByIssuanceDateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'issuanceDate', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> sortByIssuer() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'issuer', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortByIssuerDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'issuer', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> sortByProof() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'proof', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> sortByProofDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'proof', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> sortBySchemaId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'schemaId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortBySchemaIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'schemaId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> sortBySubject() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'subject', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      sortBySubjectDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'subject', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> sortByType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> sortByTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.desc);
+    });
+  }
+}
+
+extension IsarCredentialQuerySortThenBy
+    on QueryBuilder<IsarCredential, IsarCredential, QSortThenBy> {
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByClaimsJson() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'claimsJson', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByClaimsJsonDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'claimsJson', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByCredentialId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'credentialId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByCredentialIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'credentialId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByExpirationDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'expirationDate', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByExpirationDateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'expirationDate', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenByIsRevoked() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isRevoked', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByIsRevokedDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isRevoked', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByIssuanceDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'issuanceDate', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByIssuanceDateDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'issuanceDate', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenByIssuer() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'issuer', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenByIssuerDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'issuer', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenByProof() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'proof', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenByProofDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'proof', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenBySchemaId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'schemaId', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenBySchemaIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'schemaId', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenBySubject() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'subject', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy>
+      thenBySubjectDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'subject', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenByType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QAfterSortBy> thenByTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'type', Sort.desc);
+    });
+  }
+}
+
+extension IsarCredentialQueryWhereDistinct
+    on QueryBuilder<IsarCredential, IsarCredential, QDistinct> {
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct> distinctByClaimsJson(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'claimsJson', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct>
+      distinctByCredentialId({bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'credentialId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct>
+      distinctByExpirationDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'expirationDate');
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct>
+      distinctByIsRevoked() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isRevoked');
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct>
+      distinctByIssuanceDate() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'issuanceDate');
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct> distinctByIssuer(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'issuer', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct> distinctByProof(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'proof', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct> distinctBySchemaId(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'schemaId', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct> distinctBySubject(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'subject', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarCredential, IsarCredential, QDistinct> distinctByType(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'type', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension IsarCredentialQueryProperty
+    on QueryBuilder<IsarCredential, IsarCredential, QQueryProperty> {
+  QueryBuilder<IsarCredential, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<IsarCredential, String, QQueryOperations> claimsJsonProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'claimsJson');
+    });
+  }
+
+  QueryBuilder<IsarCredential, String, QQueryOperations>
+      credentialIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'credentialId');
+    });
+  }
+
+  QueryBuilder<IsarCredential, DateTime?, QQueryOperations>
+      expirationDateProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'expirationDate');
+    });
+  }
+
+  QueryBuilder<IsarCredential, bool, QQueryOperations> isRevokedProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isRevoked');
+    });
+  }
+
+  QueryBuilder<IsarCredential, DateTime, QQueryOperations>
+      issuanceDateProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'issuanceDate');
+    });
+  }
+
+  QueryBuilder<IsarCredential, String, QQueryOperations> issuerProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'issuer');
+    });
+  }
+
+  QueryBuilder<IsarCredential, String?, QQueryOperations> proofProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'proof');
+    });
+  }
+
+  QueryBuilder<IsarCredential, String, QQueryOperations> schemaIdProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'schemaId');
+    });
+  }
+
+  QueryBuilder<IsarCredential, String, QQueryOperations> subjectProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'subject');
+    });
+  }
+
+  QueryBuilder<IsarCredential, String, QQueryOperations> typeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'type');
+    });
+  }
+}

--- a/lib/features/ssi/infrastructure/persistence/isar_did.dart
+++ b/lib/features/ssi/infrastructure/persistence/isar_did.dart
@@ -1,0 +1,26 @@
+import 'package:isar/isar.dart';
+
+part 'isar_did.g.dart';
+
+@collection
+class IsarDid {
+  Id id = Isar.autoIncrement;
+
+  @Index(unique: true, replace: true)
+  late String did;
+
+  String? shortForm;
+
+  late String longForm;
+
+  late DateTime createdAt;
+
+  bool isAnchored = false;
+
+  late String keyType;
+
+  /// Full DID Document stored as JSON string
+  String? didDocumentJson;
+
+  IsarDid();
+}

--- a/lib/features/ssi/infrastructure/persistence/isar_did.g.dart
+++ b/lib/features/ssi/infrastructure/persistence/isar_did.g.dart
@@ -1,0 +1,1448 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'isar_did.dart';
+
+// **************************************************************************
+// IsarCollectionGenerator
+// **************************************************************************
+
+// coverage:ignore-file
+// ignore_for_file: duplicate_ignore, non_constant_identifier_names, constant_identifier_names, invalid_use_of_protected_member, unnecessary_cast, prefer_const_constructors, lines_longer_than_80_chars, require_trailing_commas, inference_failure_on_function_invocation, unnecessary_parenthesis, unnecessary_raw_strings, unnecessary_null_checks, join_return_with_assignment, prefer_final_locals, avoid_js_rounded_ints, avoid_positional_boolean_parameters, always_specify_types
+
+extension GetIsarDidCollection on Isar {
+  IsarCollection<IsarDid> get isarDids => this.collection();
+}
+
+const IsarDidSchema = CollectionSchema(
+  name: r'IsarDid',
+  id: 1674962400950285438,
+  properties: {
+    r'createdAt': PropertySchema(
+      id: 0,
+      name: r'createdAt',
+      type: IsarType.dateTime,
+    ),
+    r'did': PropertySchema(
+      id: 1,
+      name: r'did',
+      type: IsarType.string,
+    ),
+    r'didDocumentJson': PropertySchema(
+      id: 2,
+      name: r'didDocumentJson',
+      type: IsarType.string,
+    ),
+    r'isAnchored': PropertySchema(
+      id: 3,
+      name: r'isAnchored',
+      type: IsarType.bool,
+    ),
+    r'keyType': PropertySchema(
+      id: 4,
+      name: r'keyType',
+      type: IsarType.string,
+    ),
+    r'longForm': PropertySchema(
+      id: 5,
+      name: r'longForm',
+      type: IsarType.string,
+    ),
+    r'shortForm': PropertySchema(
+      id: 6,
+      name: r'shortForm',
+      type: IsarType.string,
+    )
+  },
+  estimateSize: _isarDidEstimateSize,
+  serialize: _isarDidSerialize,
+  deserialize: _isarDidDeserialize,
+  deserializeProp: _isarDidDeserializeProp,
+  idName: r'id',
+  indexes: {
+    r'did': IndexSchema(
+      id: -4238199618338197262,
+      name: r'did',
+      unique: true,
+      replace: true,
+      properties: [
+        IndexPropertySchema(
+          name: r'did',
+          type: IndexType.hash,
+          caseSensitive: true,
+        )
+      ],
+    )
+  },
+  links: {},
+  embeddedSchemas: {},
+  getId: _isarDidGetId,
+  getLinks: _isarDidGetLinks,
+  attach: _isarDidAttach,
+  version: '3.1.0+1',
+);
+
+int _isarDidEstimateSize(
+  IsarDid object,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  var bytesCount = offsets.last;
+  bytesCount += 3 + object.did.length * 3;
+  {
+    final value = object.didDocumentJson;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  bytesCount += 3 + object.keyType.length * 3;
+  bytesCount += 3 + object.longForm.length * 3;
+  {
+    final value = object.shortForm;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  return bytesCount;
+}
+
+void _isarDidSerialize(
+  IsarDid object,
+  IsarWriter writer,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  writer.writeDateTime(offsets[0], object.createdAt);
+  writer.writeString(offsets[1], object.did);
+  writer.writeString(offsets[2], object.didDocumentJson);
+  writer.writeBool(offsets[3], object.isAnchored);
+  writer.writeString(offsets[4], object.keyType);
+  writer.writeString(offsets[5], object.longForm);
+  writer.writeString(offsets[6], object.shortForm);
+}
+
+IsarDid _isarDidDeserialize(
+  Id id,
+  IsarReader reader,
+  List<int> offsets,
+  Map<Type, List<int>> allOffsets,
+) {
+  final object = IsarDid();
+  object.createdAt = reader.readDateTime(offsets[0]);
+  object.did = reader.readString(offsets[1]);
+  object.didDocumentJson = reader.readStringOrNull(offsets[2]);
+  object.id = id;
+  object.isAnchored = reader.readBool(offsets[3]);
+  object.keyType = reader.readString(offsets[4]);
+  object.longForm = reader.readString(offsets[5]);
+  object.shortForm = reader.readStringOrNull(offsets[6]);
+  return object;
+}
+
+P _isarDidDeserializeProp<P>(
+  IsarReader reader,
+  int propertyId,
+  int offset,
+  Map<Type, List<int>> allOffsets,
+) {
+  switch (propertyId) {
+    case 0:
+      return (reader.readDateTime(offset)) as P;
+    case 1:
+      return (reader.readString(offset)) as P;
+    case 2:
+      return (reader.readStringOrNull(offset)) as P;
+    case 3:
+      return (reader.readBool(offset)) as P;
+    case 4:
+      return (reader.readString(offset)) as P;
+    case 5:
+      return (reader.readString(offset)) as P;
+    case 6:
+      return (reader.readStringOrNull(offset)) as P;
+    default:
+      throw IsarError('Unknown property with id $propertyId');
+  }
+}
+
+Id _isarDidGetId(IsarDid object) {
+  return object.id;
+}
+
+List<IsarLinkBase<dynamic>> _isarDidGetLinks(IsarDid object) {
+  return [];
+}
+
+void _isarDidAttach(IsarCollection<dynamic> col, Id id, IsarDid object) {
+  object.id = id;
+}
+
+extension IsarDidByIndex on IsarCollection<IsarDid> {
+  Future<IsarDid?> getByDid(String did) {
+    return getByIndex(r'did', [did]);
+  }
+
+  IsarDid? getByDidSync(String did) {
+    return getByIndexSync(r'did', [did]);
+  }
+
+  Future<bool> deleteByDid(String did) {
+    return deleteByIndex(r'did', [did]);
+  }
+
+  bool deleteByDidSync(String did) {
+    return deleteByIndexSync(r'did', [did]);
+  }
+
+  Future<List<IsarDid?>> getAllByDid(List<String> didValues) {
+    final values = didValues.map((e) => [e]).toList();
+    return getAllByIndex(r'did', values);
+  }
+
+  List<IsarDid?> getAllByDidSync(List<String> didValues) {
+    final values = didValues.map((e) => [e]).toList();
+    return getAllByIndexSync(r'did', values);
+  }
+
+  Future<int> deleteAllByDid(List<String> didValues) {
+    final values = didValues.map((e) => [e]).toList();
+    return deleteAllByIndex(r'did', values);
+  }
+
+  int deleteAllByDidSync(List<String> didValues) {
+    final values = didValues.map((e) => [e]).toList();
+    return deleteAllByIndexSync(r'did', values);
+  }
+
+  Future<Id> putByDid(IsarDid object) {
+    return putByIndex(r'did', object);
+  }
+
+  Id putByDidSync(IsarDid object, {bool saveLinks = true}) {
+    return putByIndexSync(r'did', object, saveLinks: saveLinks);
+  }
+
+  Future<List<Id>> putAllByDid(List<IsarDid> objects) {
+    return putAllByIndex(r'did', objects);
+  }
+
+  List<Id> putAllByDidSync(List<IsarDid> objects, {bool saveLinks = true}) {
+    return putAllByIndexSync(r'did', objects, saveLinks: saveLinks);
+  }
+}
+
+extension IsarDidQueryWhereSort on QueryBuilder<IsarDid, IsarDid, QWhere> {
+  QueryBuilder<IsarDid, IsarDid, QAfterWhere> anyId() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(const IdWhereClause.any());
+    });
+  }
+}
+
+extension IsarDidQueryWhere on QueryBuilder<IsarDid, IsarDid, QWhereClause> {
+  QueryBuilder<IsarDid, IsarDid, QAfterWhereClause> idEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: id,
+        upper: id,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterWhereClause> idNotEqualTo(Id id) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            )
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            );
+      } else {
+        return query
+            .addWhereClause(
+              IdWhereClause.greaterThan(lower: id, includeLower: false),
+            )
+            .addWhereClause(
+              IdWhereClause.lessThan(upper: id, includeUpper: false),
+            );
+      }
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterWhereClause> idGreaterThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.greaterThan(lower: id, includeLower: include),
+      );
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterWhereClause> idLessThan(Id id,
+      {bool include = false}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(
+        IdWhereClause.lessThan(upper: id, includeUpper: include),
+      );
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterWhereClause> idBetween(
+    Id lowerId,
+    Id upperId, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IdWhereClause.between(
+        lower: lowerId,
+        includeLower: includeLower,
+        upper: upperId,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterWhereClause> didEqualTo(String did) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addWhereClause(IndexWhereClause.equalTo(
+        indexName: r'did',
+        value: [did],
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterWhereClause> didNotEqualTo(String did) {
+    return QueryBuilder.apply(this, (query) {
+      if (query.whereSort == Sort.asc) {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'did',
+              lower: [],
+              upper: [did],
+              includeUpper: false,
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'did',
+              lower: [did],
+              includeLower: false,
+              upper: [],
+            ));
+      } else {
+        return query
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'did',
+              lower: [did],
+              includeLower: false,
+              upper: [],
+            ))
+            .addWhereClause(IndexWhereClause.between(
+              indexName: r'did',
+              lower: [],
+              upper: [did],
+              includeUpper: false,
+            ));
+      }
+    });
+  }
+}
+
+extension IsarDidQueryFilter
+    on QueryBuilder<IsarDid, IsarDid, QFilterCondition> {
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> createdAtEqualTo(
+      DateTime value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> createdAtGreaterThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> createdAtLessThan(
+    DateTime value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'createdAt',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> createdAtBetween(
+    DateTime lower,
+    DateTime upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'createdAt',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'did',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'did',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'did',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'did',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'did',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'did',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'did',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'did',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'did',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'did',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition>
+      didDocumentJsonIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'didDocumentJson',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition>
+      didDocumentJsonIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'didDocumentJson',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didDocumentJsonEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'didDocumentJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition>
+      didDocumentJsonGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'didDocumentJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didDocumentJsonLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'didDocumentJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didDocumentJsonBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'didDocumentJson',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition>
+      didDocumentJsonStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'didDocumentJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didDocumentJsonEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'didDocumentJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didDocumentJsonContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'didDocumentJson',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> didDocumentJsonMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'didDocumentJson',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition>
+      didDocumentJsonIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'didDocumentJson',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition>
+      didDocumentJsonIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'didDocumentJson',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> idEqualTo(Id value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> idGreaterThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> idLessThan(
+    Id value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'id',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> idBetween(
+    Id lower,
+    Id upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'id',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> isAnchoredEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isAnchored',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'keyType',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'keyType',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'keyType',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'keyType',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'keyType',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'keyType',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'keyType',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'keyType',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'keyType',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> keyTypeIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'keyType',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormEqualTo(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'longForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormGreaterThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'longForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormLessThan(
+    String value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'longForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormBetween(
+    String lower,
+    String upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'longForm',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'longForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'longForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'longForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'longForm',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'longForm',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> longFormIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'longForm',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'shortForm',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'shortForm',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'shortForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'shortForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'shortForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'shortForm',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'shortForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'shortForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormContains(
+      String value,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'shortForm',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormMatches(
+      String pattern,
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'shortForm',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'shortForm',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterFilterCondition> shortFormIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'shortForm',
+        value: '',
+      ));
+    });
+  }
+}
+
+extension IsarDidQueryObject
+    on QueryBuilder<IsarDid, IsarDid, QFilterCondition> {}
+
+extension IsarDidQueryLinks
+    on QueryBuilder<IsarDid, IsarDid, QFilterCondition> {}
+
+extension IsarDidQuerySortBy on QueryBuilder<IsarDid, IsarDid, QSortBy> {
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByDid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'did', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByDidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'did', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByDidDocumentJson() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'didDocumentJson', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByDidDocumentJsonDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'didDocumentJson', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByIsAnchored() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isAnchored', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByIsAnchoredDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isAnchored', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByKeyType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'keyType', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByKeyTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'keyType', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByLongForm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longForm', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByLongFormDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longForm', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByShortForm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shortForm', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> sortByShortFormDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shortForm', Sort.desc);
+    });
+  }
+}
+
+extension IsarDidQuerySortThenBy
+    on QueryBuilder<IsarDid, IsarDid, QSortThenBy> {
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByCreatedAtDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'createdAt', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByDid() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'did', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByDidDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'did', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByDidDocumentJson() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'didDocumentJson', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByDidDocumentJsonDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'didDocumentJson', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenById() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByIdDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'id', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByIsAnchored() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isAnchored', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByIsAnchoredDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isAnchored', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByKeyType() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'keyType', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByKeyTypeDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'keyType', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByLongForm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longForm', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByLongFormDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'longForm', Sort.desc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByShortForm() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shortForm', Sort.asc);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QAfterSortBy> thenByShortFormDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'shortForm', Sort.desc);
+    });
+  }
+}
+
+extension IsarDidQueryWhereDistinct
+    on QueryBuilder<IsarDid, IsarDid, QDistinct> {
+  QueryBuilder<IsarDid, IsarDid, QDistinct> distinctByCreatedAt() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'createdAt');
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QDistinct> distinctByDid(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'did', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QDistinct> distinctByDidDocumentJson(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'didDocumentJson',
+          caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QDistinct> distinctByIsAnchored() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isAnchored');
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QDistinct> distinctByKeyType(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'keyType', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QDistinct> distinctByLongForm(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'longForm', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<IsarDid, IsarDid, QDistinct> distinctByShortForm(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'shortForm', caseSensitive: caseSensitive);
+    });
+  }
+}
+
+extension IsarDidQueryProperty
+    on QueryBuilder<IsarDid, IsarDid, QQueryProperty> {
+  QueryBuilder<IsarDid, int, QQueryOperations> idProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'id');
+    });
+  }
+
+  QueryBuilder<IsarDid, DateTime, QQueryOperations> createdAtProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'createdAt');
+    });
+  }
+
+  QueryBuilder<IsarDid, String, QQueryOperations> didProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'did');
+    });
+  }
+
+  QueryBuilder<IsarDid, String?, QQueryOperations> didDocumentJsonProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'didDocumentJson');
+    });
+  }
+
+  QueryBuilder<IsarDid, bool, QQueryOperations> isAnchoredProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isAnchored');
+    });
+  }
+
+  QueryBuilder<IsarDid, String, QQueryOperations> keyTypeProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'keyType');
+    });
+  }
+
+  QueryBuilder<IsarDid, String, QQueryOperations> longFormProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'longForm');
+    });
+  }
+
+  QueryBuilder<IsarDid, String?, QQueryOperations> shortFormProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'shortForm');
+    });
+  }
+}

--- a/lib/features/ssi/infrastructure/repositories/isar_ssi_repository.dart
+++ b/lib/features/ssi/infrastructure/repositories/isar_ssi_repository.dart
@@ -1,0 +1,112 @@
+import 'dart:convert';
+import 'package:injectable/injectable.dart';
+import 'package:isar/isar.dart';
+import '../../domain/entities/did.dart';
+import '../../domain/entities/verifiable_credential.dart';
+import '../../domain/repositories/ssi_repository.dart';
+import '../persistence/isar_credential.dart';
+import '../persistence/isar_did.dart';
+
+@LazySingleton(as: SsiRepository)
+class IsarSsiRepository implements SsiRepository {
+  final Isar _isar;
+
+  IsarSsiRepository(this._isar);
+
+  @override
+  Future<void> saveDid(Did did, Map<String, dynamic> didDocument) async {
+    await _isar.writeTxn(() async {
+      final isarDid = IsarDid()
+        ..did = did.did
+        ..shortForm = did.shortForm
+        ..longForm = did.longForm
+        ..createdAt = did.createdAt
+        ..isAnchored = did.isAnchored
+        ..keyType = did.keyType
+        ..didDocumentJson = jsonEncode(didDocument);
+
+      await _isar.isarDids.putByDid(isarDid);
+    });
+  }
+
+  @override
+  Future<List<Did>> getDids() async {
+    final isarDids = await _isar.isarDids.where().findAll();
+    return isarDids.map((d) => Did(
+      did: d.did,
+      shortForm: d.shortForm,
+      longForm: d.longForm,
+      createdAt: d.createdAt,
+      isAnchored: d.isAnchored,
+      keyType: d.keyType,
+    )).toList();
+  }
+
+  @override
+  Future<Map<String, dynamic>?> getDidDocument(String did) async {
+    final isarDid = await _isar.isarDids.filter().didEqualTo(did).findFirst();
+    if (isarDid?.didDocumentJson == null) return null;
+    return jsonDecode(isarDid!.didDocumentJson!) as Map<String, dynamic>;
+  }
+
+  @override
+  Future<void> saveCredential(VerifiableCredential credential) async {
+    await _isar.writeTxn(() async {
+      final isarCredential = IsarCredential()
+        ..credentialId = credential.id
+        ..issuer = credential.issuer
+        ..subject = credential.subject
+        ..type = credential.type
+        ..schemaId = credential.schemaId
+        ..claimsJson = jsonEncode(credential.claims)
+        ..issuanceDate = credential.issuanceDate
+        ..expirationDate = credential.expirationDate
+        ..proof = credential.proof
+        ..isRevoked = credential.isRevoked;
+
+      await _isar.isarCredentials.putByCredentialId(isarCredential);
+    });
+  }
+
+  @override
+  Future<List<VerifiableCredential>> getCredentials() async {
+    final isarCredentials = await _isar.isarCredentials.where().findAll();
+    return isarCredentials.map((c) => VerifiableCredential(
+      id: c.credentialId,
+      issuer: c.issuer,
+      subject: c.subject,
+      type: c.type,
+      schemaId: c.schemaId,
+      claims: Map<String, dynamic>.from(jsonDecode(c.claimsJson) as Map),
+      issuanceDate: c.issuanceDate,
+      expirationDate: c.expirationDate,
+      proof: c.proof,
+      isRevoked: c.isRevoked,
+    )).toList();
+  }
+
+  @override
+  Future<VerifiableCredential?> getCredentialById(String credentialId) async {
+    final c = await _isar.isarCredentials.filter().credentialIdEqualTo(credentialId).findFirst();
+    if (c == null) return null;
+    return VerifiableCredential(
+      id: c.credentialId,
+      issuer: c.issuer,
+      subject: c.subject,
+      type: c.type,
+      schemaId: c.schemaId,
+      claims: Map<String, dynamic>.from(jsonDecode(c.claimsJson) as Map),
+      issuanceDate: c.issuanceDate,
+      expirationDate: c.expirationDate,
+      proof: c.proof,
+      isRevoked: c.isRevoked,
+    );
+  }
+
+  @override
+  Future<void> deleteCredential(String credentialId) async {
+    await _isar.writeTxn(() async {
+      await _isar.isarCredentials.filter().credentialIdEqualTo(credentialId).deleteAll();
+    });
+  }
+}

--- a/lib/features/ssi/infrastructure/services/ssi_service_impl.dart
+++ b/lib/features/ssi/infrastructure/services/ssi_service_impl.dart
@@ -4,6 +4,7 @@ import 'package:injectable/injectable.dart';
 import 'package:crypto/crypto.dart';
 import '../../domain/entities/did.dart';
 import '../../domain/entities/verifiable_credential.dart';
+import '../../domain/repositories/ssi_repository.dart';
 import '../../domain/services/ssi_service.dart';
 
 /// Basic SSI Service implementation.
@@ -19,11 +20,9 @@ import '../../domain/services/ssi_service.dart';
 /// Reference: docs/research/SSI_ARCHITECTURE_DECISION.md
 @LazySingleton(as: SsiService)
 class SsiServiceImpl implements SsiService {
-  // TODO(ssi): Migrate to Isar persistence for DIDs, credentials, and DID documents.
-  // Currently in-memory only — data lost on app restart.
-  final List<Did> _dids = [];
-  final List<VerifiableCredential> _credentials = [];
-  final Map<String, Map<String, dynamic>> _didDocuments = {};
+  final SsiRepository _repository;
+
+  SsiServiceImpl(this._repository);
 
   @override
   Future<Did> createDid() async {
@@ -43,25 +42,25 @@ class SsiServiceImpl implements SsiService {
       keyType: 'Ed25519',
     );
 
-    _dids.add(did);
-
-    // Store the DID Document
-    _didDocuments[didString] = _createDidDocument(did);
+    // Store the DID and its Document
+    await _repository.saveDid(did, _createDidDocument(did));
 
     return did;
   }
 
   @override
   Future<Map<String, dynamic>?> resolveDid(String did) async {
-    // Local resolution first (long-form includes initial state)
-    if (_didDocuments.containsKey(did)) {
-      return _didDocuments[did];
+    // Local resolution first
+    final doc = await _repository.getDidDocument(did);
+    if (doc != null) {
+      return doc;
     }
 
-    // Try resolving as long-form DID
-    for (final d in _dids) {
+    // Try resolving as long-form DID (if short-form was provided)
+    final allDids = await _repository.getDids();
+    for (final d in allDids) {
       if (d.longForm == did || d.activeDid == did) {
-        return _didDocuments[d.did];
+        return _repository.getDidDocument(d.did);
       }
     }
 
@@ -77,7 +76,9 @@ class SsiServiceImpl implements SsiService {
     DateTime? expirationDate,
   }) async {
     final credentialId = 'vc:${_generateSeed().substring(0, 16)}';
-    final ourDid = _dids.isNotEmpty ? _dids.first : await createDid();
+
+    final allDids = await _repository.getDids();
+    final ourDid = allDids.isNotEmpty ? allDids.first : await createDid();
 
     final vc = VerifiableCredential(
       id: credentialId,
@@ -91,7 +92,7 @@ class SsiServiceImpl implements SsiService {
       proof: _generateProof(credentialId, claims, ourDid.activeDid),
     );
 
-    _credentials.add(vc);
+    await _repository.saveCredential(vc);
     return vc;
   }
 
@@ -132,7 +133,7 @@ class SsiServiceImpl implements SsiService {
 
   @override
   Future<void> revokeCredential(String credentialId) async {
-    _credentials.removeWhere((vc) => vc.id == credentialId);
+    await _repository.deleteCredential(credentialId);
   }
 
   @override

--- a/test/features/ssi/ssi_persistence_test.dart
+++ b/test/features/ssi/ssi_persistence_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:orionhealth_health/features/ssi/domain/repositories/ssi_repository.dart';
+import 'package:orionhealth_health/features/ssi/infrastructure/repositories/isar_ssi_repository.dart';
+import 'package:orionhealth_health/features/ssi/infrastructure/services/ssi_service_impl.dart';
+import 'package:orionhealth_health/features/ssi/infrastructure/persistence/isar_did.dart';
+import 'package:orionhealth_health/features/ssi/infrastructure/persistence/isar_credential.dart';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Isar isar;
+  late SsiRepository repository;
+  late SsiServiceImpl service;
+  late String testPath;
+
+  setUpAll(() async {
+    testPath = p.join(Directory.current.path, 'test_db_ssi');
+    await Directory(testPath).create(recursive: true);
+
+    await Isar.initializeIsarCore(download: true);
+    isar = await Isar.open(
+      [IsarDidSchema, IsarCredentialSchema],
+      directory: testPath,
+    );
+  });
+
+  tearDownAll(() async {
+    await isar.close();
+    if (await Directory(testPath).exists()) {
+      await Directory(testPath).delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    await isar.writeTxn(() async {
+      await isar.isarDids.clear();
+      await isar.isarCredentials.clear();
+    });
+    repository = IsarSsiRepository(isar);
+    service = SsiServiceImpl(repository);
+  });
+
+  test('SSI data persists across service restarts', () async {
+    // 1. Create data in first session
+    final did = await service.createDid();
+    final vc = await service.issueCredential(
+      schemaId: 'orion:schemas:VaccinationCredential:v1',
+      subjectDid: did.activeDid,
+      claims: {'vaccineName': 'COVID-19'},
+    );
+
+    // 2. Simulate "app restart" by creating new service instance with same Isar
+    final newRepository = IsarSsiRepository(isar);
+    final newService = SsiServiceImpl(newRepository);
+
+    // 3. Verify data is still there
+    final resolvedDoc = await newService.resolveDid(did.did);
+    expect(resolvedDoc, isNotNull);
+    expect(resolvedDoc!['id'], did.did);
+
+    final credentials = await newRepository.getCredentials();
+    expect(credentials.length, 1);
+    expect(credentials.first.id, vc.id);
+    expect(credentials.first.claims['vaccineName'], 'COVID-19');
+  });
+
+  test('revokeCredential persists removal', () async {
+    final did = await service.createDid();
+    final vc = await service.issueCredential(
+      schemaId: 'orion:schemas:VaccinationCredential:v1',
+      subjectDid: did.activeDid,
+      claims: {'vaccineName': 'Flu'},
+    );
+
+    await service.revokeCredential(vc.id);
+
+    // Restart
+    final newRepository = IsarSsiRepository(isar);
+    final credentials = await newRepository.getCredentials();
+    expect(credentials, isEmpty);
+  });
+}

--- a/test/features/ssi/ssi_service_test.dart
+++ b/test/features/ssi/ssi_service_test.dart
@@ -1,13 +1,42 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/ssi/domain/entities/credential_schema.dart';
 import 'package:orionhealth_health/features/ssi/domain/entities/verifiable_credential.dart';
+import 'package:orionhealth_health/features/ssi/domain/repositories/ssi_repository.dart';
+import 'package:orionhealth_health/features/ssi/domain/entities/did.dart';
 import 'package:orionhealth_health/features/ssi/infrastructure/services/ssi_service_impl.dart';
+
+class MockSsiRepository extends Mock implements SsiRepository {}
 
 void main() {
   late SsiServiceImpl service;
+  late MockSsiRepository mockRepository;
 
   setUp(() {
-    service = SsiServiceImpl();
+    mockRepository = MockSsiRepository();
+    service = SsiServiceImpl(mockRepository);
+
+    // Default mock behaviors
+    when(() => mockRepository.getDids()).thenAnswer((_) async => []);
+    when(() => mockRepository.saveDid(any(), any())).thenAnswer((_) async {});
+    when(() => mockRepository.saveCredential(any())).thenAnswer((_) async {});
+  });
+
+  setUpAll(() {
+    registerFallbackValue(Did(
+      did: 'did:test',
+      longForm: 'did:test:long',
+      createdAt: DateTime.now(),
+    ));
+    registerFallbackValue(VerifiableCredential(
+      id: 'vc:test',
+      issuer: 'did:issuer',
+      subject: 'did:subject',
+      type: 'Test',
+      schemaId: 'schema',
+      claims: {},
+      issuanceDate: DateTime.now(),
+    ));
   });
 
   group('SsiServiceImpl', () {
@@ -20,6 +49,8 @@ void main() {
         expect(did.keyType, 'Ed25519');
         expect(did.isAnchored, false);
         expect(did.createdAt, isA<DateTime>());
+
+        verify(() => mockRepository.saveDid(did, any())).called(1);
       });
 
       test('generates unique DIDs on each call', () async {
@@ -38,15 +69,25 @@ void main() {
 
     group('resolveDid', () {
       test('resolves locally created DID', () async {
-        final did = await service.createDid();
+        final did = Did(
+          did: 'did:orion:123',
+          longForm: 'did:orion:123;initial-state=abc',
+          createdAt: DateTime.now(),
+        );
+        final didDoc = {'id': did.did, 'verificationMethod': []};
+
+        when(() => mockRepository.getDidDocument(did.did)).thenAnswer((_) async => didDoc);
+
         final doc = await service.resolveDid(did.did);
 
         expect(doc, isNotNull);
         expect(doc!['id'], did.did);
-        expect(doc['verificationMethod'], isA<List>());
       });
 
       test('returns null for unknown DID', () async {
+        when(() => mockRepository.getDidDocument(any())).thenAnswer((_) async => null);
+        when(() => mockRepository.getDids()).thenAnswer((_) async => []);
+
         final doc = await service.resolveDid('did:orion:unknown');
         expect(doc, isNull);
       });
@@ -55,6 +96,8 @@ void main() {
     group('issueCredential', () {
       test('issues a VerifiableCredential with proof', () async {
         final did = await service.createDid();
+        when(() => mockRepository.getDids()).thenAnswer((_) async => [did]);
+
         final vc = await service.issueCredential(
           schemaId: 'orion:schemas:VaccinationCredential:v1',
           subjectDid: did.activeDid,
@@ -71,10 +114,14 @@ void main() {
         expect(vc.claims['vaccineName'], 'COVID-19 mRNA');
         expect(vc.proof, isNotNull);
         expect(vc.isValid, true);
+
+        verify(() => mockRepository.saveCredential(vc)).called(1);
       });
 
       test('issued credential is verifiable', () async {
         final did = await service.createDid();
+        when(() => mockRepository.getDids()).thenAnswer((_) async => [did]);
+
         final vc = await service.issueCredential(
           schemaId: 'orion:schemas:PrescriptionCredential:v1',
           subjectDid: did.activeDid,
@@ -87,6 +134,8 @@ void main() {
 
       test('does not verify tampered credential', () async {
         final did = await service.createDid();
+        when(() => mockRepository.getDids()).thenAnswer((_) async => [did]);
+
         final vc = await service.issueCredential(
           schemaId: 'orion:schemas:LabResultCredential:v1',
           subjectDid: did.activeDid,
@@ -113,6 +162,8 @@ void main() {
     group('selective disclosure', () {
       test('creates presentation with only specified fields', () async {
         final did = await service.createDid();
+        when(() => mockRepository.getDids()).thenAnswer((_) async => [did]);
+
         final vc = await service.issueCredential(
           schemaId: 'orion:schemas:VaccinationCredential:v1',
           subjectDid: did.activeDid,
@@ -140,21 +191,13 @@ void main() {
 
     group('revokeCredential', () {
       test('removes credential from store', () async {
-        final did = await service.createDid();
-        final vc = await service.issueCredential(
-          schemaId: 'orion:schemas:VaccinationCredential:v1',
-          subjectDid: did.activeDid,
-          claims: {'vaccineName': 'Flu'},
-        );
+        when(() => mockRepository.deleteCredential(any())).thenAnswer((_) async {});
 
-        await service.revokeCredential(vc.id);
+        await service.revokeCredential('vc:123');
 
-        // Verification should fail for revoked credential
-        // (in production, this would check a revocation registry)
+        verify(() => mockRepository.deleteCredential('vc:123')).called(1);
       });
     });
-  });
-
   group('VerifiableCredential', () {
     test('isValid returns true for non-expired, non-revoked credential', () {
       final vc = VerifiableCredential(
@@ -223,5 +266,6 @@ void main() {
       expect(CredentialSchema.prescriptionCredential.attributes, contains('medicationName'));
       expect(CredentialSchema.prescriptionCredential.attributes, contains('dosage'));
     });
+  });
   });
 }


### PR DESCRIPTION
Migrated the SSI feature from volatile in-memory storage to persistent Isar database storage. This includes the creation of dedicated Isar entities for DIDs and Verifiable Credentials, the introduction of a repository pattern for clean data access, and the refactoring of the SSI service to utilize this new persistence layer. Verified the changes with a new persistence test suite and updated existing unit tests.

Fixes #172

---
*PR created automatically by Jules for task [13083227161025445412](https://jules.google.com/task/13083227161025445412) started by @iberi22*