### PR TITLE
feat: secp256k1 key support for ION Sidetree

### DIFF
--- a/lib/features/ssi/infrastructure/services/sidetree_anchor_client.dart
+++ b/lib/features/ssi/infrastructure/services/sidetree_anchor_client.dart
@@ -1,10 +1,12 @@
 import 'dart:async';
 import 'dart:convert';
 import 'dart:math';
+import 'dart:typed_data';
 
 import 'package:crypto/crypto.dart';
 import 'package:http/http.dart' as http;
 import 'package:injectable/injectable.dart';
+import 'package:pointycastle/export.dart';
 
 /// ION Sidetree Anchor Client — registers DIDs on the ION network.
 ///
@@ -24,7 +26,7 @@ import 'package:injectable/injectable.dart';
 /// Current implementation:
 ///   - DID resolution via public ION node (FULLY FUNCTIONAL)
 ///   - DID creation skeleton (needs secp256k1 keys)
-///   - Uses Ed25519 as placeholder (ION requires secp256k1)
+///   - Uses secp256k1 for key generation (ION REQUIREMENT)
 ///
 /// Reference: https://identity.foundation/sidetree/spec/
 @lazySingleton
@@ -93,9 +95,9 @@ class SidetreeAnchorClient {
     required List<Map<String, dynamic>> publicKeys,
     List<Map<String, dynamic>> services = const [],
   }) async {
-    // Generate placeholder keys (Ed25519 — ION needs secp256k1, see TODO)
-    final recoveryKey = await _generatePlaceholderKey();
-    final updateKey = await _generatePlaceholderKey();
+    // Generate real secp256k1 keys for ION
+    final recoveryKey = await generateKeyPair();
+    final updateKey = await generateKeyPair();
 
     // Build the DID Document patches
     final patches = <Map<String, dynamic>>[
@@ -123,8 +125,8 @@ class SidetreeAnchorClient {
     // Create the Sidetree Create operation
     final operation = {
       'type': 'create',
-      'suffixData': base64Url.encode(suffixData),
-      'delta': base64Url.encode(delta),
+      'suffixData': base64Url.encode(suffixData).replaceAll('=', ''),
+      'delta': base64Url.encode(delta).replaceAll('=', ''),
     };
 
     // Submit to ION node
@@ -156,35 +158,63 @@ class SidetreeAnchorClient {
 
   /// Generate a key pair for ION operations.
   ///
-  /// NOTE: This currently generates Ed25519 keys. ION REQUIRES secp256k1
-  /// keys (Bitcoin's curve). To fix:
-  ///   1. Add `pointycastle` or `secp256k1` Dart package
-  ///   2. Generate a secp256k1 keypair
-  ///   3. Encode public key in JWK format with "kty": "EC", "crv": "secp256k1"
+  /// Generates a secp256k1 key pair (Bitcoin's curve) and returns it
+  /// in JWK format for the public key and hex format for the private key.
   Future<Map<String, dynamic>> generateKeyPair() async {
-    return _generatePlaceholderKey();
-  }
+    final domainParams = ECDomainParameters('secp256k1');
+    final keyGen = ECKeyGenerator();
 
-  Future<Map<String, dynamic>> _generatePlaceholderKey() async {
     final random = Random.secure();
-    final privateBytes = List<int>.generate(32, (_) => random.nextInt(256));
+    final seed = Uint8List.fromList(List.generate(32, (_) => random.nextInt(256)));
 
-    // Ed25519 public key generation (simplified)
-    final hash = sha256.convert(privateBytes);
-    final publicKeyBytes = base64Url.encode(hash.bytes).substring(0, 43);
+    keyGen.init(ParametersWithRandom(
+      ECKeyGeneratorParameters(domainParams),
+      FortunaRandom()..seed(KeyParameter(seed)),
+    ));
+
+    final pair = keyGen.generateKeyPair();
+    final publicKey = pair.publicKey;
+    final privateKey = pair.privateKey;
+
+    final xBigInt = publicKey.Q!.x!.toBigInteger()!;
+    final yBigInt = publicKey.Q!.y!.toBigInteger()!;
+    final d = privateKey.d!;
+
+    final xBytes = _bigIntToUint8List(xBigInt);
+    final yBytes = _bigIntToUint8List(yBigInt);
+    final privateKeyHex = d.toRadixString(16).padLeft(64, '0');
 
     return {
       'type': 'JsonWebKey2020',
       'id': '#key-${random.nextInt(999999)}',
       'publicKeyJwk': {
-        // TODO: Change to secp256k1:
-        // "kty": "EC", "crv": "secp256k1", "x": "...", "y": "..."
-        'kty': 'OKP',
-        'crv': 'Ed25519',
-        'x': publicKeyBytes,
+        'kty': 'EC',
+        'crv': 'secp256k1',
+        'x': base64Url.encode(xBytes).replaceAll('=', ''),
+        'y': base64Url.encode(yBytes).replaceAll('=', ''),
       },
-      'privateKeyHex': privateBytes.map((b) => b.toRadixString(16).padLeft(2, '0')).join(),
+      'privateKeyHex': privateKeyHex,
     };
+  }
+
+  Uint8List _bigIntToUint8List(BigInt bi) {
+    var hex = bi.toRadixString(16);
+    if (hex.length % 2 != 0) {
+      hex = '0$hex';
+    }
+    // Ensure 32 bytes for secp256k1 coordinates
+    while (hex.length < 64) {
+      hex = '00$hex';
+    }
+    if (hex.length > 64) {
+      hex = hex.substring(hex.length - 64);
+    }
+
+    final result = Uint8List(32);
+    for (var i = 0; i < 32; i++) {
+      result[i] = int.parse(hex.substring(i * 2, i * 2 + 2), radix: 16);
+    }
+    return result;
   }
 
   String _hashPublicKey(Map<String, dynamic> jwk) {

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1046,18 +1046,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1265,6 +1265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.8"
+  pointycastle:
+    dependency: "direct main"
+    description:
+      name: pointycastle
+      sha256: "92aa3841d083cc4b0f4709b5c74fd6409a3e6ba833ffc7dc6a8fee096366acf5"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.0"
   pool:
     dependency: transitive
     description:
@@ -1482,10 +1490,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,6 +79,7 @@ dependencies:
   openai_dart: ^1.0.0
   http: ^1.2.0
   crypto: ^3.0.7
+  pointycastle: ^4.0.0
   
 dev_dependencies:
   flutter_test:

--- a/test/features/ssi/sidetree_anchor_client_test.dart
+++ b/test/features/ssi/sidetree_anchor_client_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/ssi/infrastructure/services/sidetree_anchor_client.dart';
+
+void main() {
+  group('SidetreeAnchorClient Key Generation', () {
+    final client = SidetreeAnchorClient();
+
+    test('generateKeyPair() returns valid secp256k1 JWK', () async {
+      final keyPair = await client.generateKeyPair();
+
+      expect(keyPair['type'], 'JsonWebKey2020');
+      expect(keyPair['publicKeyJwk'], isNotNull);
+
+      final jwk = keyPair['publicKeyJwk'] as Map<String, dynamic>;
+      expect(jwk['kty'], 'EC');
+      expect(jwk['crv'], 'secp256k1');
+      expect(jwk['x'], isNotNull);
+      expect(jwk['y'], isNotNull);
+
+      // x and y should be 43 characters (base64url for 32 bytes)
+      expect((jwk['x'] as String).length, 43);
+      expect((jwk['y'] as String).length, 43);
+
+      expect(keyPair['privateKeyHex'], isNotNull);
+      expect((keyPair['privateKeyHex'] as String).length, 64); // 32 bytes hex
+    });
+
+    test('generateKeyPair() generates unique keys', () async {
+      final key1 = await client.generateKeyPair();
+      final key2 = await client.generateKeyPair();
+
+      expect(key1['privateKeyHex'], isNot(key2['privateKeyHex']));
+      expect(key1['publicKeyJwk']['x'], isNot(key2['publicKeyJwk']['x']));
+    });
+  });
+}


### PR DESCRIPTION
This PR replaces the placeholder Ed25519 key generation in `SidetreeAnchorClient` with a production-ready `secp256k1` implementation (Bitcoin curve) as required by the ION Sidetree specification.

Key changes:
- Integrated `pointycastle` for cryptographic operations.
- Implemented `generateKeyPair()` to produce `secp256k1` keys in JWK format.
- Ensured coordinates (x, y) and private key (d) are correctly extracted and padded to 32 bytes.
- Updated `createDid()` to utilize these real keys for ION anchoring operations.
- Added a new test suite `test/features/ssi/sidetree_anchor_client_test.dart` to verify JWK format and uniqueness.
- Verified that existing SSI tests pass and `dart analyze` is clean.

Fixes #189

---
*PR created automatically by Jules for task [14194666936652993692](https://jules.google.com/task/14194666936652993692) started by @iberi22*