### PR TITLE
Fix DeviceCapabilityService to recommend local models instead of cloud models

### DIFF
--- a/lib/features/settings/domain/services/device_capability_service.dart
+++ b/lib/features/settings/domain/services/device_capability_service.dart
@@ -275,13 +275,19 @@ class DeviceCapabilityService {
   }
 
   String _getRecommendedModel(DeviceCapabilityTier tier) {
+    final recommendedLocal = getRecommendedLocalModel();
+    if (recommendedLocal != null) {
+      return recommendedLocal;
+    }
+
+    // Fallback based on tier if no local model found
     switch (tier) {
       case DeviceCapabilityTier.high:
-        return 'gemini-2.5-flash';
+        return 'phi-4-mini';
       case DeviceCapabilityTier.medium:
-        return 'gemini-2.0-flash';
+        return 'deepseek-r1';
       case DeviceCapabilityTier.low:
-        return 'gemini-2.0-flash-lite';
+        return 'smolLM-135m';
     }
   }
 

--- a/test/features/settings/domain/services/device_capability_service_test.dart
+++ b/test/features/settings/domain/services/device_capability_service_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/settings/domain/services/device_capability_service.dart';
+
+void main() {
+  late DeviceCapabilityService service;
+
+  setUp(() {
+    service = DeviceCapabilityService();
+  });
+
+  group('DeviceCapabilityService', () {
+    test('detectCapability returns a local model instead of cloud', () async {
+      final capability = await service.detectCapability();
+
+      // Known cloud models that should NOT be returned
+      final cloudModels = [
+        'gemini-2.5-flash',
+        'gemini-2.0-flash',
+        'gemini-2.0-flash-lite',
+      ];
+
+      expect(
+        cloudModels.contains(capability.recommendedModel),
+        isFalse,
+        reason: 'Should not recommend cloud model ${capability.recommendedModel}'
+      );
+
+      // Should be one of the local models
+      final localModelIds = availableLocalModelDefs.map((m) => m.id).toList();
+      expect(
+        localModelIds.contains(capability.recommendedModel),
+        isTrue,
+        reason: 'Should recommend a local model, but got ${capability.recommendedModel}'
+      );
+    });
+  });
+}


### PR DESCRIPTION
This PR fixes an issue where `DeviceCapabilityService._getRecommendedModel()` was returning cloud-based Gemini models instead of the optimal local models for the device. 

Key changes:
- `_getRecommendedModel` now calls `getRecommendedLocalModel()` first.
- If no recommendation is found via filtering, it falls back to a tier-based selection of local models (phi-4-mini, deepseek-r1, or smolLM-135m) instead of cloud models.
- Added a new unit test suite in `test/features/settings/domain/services/device_capability_service_test.dart` to ensure `detectCapability()` correctly identifies and recommends local models based on the device's capabilities.
- Verified that all existing tests in `test/core/services/device_capability_service_test.dart` still pass.

Fixes #219

---
*PR created automatically by Jules for task [15197889706565293470](https://jules.google.com/task/15197889706565293470) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized device capability detection and model recommendation system to prioritize locally available models based on your device's specific capabilities, providing better-tailored model suggestions.

* **Tests**
  * Added new test suite for device capability detection to validate model recommendation behavior and ensure proper compatibility with available local models on your device.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/OrionHealth/pull/220)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->