### PR TITLE
Resolve flutter_blue_plus Windows warning + pubspec audit

### DIFF
--- a/lib/features/reports/presentation/pages/report_detail_page.dart
+++ b/lib/features/reports/presentation/pages/report_detail_page.dart
@@ -1,5 +1,5 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_markdown/flutter_markdown.dart';
+import 'package:flutter_markdown_plus/flutter_markdown_plus.dart';
 import '../../domain/entities/report.dart';
 
 class ReportDetailPage extends StatelessWidget {

--- a/lib/features/settings/presentation/pages/llm_settings_page.dart
+++ b/lib/features/settings/presentation/pages/llm_settings_page.dart
@@ -1626,5 +1626,33 @@ class _InfoRow extends StatelessWidget {
   }
 }
 
+class _PrivacyToggle extends StatelessWidget {
+  final bool allowCloudApiCalls;
+  final ValueChanged<bool> onChanged;
 
+  const _PrivacyToggle({
+    required this.allowCloudApiCalls,
+    required this.onChanged,
+  });
 
+  @override
+  Widget build(BuildContext context) {
+    return SwitchListTile(
+      title: const Text(
+        'Permitir llamadas a la nube',
+        style: TextStyle(
+          color: Colors.white,
+          fontWeight: FontWeight.bold,
+        ),
+      ),
+      subtitle: const Text(
+        'Permite el uso de modelos en la nube para mejorar las respuestas.',
+        style: TextStyle(color: Colors.white70),
+      ),
+      value: allowCloudApiCalls,
+      onChanged: onChanged,
+      activeTrackColor: AppColors.primary.withValues(alpha: 0.5),
+      activeThumbColor: AppColors.primary,
+    );
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -229,10 +229,10 @@ packages:
     dependency: "direct main"
     description:
       name: cupertino_icons
-      sha256: ba631d1c7f7bef6b729a622b7b752645a2d076dba9976925b8f25725a30e1ee6
+      sha256: "41e005c33bd814be4d3096aff55b1908d419fde52ca656c8c47719ec745873cd"
       url: "https://pub.dev"
     source: hosted
-    version: "1.0.8"
+    version: "1.0.9"
   dart_style:
     dependency: transitive
     description:
@@ -293,10 +293,10 @@ packages:
     dependency: "direct main"
     description:
       name: equatable
-      sha256: "567c64b3cb4cf82397aac55f4f0cbd3ca20d77c6c03bedbc4ceaddc08904aef7"
+      sha256: "3e0141505477fd8ad55d6eb4e7776d3fe8430be8e497ccb1521370c3f21a3e2b"
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.7"
+    version: "2.0.8"
   fake_async:
     dependency: transitive
     description:
@@ -442,10 +442,10 @@ packages:
     dependency: "direct main"
     description:
       name: flutter_blue_plus
-      sha256: b33e74090d752fae75b9df8d227cb09b0da75b8d3e6a24108d1bfc884ed00ba8
+      sha256: "80eab9325aaa6736eb0f59edb77ff42a98466fe2963d4d4c155c69c509504982"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.3.2"
   flutter_blue_plus_android:
     dependency: transitive
     description:
@@ -486,6 +486,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "9.0.0"
+  flutter_blue_plus_winrt:
+    dependency: "direct main"
+    description:
+      name: flutter_blue_plus_winrt
+      sha256: "0000b2d818e6f79ad07764206fdd8afb69426fd44453c6254c35828fd16aa09f"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.0.20"
   flutter_driver:
     dependency: transitive
     description: flutter
@@ -503,23 +511,23 @@ packages:
     dependency: "direct dev"
     description:
       name: flutter_lints
-      sha256: "5398f14efa795ffb7a33e9b6a08798b26a180edac4ad7db3f231e40f82ce11e1"
+      sha256: "3105dc8492f6183fb076ccf1f351ac3d60564bff92e20bfc4af9cc1651f4e7e1"
       url: "https://pub.dev"
     source: hosted
-    version: "5.0.0"
+    version: "6.0.0"
   flutter_localizations:
     dependency: "direct main"
     description: flutter
     source: sdk
     version: "0.0.0"
-  flutter_markdown:
+  flutter_markdown_plus:
     dependency: "direct main"
     description:
-      name: flutter_markdown
-      sha256: "08fb8315236099ff8e90cb87bb2b935e0a724a3af1623000a9cec930468e0f27"
+      name: flutter_markdown_plus
+      sha256: "039177906850278e8fb1cd364115ee0a46281135932fa8ecea8455522166d2de"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7+1"
+    version: "1.0.7"
   flutter_plugin_android_lifecycle:
     dependency: transitive
     description:
@@ -707,10 +715,10 @@ packages:
     dependency: "direct main"
     description:
       name: health
-      sha256: ec6ba8485bb86cac9001fe721811dae470172d0a153ad6778e77fb1ff975dd8f
+      sha256: "2d9e119f3a1d281139f93149b41032b9f80b759960875bc784c5a25dd3c17524"
       url: "https://pub.dev"
     source: hosted
-    version: "13.2.1"
+    version: "13.3.1"
   health_wallet:
     dependency: "direct main"
     description:
@@ -762,10 +770,10 @@ packages:
     dependency: "direct main"
     description:
       name: image_picker
-      sha256: "784210112be18ea55f69d7076e2c656a4e24949fa9e76429fe53af0c0f4fa320"
+      sha256: "91c025426c2881c551100bce834e201c835a170151545f58d17da5180ca7d9ac"
       url: "https://pub.dev"
     source: hosted
-    version: "1.2.1"
+    version: "1.2.2"
   image_picker_android:
     dependency: transitive
     description:
@@ -966,10 +974,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: "12f842a479589fea194fe5c5a3095abc7be0c1f2ddfa9a0e76aed1dbd26a87df"
       url: "https://pub.dev"
     source: hosted
-    version: "5.1.1"
+    version: "6.1.0"
   local_auth:
     dependency: "direct main"
     description:
@@ -1506,10 +1514,10 @@ packages:
     dependency: "direct main"
     description:
       name: uuid
-      sha256: a11b666489b1954e01d992f3d601b1804a33937b5a8fe677bd26b8a9f96f96e8
+      sha256: "1fef9e8e11e2991bb773070d4656b7bd5d850967a2456cfc83cf47925ba79489"
       url: "https://pub.dev"
     source: hosted
-    version: "4.5.2"
+    version: "4.5.3"
   vector_math:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,10 +35,10 @@ dependencies:
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
-  cupertino_icons: ^1.0.8
+  cupertino_icons: ^1.0.9
   file_picker: ^10.3.7
-  image_picker: ^1.2.1
-  uuid: ^4.5.2
+  image_picker: ^1.2.2
+  uuid: ^4.5.3
   intl: ^0.20.2
   flutter_bloc: ^8.1.0
   hex: ^0.2.0
@@ -51,8 +51,8 @@ dependencies:
   isar_flutter_libs: ^3.1.0+1
   objectbox_flutter_libs: any
   path_provider: ^2.1.5
-  flutter_markdown: ^0.7.7+1
-  equatable: ^2.0.7
+  flutter_markdown_plus: ^1.0.7
+  equatable: ^2.0.8
   device_info_plus: 12.4.0
   isar_agent_memory:
     path: packages/isar_agent_memory
@@ -62,7 +62,7 @@ dependencies:
     path: packages/health_wallet
   onnxruntime: ^1.4.1
   permission_handler: ^12.0.1
-  health: ^13.2.1
+  health: ^13.3.1
   google_fonts: ^6.3.2
   flutter_gemma: ^0.12.6
 
@@ -73,7 +73,8 @@ dependencies:
   shared_preferences: ^2.3.0
 
   # Bluetooth Low Energy for medical data sharing
-  flutter_blue_plus: ^2.3.1
+  flutter_blue_plus: ^2.3.2
+  flutter_blue_plus_winrt: ^0.0.20
   google_mlkit_text_recognition: ^0.15.1
   openai_dart: ^1.0.0
   http: ^1.2.0
@@ -88,7 +89,7 @@ dev_dependencies:
   # activated in the `analysis_options.yaml` file located at the root of your
   # package. See that file for information about deactivating specific lint
   # rules and activating additional ones.
-  flutter_lints: ^5.0.0
+  flutter_lints: ^6.0.0
   build_runner: ^2.4.13
   isar_generator: ^3.1.0+1
   injectable_generator: ^2.4.2

--- a/windows/flutter/generated_plugin_registrant.cc
+++ b/windows/flutter/generated_plugin_registrant.cc
@@ -8,6 +8,7 @@
 
 #include <file_selector_windows/file_selector_windows.h>
 #include <firebase_core/firebase_core_plugin_c_api.h>
+#include <flutter_blue_plus_winrt/flutter_blue_plus_plugin.h>
 #include <flutter_gemma/flutter_gemma_plugin.h>
 #include <flutter_secure_storage_windows/flutter_secure_storage_windows_plugin.h>
 #include <isar_flutter_libs/isar_flutter_libs_plugin.h>
@@ -20,6 +21,8 @@ void RegisterPlugins(flutter::PluginRegistry* registry) {
       registry->GetRegistrarForPlugin("FileSelectorWindows"));
   FirebaseCorePluginCApiRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FirebaseCorePluginCApi"));
+  FlutterBluePlusPluginRegisterWithRegistrar(
+      registry->GetRegistrarForPlugin("FlutterBluePlusPlugin"));
   FlutterGemmaPluginRegisterWithRegistrar(
       registry->GetRegistrarForPlugin("FlutterGemmaPlugin"));
   FlutterSecureStorageWindowsPluginRegisterWithRegistrar(

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -5,6 +5,7 @@
 list(APPEND FLUTTER_PLUGIN_LIST
   file_selector_windows
   firebase_core
+  flutter_blue_plus_winrt
   flutter_gemma
   flutter_secure_storage_windows
   isar_flutter_libs


### PR DESCRIPTION
This PR resolves the persistent `flutter_blue_plus` warning on Windows by adding the missing `flutter_blue_plus_winrt` dependency. Additionally, it performs a project-wide pubspec audit, updating several packages and migrating from the discontinued `flutter_markdown` to `flutter_markdown_plus`. It also includes a fix for a corrupted `llm_settings_page.dart` file which had syntax errors and a missing widget.

Fixes #174

---
*PR created automatically by Jules for task [6934500321197446670](https://jules.google.com/task/6934500321197446670) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated multiple package versions: UUID, image picker, icons library, markdown renderer, Bluetooth packages, and development tools.
  * Added Windows platform Bluetooth Low Energy plugin support.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/OrionHealth/pull/177)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->