### PR TITLE
Wire 'Use' button to activate local LLM model

### DIFF
--- a/lib/features/settings/presentation/pages/llm_settings_page.dart
+++ b/lib/features/settings/presentation/pages/llm_settings_page.dart
@@ -5,6 +5,8 @@ import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
 import '../../application/llm_settings_cubit.dart';
 import '../../domain/services/device_capability_service.dart';
+import '../../../local_agent/domain/services/llm_adapter.dart';
+import '../../../local_agent/infrastructure/adapters/flutter_gemma_adapter.dart';
 
 // ---------------------------------------------------------------------------
 // Constants
@@ -453,14 +455,37 @@ class _ModelListItem extends StatelessWidget {
                 _actionButton(
                   label: 'Usar',
                   icon: Icons.play_arrow,
-                  onTap: () {
-                    context
+                  onTap: () async {
+                    final adapter = getIt<LlmAdapter>(instanceName: 'gemma')
+                        as FlutterGemmaAdapter;
+
+                    final isInstalled = await adapter.isModelInstalled(modelId);
+
+                    if (!context.mounted) return;
+
+                    if (!isInstalled) {
+                      ScaffoldMessenger.of(context).showSnackBar(
+                        SnackBar(
+                          content: Text('El modelo $modelName no está instalado'),
+                          backgroundColor: Colors.orangeAccent,
+                          duration: const Duration(seconds: 2),
+                        ),
+                      );
+                      return;
+                    }
+
+                    await context
                         .read<LlmSettingsCubit>()
                         .updateLocalModel(modelId);
+                    await adapter.reloadActiveModel();
+
+                    if (!context.mounted) return;
+
                     ScaffoldMessenger.of(context).showSnackBar(
                       SnackBar(
-                        content: Text('Usando $modelName'),
-                        backgroundColor: AppColors.primary.withValues(alpha: 0.71),
+                        content: Text('$modelName activado para inferencia'),
+                        backgroundColor:
+                            AppColors.primary.withValues(alpha: 0.71),
                         duration: const Duration(seconds: 1),
                       ),
                     );


### PR DESCRIPTION
Updated the "Usar" (Use) button in `LlmSettingsPage` to activate the selected local model for inference. The button now checks if the model is installed using `FlutterGemmaAdapter.isModelInstalled()` and reloads it into the inference engine via `FlutterGemmaAdapter.reloadActiveModel()`. Added necessary imports and error/success feedback via SnackBars.

Fixes #218

---
*PR created automatically by Jules for task [2461309629119137576](https://jules.google.com/task/2461309629119137576) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced local model selection with installation verification before use.
  * Added error notifications when a model fails to load and confirmation feedback on successful selection.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/OrionHealth/pull/221)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->