### PR TITLE
Add unit tests for SidetreeAnchorClient

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1046,18 +1046,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1482,10 +1482,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/ssi/sidetree_anchor_client_test.dart
+++ b/test/features/ssi/sidetree_anchor_client_test.dart
@@ -1,0 +1,139 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:http/http.dart' as http;
+import 'package:orionhealth_health/features/ssi/infrastructure/services/sidetree_anchor_client.dart';
+
+class MockHttpClient extends Mock implements http.Client {}
+
+void main() {
+  late SidetreeAnchorClient client;
+  late MockHttpClient mockHttpClient;
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
+  });
+
+  setUp(() {
+    mockHttpClient = MockHttpClient();
+    client = SidetreeAnchorClient(httpClient: mockHttpClient);
+  });
+
+  group('SidetreeAnchorClient', () {
+    group('resolve', () {
+      const did = 'did:ion:test-did';
+      final mockDoc = {'id': did, 'verificationMethod': []};
+
+      test('returns decoded JSON when response is 200', () async {
+        when(() => mockHttpClient.get(any(), headers: any(named: 'headers')))
+            .thenAnswer((_) async => http.Response(jsonEncode(mockDoc), 200));
+
+        final result = await client.resolve(did);
+
+        expect(result, equals(mockDoc));
+        verify(() => mockHttpClient.get(
+              Uri.parse('${SidetreeAnchorClient.defaultIonNode}/identifiers/$did'),
+              headers: {'Accept': 'application/json'},
+            )).called(1);
+      });
+
+      test('returns null when response is 404', () async {
+        when(() => mockHttpClient.get(any(), headers: any(named: 'headers')))
+            .thenAnswer((_) async => http.Response('Not Found', 404));
+
+        final result = await client.resolve(did);
+
+        expect(result, isNull);
+      });
+
+      test('throws SidetreeException when response is not 200 or 404', () async {
+        when(() => mockHttpClient.get(any(), headers: any(named: 'headers')))
+            .thenAnswer((_) async => http.Response('Internal Server Error', 500));
+
+        expect(() => client.resolve(did), throwsA(isA<SidetreeException>()));
+      });
+
+      test('throws SidetreeException on network error', () async {
+        when(() => mockHttpClient.get(any(), headers: any(named: 'headers')))
+            .thenThrow(Exception('Network Error'));
+
+        expect(() => client.resolve(did), throwsA(isA<SidetreeException>()));
+      });
+    });
+
+    group('isAnchored', () {
+      const did = 'did:ion:test-did';
+
+      test('returns true when resolve returns a document', () async {
+        when(() => mockHttpClient.get(any(), headers: any(named: 'headers')))
+            .thenAnswer((_) async => http.Response(jsonEncode({'id': did}), 200));
+
+        final result = await client.isAnchored(did);
+
+        expect(result, isTrue);
+      });
+
+      test('returns false when resolve returns null', () async {
+        when(() => mockHttpClient.get(any(), headers: any(named: 'headers')))
+            .thenAnswer((_) async => http.Response('Not Found', 404));
+
+        final result = await client.isAnchored(did);
+
+        expect(result, isFalse);
+      });
+    });
+
+    group('createDid', () {
+      final publicKeys = [
+        {'id': 'key-1', 'type': 'EcdsaSecp256k1VerificationKey2019'}
+      ];
+      final mockResponse = {
+        'didSuffix': 'test-suffix',
+        'operationHash': 'test-hash',
+      };
+
+      test('returns IonCreateResult on success', () async {
+        when(() => mockHttpClient.post(any(),
+                headers: any(named: 'headers'), body: any(named: 'body')))
+            .thenAnswer((_) async => http.Response(jsonEncode(mockResponse), 200));
+
+        final result = await client.createDid(publicKeys: publicKeys);
+
+        expect(result, isA<IonCreateResult>());
+        expect(result.didSuffix, equals('test-suffix'));
+        expect(result.did, equals('did:ion:test-suffix'));
+        expect(result.operationHash, equals('test-hash'));
+
+        verify(() => mockHttpClient.post(
+              Uri.parse('${SidetreeAnchorClient.defaultIonNode}/operations'),
+              headers: {'Content-Type': 'application/json'},
+              body: any(named: 'body'),
+            )).called(1);
+      });
+
+      test('throws SidetreeException on error', () async {
+        when(() => mockHttpClient.post(any(),
+                headers: any(named: 'headers'), body: any(named: 'body')))
+            .thenAnswer((_) async => http.Response('Error', 500));
+
+        expect(() => client.createDid(publicKeys: publicKeys),
+            throwsA(isA<SidetreeException>()));
+      });
+    });
+
+    group('generateKeyPair', () {
+      test('returns valid JWK structure', () async {
+        final keyPair = await client.generateKeyPair();
+
+        expect(keyPair['type'], equals('JsonWebKey2020'));
+        expect(keyPair['id'], startsWith('#key-'));
+        expect(keyPair['publicKeyJwk'], isA<Map>());
+        expect(keyPair['publicKeyJwk']['kty'], equals('OKP'));
+        expect(keyPair['publicKeyJwk']['crv'], equals('Ed25519'));
+        expect(keyPair['publicKeyJwk']['x'], isA<String>());
+        expect(keyPair['privateKeyHex'], isA<String>());
+        expect(keyPair['privateKeyHex'].length, equals(64)); // 32 bytes in hex
+      });
+    });
+  });
+}


### PR DESCRIPTION
I have added comprehensive unit tests for the `SidetreeAnchorClient` class in `test/features/ssi/sidetree_anchor_client_test.dart`.

Key highlights:
- **Comprehensive Coverage**: Added tests for all public methods (`resolve`, `isAnchored`, `createDid`, `generateKeyPair`).
- **Robust Error Handling**: Verified that the client correctly handles and throws `SidetreeException` for various failure modes, including non-200/404 HTTP status codes and network exceptions.
- **Mocking**: Used `mocktail` to mock `http.Client` for clean and predictable testing of network interactions.
- **Data Integrity**: Verified the structure of generated key pairs and the processing of ION node responses.

All tests passed successfully, and static analysis is clean.

Fixes #187

---
*PR created automatically by Jules for task [2666503922881581192](https://jules.google.com/task/2666503922881581192) started by @iberi22*