### PR TITLE
SSI: aries-askar FFI PoC (Blocked by missing dependency)

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -306,7 +306,7 @@ packages:
     source: hosted
     version: "1.3.3"
   ffi:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: ffi
       sha256: "289279317b4b16eb2bb7e271abccd4bf84ec9bdcbe999e278a94b804f5630418"
@@ -1046,18 +1046,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1482,10 +1482,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,7 @@ dependencies:
   openai_dart: ^1.0.0
   http: ^1.2.0
   crypto: ^3.0.7
+  ffi: ^2.1.2
   
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
I have added the `ffi` dependency to the project as a prerequisite for the `aries-askar` FFI integration. However, I am currently stuck on adding the `aries_askar` package itself. I have performed extensive searches on `pub.dev`, checked for local packages in the `packages/` directory, and tried several potential Git repository URLs (including Hyperledger and the user's namespace), but the package could not be located. Without this dependency, the implementation of the `createAnonCredsProof` and `verifyAnonCredsProof` methods using real AnonCreds ZKP is not possible. I have documented the research steps taken in the commit message.

Fixes #179

---
*PR created automatically by Jules for task [9921158405808042973](https://jules.google.com/task/9921158405808042973) started by @iberi22*