### PR TITLE
E2E Integration Test: BLE -> SSI -> AnonCreds

### DIFF
--- a/lib/features/auth/infrastructure/services/ble_medical_sharing_service.dart
+++ b/lib/features/auth/infrastructure/services/ble_medical_sharing_service.dart
@@ -218,6 +218,49 @@ class BleMedicalSharingService {
     return _bleService.sendData(package);
   }
 
+  /// Encrypt any medical data into a [MedicalSharePackage].
+  Future<MedicalSharePackage> encryptPackage(
+    Map<String, dynamic> data, {
+    required String packageType,
+    required String recipientNodeId,
+  }) async {
+    final jsonStr = jsonEncode(data);
+    final plainBytes = utf8.encode(jsonStr);
+    final encrypted = await _encryptionService.encryptBytes(
+      Uint8List.fromList(plainBytes),
+    );
+
+    return MedicalSharePackage(
+      id: 'pkg:${DateTime.now().millisecondsSinceEpoch}',
+      senderNodeId: 'self',
+      recipientNodeId: recipientNodeId,
+      createdAt: DateTime.now(),
+      expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+      payload: EncryptedMedicalPayload(
+        cipherText: base64Encode(encrypted),
+        iv: _generateIv(),
+        authTag: '',
+      ),
+      metadata: MedicalShareMetadata(
+        packageType: packageType,
+        consentVerified: true,
+        includedCategories: const {},
+        appVersion: '1.0.0',
+      ),
+      signature: '',
+    );
+  }
+
+  /// Decrypt a [MedicalSharePackage] back into a data map.
+  Future<Map<String, dynamic>> decryptPackage(
+      MedicalSharePackage package) async {
+    final encryptedBytes = base64Decode(package.payload.cipherText);
+    final decryptedBytes =
+        await _encryptionService.decryptBytes(encryptedBytes);
+    final jsonStr = utf8.decode(decryptedBytes);
+    return jsonDecode(jsonStr) as Map<String, dynamic>;
+  }
+
   String _generateIv() {
     // IV is handled by EncryptionService; placeholder for non-sensitive payload
     return base64Encode(Uint8List(12));

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1046,18 +1046,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1482,10 +1482,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/ssi/ssi_e2e_test.dart
+++ b/test/features/ssi/ssi_e2e_test.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+
+import 'package:orionhealth_health/features/auth/infrastructure/services/ble_medical_sharing_service.dart';
+import 'package:orionhealth_health/features/auth/infrastructure/services/encryption_service.dart';
+import 'package:orionhealth_health/features/ble_sharing/domain/ble_sharing_service.dart';
+import 'package:orionhealth_health/features/ssi/domain/entities/did.dart';
+import 'package:orionhealth_health/features/ssi/domain/entities/verifiable_credential.dart';
+import 'package:orionhealth_health/features/ssi/domain/repositories/ssi_repository.dart';
+import 'package:orionhealth_health/features/ssi/domain/services/anoncreds_service.dart';
+import 'package:orionhealth_health/features/ssi/infrastructure/services/anoncreds_service_impl.dart';
+import 'package:orionhealth_health/features/ssi/infrastructure/services/ssi_service_impl.dart';
+
+/// Fake SSI Repository for in-memory testing.
+class FakeSsiRepository implements SsiRepository {
+  final Map<String, Did> _dids = {};
+  final Map<String, Map<String, dynamic>> _didDocs = {};
+  final Map<String, VerifiableCredential> _credentials = {};
+
+  @override
+  Future<void> saveDid(Did did, Map<String, dynamic> didDocument) async {
+    _dids[did.did] = did;
+    _didDocs[did.did] = didDocument;
+  }
+
+  @override
+  Future<List<Did>> getDids() async => _dids.values.toList();
+
+  @override
+  Future<Map<String, dynamic>?> getDidDocument(String did) async => _didDocs[did];
+
+  @override
+  Future<void> saveCredential(VerifiableCredential credential) async {
+    _credentials[credential.id] = credential;
+  }
+
+  @override
+  Future<List<VerifiableCredential>> getCredentials() async => _credentials.values.toList();
+
+  @override
+  Future<VerifiableCredential?> getCredentialById(String credentialId) async => _credentials[credentialId];
+
+  @override
+  Future<void> deleteCredential(String credentialId) async {
+    _credentials.remove(credentialId);
+  }
+}
+
+/// Simple Fake Encryption Service that doesn't depend on native plugins.
+class FakeEncryptionService extends Mock implements EncryptionService {
+  @override
+  Future<void> initialize() async {}
+
+  @override
+  Future<Uint8List> encryptBytes(Uint8List data) async {
+    // Identity "encryption" for tests
+    return data;
+  }
+
+  @override
+  Future<Uint8List> decryptBytes(Uint8List encryptedData) async {
+    // Identity "decryption" for tests
+    return encryptedData;
+  }
+
+  @override
+  Future<Uint8List> encrypt(String plaintext) async {
+    return Uint8List.fromList(utf8.encode(plaintext));
+  }
+}
+
+class MockBleSharingService extends Mock implements BleSharingService {}
+
+void main() {
+  late SsiServiceImpl ssiService;
+  late AnonCredsServiceImpl anonCredsService;
+  late BleMedicalSharingService bleSharingService;
+  late FakeSsiRepository repository;
+  late FakeEncryptionService encryptionService;
+  late MockBleSharingService mockBleService;
+
+  setUp(() {
+    repository = FakeSsiRepository();
+    encryptionService = FakeEncryptionService();
+    mockBleService = MockBleSharingService();
+
+    ssiService = SsiServiceImpl(repository);
+    anonCredsService = AnonCredsServiceImpl();
+    bleSharingService = BleMedicalSharingService(
+      mockBleService,
+      encryptionService,
+      ssiService,
+    );
+  });
+
+  group('SSI to BLE E2E Integration', () {
+    test('Full Pipeline: DID -> VC -> AnonCreds -> Verify -> BLE Package', () async {
+      // 1. Setup Identities
+      final issuerDid = await ssiService.createDid();
+      final subjectDid = await ssiService.createDid();
+
+      expect(issuerDid.activeDid, startsWith('did:orion:'));
+      expect(subjectDid.activeDid, startsWith('did:orion:'));
+
+      // 2. Issue Verifiable Credential (Standard)
+      final claims = {
+        'vaccine': 'Pfizer-BioNTech',
+        'lot': 'AA1234',
+        'date': '2023-10-01',
+        'patientName': 'John Doe',
+      };
+
+      final vc = await ssiService.issueCredential(
+        schemaId: 'orion:schemas:VaccinationCredential:v1',
+        subjectDid: subjectDid.activeDid,
+        claims: claims,
+      );
+
+      expect(vc.type, 'VaccinationCredential');
+      expect(await ssiService.verifyCredential(vc), isTrue);
+
+      // 3. Upgrade to AnonCreds & Issue
+      final issuerKeys = await anonCredsService.generateIssuerKeys();
+      final anonCredsVc = await anonCredsService.issueCredential(
+        credential: vc,
+        issuerKeys: issuerKeys,
+        linkSecret: 'my-secret-123',
+      );
+
+      expect(anonCredsVc.proof, contains('Ed25519Signature2020'));
+
+      // 4. Create Selective Disclosure Presentation
+      // We only want to reveal the vaccine name and date, keeping patientName and lot hidden.
+      final disclosedFields = ['vaccine', 'date'];
+      final presentation = await anonCredsService.createPresentation(
+        credential: anonCredsVc,
+        disclosedFields: disclosedFields,
+        linkSecret: 'my-secret-123',
+      );
+
+      expect(presentation.disclosedFields.length, 2);
+      expect(presentation.disclosedFields['vaccine'], 'Pfizer-BioNTech');
+      expect(presentation.disclosedFields['patientName'], isNull);
+      expect(presentation.hiddenCommitments.containsKey('patientName'), isTrue);
+
+      // 5. Verify Presentation
+      final isPresentationValid = await anonCredsService.verifyPresentation(
+        presentation,
+        expectedLinkSecret: 'my-secret-123',
+      );
+      expect(isPresentationValid, isTrue);
+
+      // 6. Simulate BLE Sharing (Encryption/Decryption)
+      // We wrap the AnonCreds presentation in a BLE package
+      final presentationData = presentation.toJson();
+
+      final package = await bleSharingService.encryptPackage(
+        presentationData,
+        packageType: 'VerifiablePresentation',
+        recipientNodeId: 'hospital-node-001',
+      );
+
+      expect(package.metadata.packageType, 'VerifiablePresentation');
+      expect(package.recipientNodeId, 'hospital-node-001');
+
+      // 7. Receive and Decrypt on the other side
+      final receivedData = await bleSharingService.decryptPackage(package);
+      final receivedPresentation = AnonCredsPresentation.fromJson(receivedData);
+
+      expect(receivedPresentation.disclosedFields['vaccine'], 'Pfizer-BioNTech');
+      expect(receivedPresentation.disclosedFields['patientName'], isNull);
+
+      // 8. Re-verify received presentation
+      final isReceivedValid = await anonCredsService.verifyPresentation(
+        receivedPresentation,
+        expectedLinkSecret: 'my-secret-123',
+      );
+      expect(isReceivedValid, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
Implemented an end-to-end integration test that exercises the full medical credential sharing pipeline:
- Create DIDs via SsiServiceImpl.
- Issue a VerifiableCredential (VaccinationRecord).
- Create an AnonCreds presentation with selective disclosure via AnonCredsServiceImpl.
- Verify the presentation.
- Simulate BLE sharing by encrypting and decrypting the package via BleMedicalSharingService.

Also added `encryptPackage` and `decryptPackage` helper methods to `BleMedicalSharingService` to support this flow.

Fixes #188

---
*PR created automatically by Jules for task [9545290744912591172](https://jules.google.com/task/9545290744912591172) started by @iberi22*