### PR TITLE
Add drug interaction dataset for RxNorm codes

### DIFF
--- a/assets/medical-standards/drug_interactions.json
+++ b/assets/medical-standards/drug_interactions.json
@@ -1,0 +1,2364 @@
+{
+  "metadata": {
+    "standard": "Drug-Drug Interactions",
+    "version": "1.1.0",
+    "lastUpdated": "2026-05-13",
+    "source": "OrionHealth Internal Safety DB",
+    "totalCount": 181
+  },
+  "data": [
+    {
+      "drugA": {
+        "code": "10324",
+        "name": "Tamoxifen"
+      },
+      "drugB": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "severity": "major",
+      "description": "Reduced clinical efficacy of tamoxifen in breast cancer prevention.",
+      "mechanism": "Inhibition of CYP2D6 prevents conversion of tamoxifen to its active metabolites."
+    },
+    {
+      "drugA": {
+        "code": "10324",
+        "name": "Tamoxifen"
+      },
+      "drugB": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "severity": "major",
+      "description": "Reduced clinical efficacy of tamoxifen in breast cancer prevention.",
+      "mechanism": "Inhibition of CYP2D6 prevents conversion of tamoxifen to its active metabolites."
+    },
+    {
+      "drugA": {
+        "code": "10324",
+        "name": "Tamoxifen"
+      },
+      "drugB": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "severity": "major",
+      "description": "Reduced clinical efficacy of tamoxifen in breast cancer prevention.",
+      "mechanism": "Inhibition of CYP2D6 prevents conversion of tamoxifen to its active metabolites."
+    },
+    {
+      "drugA": {
+        "code": "1039156",
+        "name": "Apixaban"
+      },
+      "drugB": {
+        "code": "1191",
+        "name": "Aspirin"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "1039156",
+        "name": "Apixaban"
+      },
+      "drugB": {
+        "code": "32968",
+        "name": "Clopidogrel"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "1039156",
+        "name": "Apixaban"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "1039156",
+        "name": "Apixaban"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "1039156",
+        "name": "Apixaban"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "10582",
+        "name": "Levothyroxine"
+      },
+      "drugB": {
+        "code": "1897",
+        "name": "Calcium carbonate"
+      },
+      "severity": "moderate",
+      "description": "Reduced drug absorption leading to therapeutic failure.",
+      "mechanism": "Formation of insoluble chelates in the gastrointestinal tract."
+    },
+    {
+      "drugA": {
+        "code": "1114195",
+        "name": "Rivaroxaban"
+      },
+      "drugB": {
+        "code": "1191",
+        "name": "Aspirin"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "1114195",
+        "name": "Rivaroxaban"
+      },
+      "drugB": {
+        "code": "32968",
+        "name": "Clopidogrel"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "1114195",
+        "name": "Rivaroxaban"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "1114195",
+        "name": "Rivaroxaban"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "1114195",
+        "name": "Rivaroxaban"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "1191",
+        "name": "Aspirin"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "18631",
+        "name": "Azithromycin"
+      },
+      "severity": "major",
+      "description": "Enhanced anticoagulant effect increases bleeding risk significantly.",
+      "mechanism": "Inhibition of CYP450 enzymes and alteration of Vitamin K-producing gut flora."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "21212",
+        "name": "Clarithromycin"
+      },
+      "severity": "major",
+      "description": "Enhanced anticoagulant effect increases bleeding risk significantly.",
+      "mechanism": "Inhibition of CYP450 enzymes and alteration of Vitamin K-producing gut flora."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "2551",
+        "name": "Ciprofloxacin"
+      },
+      "severity": "major",
+      "description": "Enhanced anticoagulant effect increases bleeding risk significantly.",
+      "mechanism": "Inhibition of CYP450 enzymes and alteration of Vitamin K-producing gut flora."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "32968",
+        "name": "Clopidogrel"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "major",
+      "description": "Increased risk of serious gastrointestinal bleeding and systemic hemorrhage.",
+      "mechanism": "Synergistic effect on coagulation cascade and platelet aggregation inhibition."
+    },
+    {
+      "drugA": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "drugB": {
+        "code": "82122",
+        "name": "Levofloxacin"
+      },
+      "severity": "major",
+      "description": "Enhanced anticoagulant effect increases bleeding risk significantly.",
+      "mechanism": "Inhibition of CYP450 enzymes and alteration of Vitamin K-producing gut flora."
+    },
+    {
+      "drugA": {
+        "code": "1202",
+        "name": "Atenolol"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "1202",
+        "name": "Atenolol"
+      },
+      "drugB": {
+        "code": "145507",
+        "name": "Glimepiride"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "1202",
+        "name": "Atenolol"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "1202",
+        "name": "Atenolol"
+      },
+      "drugB": {
+        "code": "4820",
+        "name": "Gliclazide"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "135561",
+        "name": "Sildenafil"
+      },
+      "drugB": {
+        "code": "35827",
+        "name": "Isosorbide mononitrate"
+      },
+      "severity": "major",
+      "description": "Severe, potentially fatal hypotension. Co-administration is strictly contraindicated.",
+      "mechanism": "Potentiation of nitric oxide-mediated vasodilation via cGMP accumulation."
+    },
+    {
+      "drugA": {
+        "code": "135561",
+        "name": "Sildenafil"
+      },
+      "drugB": {
+        "code": "7434",
+        "name": "Nitroglycerin"
+      },
+      "severity": "major",
+      "description": "Severe, potentially fatal hypotension. Co-administration is strictly contraindicated.",
+      "mechanism": "Potentiation of nitric oxide-mediated vasodilation via cGMP accumulation."
+    },
+    {
+      "drugA": {
+        "code": "1488564",
+        "name": "Dapagliflozin"
+      },
+      "drugB": {
+        "code": "4603",
+        "name": "Furosemide"
+      },
+      "severity": "minor",
+      "description": "Increased risk of volume depletion, hypotension, and electrolyte disturbances.",
+      "mechanism": "Additive osmotic and pharmacological diuretic effects."
+    },
+    {
+      "drugA": {
+        "code": "1488564",
+        "name": "Dapagliflozin"
+      },
+      "drugB": {
+        "code": "5487",
+        "name": "Hydrochlorothiazide"
+      },
+      "severity": "minor",
+      "description": "Increased risk of volume depletion, hypotension, and electrolyte disturbances.",
+      "mechanism": "Additive osmotic and pharmacological diuretic effects."
+    },
+    {
+      "drugA": {
+        "code": "1488564",
+        "name": "Dapagliflozin"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "minor",
+      "description": "Increased risk of volume depletion, hypotension, and electrolyte disturbances.",
+      "mechanism": "Additive osmotic and pharmacological diuretic effects."
+    },
+    {
+      "drugA": {
+        "code": "153165",
+        "name": "Esomeprazole"
+      },
+      "drugB": {
+        "code": "32968",
+        "name": "Clopidogrel"
+      },
+      "severity": "moderate",
+      "description": "Reduced antiplatelet efficacy of clopidogrel, increasing cardiovascular risk.",
+      "mechanism": "Inhibition of CYP2C19 prevents conversion of clopidogrel to its active form."
+    },
+    {
+      "drugA": {
+        "code": "1545631",
+        "name": "Empagliflozin"
+      },
+      "drugB": {
+        "code": "4603",
+        "name": "Furosemide"
+      },
+      "severity": "minor",
+      "description": "Increased risk of volume depletion, hypotension, and electrolyte disturbances.",
+      "mechanism": "Additive osmotic and pharmacological diuretic effects."
+    },
+    {
+      "drugA": {
+        "code": "1545631",
+        "name": "Empagliflozin"
+      },
+      "drugB": {
+        "code": "5487",
+        "name": "Hydrochlorothiazide"
+      },
+      "severity": "minor",
+      "description": "Increased risk of volume depletion, hypotension, and electrolyte disturbances.",
+      "mechanism": "Additive osmotic and pharmacological diuretic effects."
+    },
+    {
+      "drugA": {
+        "code": "1545631",
+        "name": "Empagliflozin"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "minor",
+      "description": "Increased risk of volume depletion, hypotension, and electrolyte disturbances.",
+      "mechanism": "Additive osmotic and pharmacological diuretic effects."
+    },
+    {
+      "drugA": {
+        "code": "1603",
+        "name": "Bisoprolol"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "1603",
+        "name": "Bisoprolol"
+      },
+      "drugB": {
+        "code": "145507",
+        "name": "Glimepiride"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "1603",
+        "name": "Bisoprolol"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "1603",
+        "name": "Bisoprolol"
+      },
+      "drugB": {
+        "code": "4820",
+        "name": "Gliclazide"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "18631",
+        "name": "Azithromycin"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "moderate",
+      "description": "Potential for severe hypotension and acute kidney injury.",
+      "mechanism": "Inhibition of CYP3A4-mediated metabolism of calcium channel blockers."
+    },
+    {
+      "drugA": {
+        "code": "18631",
+        "name": "Azithromycin"
+      },
+      "drugB": {
+        "code": "17767",
+        "name": "Amlodipine"
+      },
+      "severity": "moderate",
+      "description": "Potential for severe hypotension and acute kidney injury.",
+      "mechanism": "Inhibition of CYP3A4-mediated metabolism of calcium channel blockers."
+    },
+    {
+      "drugA": {
+        "code": "18631",
+        "name": "Azithromycin"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "moderate",
+      "description": "Potential for severe hypotension and acute kidney injury.",
+      "mechanism": "Inhibition of CYP3A4-mediated metabolism of calcium channel blockers."
+    },
+    {
+      "drugA": {
+        "code": "18631",
+        "name": "Azithromycin"
+      },
+      "drugB": {
+        "code": "7424",
+        "name": "Nifedipine"
+      },
+      "severity": "moderate",
+      "description": "Potential for severe hypotension and acute kidney injury.",
+      "mechanism": "Inhibition of CYP3A4-mediated metabolism of calcium channel blockers."
+    },
+    {
+      "drugA": {
+        "code": "19001",
+        "name": "Irbesartan"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "19001",
+        "name": "Irbesartan"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "19001",
+        "name": "Irbesartan"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "19001",
+        "name": "Irbesartan"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "major",
+      "description": "Combination increases risk of life-threatening hyperkalemia.",
+      "mechanism": "Additive potassium-sparing effects in the distal nephron."
+    },
+    {
+      "drugA": {
+        "code": "1998",
+        "name": "Captopril"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "1998",
+        "name": "Captopril"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "1998",
+        "name": "Captopril"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "1998",
+        "name": "Captopril"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "major",
+      "description": "Combination increases risk of life-threatening hyperkalemia.",
+      "mechanism": "Additive potassium-sparing effects in the distal nephron."
+    },
+    {
+      "drugA": {
+        "code": "2002",
+        "name": "Carbamazepine"
+      },
+      "drugB": {
+        "code": "1039156",
+        "name": "Apixaban"
+      },
+      "severity": "moderate",
+      "description": "Reduced efficacy of the co-administered drug.",
+      "mechanism": "Induction of hepatic enzymes (CYP3A4) increases drug metabolism."
+    },
+    {
+      "drugA": {
+        "code": "2002",
+        "name": "Carbamazepine"
+      },
+      "drugB": {
+        "code": "1114195",
+        "name": "Rivaroxaban"
+      },
+      "severity": "moderate",
+      "description": "Reduced efficacy of the co-administered drug.",
+      "mechanism": "Induction of hepatic enzymes (CYP3A4) increases drug metabolism."
+    },
+    {
+      "drugA": {
+        "code": "2002",
+        "name": "Carbamazepine"
+      },
+      "drugB": {
+        "code": "11289",
+        "name": "Warfarin"
+      },
+      "severity": "moderate",
+      "description": "Reduced efficacy of the co-administered drug.",
+      "mechanism": "Induction of hepatic enzymes (CYP3A4) increases drug metabolism."
+    },
+    {
+      "drugA": {
+        "code": "2002",
+        "name": "Carbamazepine"
+      },
+      "drugB": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "severity": "moderate",
+      "description": "Reduced efficacy of the co-administered drug.",
+      "mechanism": "Induction of hepatic enzymes (CYP3A4) increases drug metabolism."
+    },
+    {
+      "drugA": {
+        "code": "2002",
+        "name": "Carbamazepine"
+      },
+      "drugB": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "severity": "moderate",
+      "description": "Reduced efficacy of the co-administered drug.",
+      "mechanism": "Induction of hepatic enzymes (CYP3A4) increases drug metabolism."
+    },
+    {
+      "drugA": {
+        "code": "2002",
+        "name": "Carbamazepine"
+      },
+      "drugB": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "severity": "moderate",
+      "description": "Reduced efficacy of the co-administered drug.",
+      "mechanism": "Induction of hepatic enzymes (CYP3A4) increases drug metabolism."
+    },
+    {
+      "drugA": {
+        "code": "2002",
+        "name": "Carbamazepine"
+      },
+      "drugB": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "severity": "moderate",
+      "description": "Reduced efficacy of the co-administered drug.",
+      "mechanism": "Induction of hepatic enzymes (CYP3A4) increases drug metabolism."
+    },
+    {
+      "drugA": {
+        "code": "20352",
+        "name": "Carvedilol"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "20352",
+        "name": "Carvedilol"
+      },
+      "drugB": {
+        "code": "145507",
+        "name": "Glimepiride"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "20352",
+        "name": "Carvedilol"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "20352",
+        "name": "Carvedilol"
+      },
+      "drugB": {
+        "code": "4820",
+        "name": "Gliclazide"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "21212",
+        "name": "Clarithromycin"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "moderate",
+      "description": "Potential for severe hypotension and acute kidney injury.",
+      "mechanism": "Inhibition of CYP3A4-mediated metabolism of calcium channel blockers."
+    },
+    {
+      "drugA": {
+        "code": "21212",
+        "name": "Clarithromycin"
+      },
+      "drugB": {
+        "code": "17767",
+        "name": "Amlodipine"
+      },
+      "severity": "moderate",
+      "description": "Potential for severe hypotension and acute kidney injury.",
+      "mechanism": "Inhibition of CYP3A4-mediated metabolism of calcium channel blockers."
+    },
+    {
+      "drugA": {
+        "code": "21212",
+        "name": "Clarithromycin"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "moderate",
+      "description": "Potential for severe hypotension and acute kidney injury.",
+      "mechanism": "Inhibition of CYP3A4-mediated metabolism of calcium channel blockers."
+    },
+    {
+      "drugA": {
+        "code": "21212",
+        "name": "Clarithromycin"
+      },
+      "drugB": {
+        "code": "7424",
+        "name": "Nifedipine"
+      },
+      "severity": "moderate",
+      "description": "Potential for severe hypotension and acute kidney injury.",
+      "mechanism": "Inhibition of CYP3A4-mediated metabolism of calcium channel blockers."
+    },
+    {
+      "drugA": {
+        "code": "214354",
+        "name": "Candesartan"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "214354",
+        "name": "Candesartan"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "214354",
+        "name": "Candesartan"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "214354",
+        "name": "Candesartan"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "major",
+      "description": "Combination increases risk of life-threatening hyperkalemia.",
+      "mechanism": "Additive potassium-sparing effects in the distal nephron."
+    },
+    {
+      "drugA": {
+        "code": "236430",
+        "name": "Duloxetine"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "High risk of serotonin syndrome, characterized by mental status changes and neuromuscular hyperactivity.",
+      "mechanism": "Additive serotonergic effects via reuptake inhibition and direct receptor stimulation."
+    },
+    {
+      "drugA": {
+        "code": "236430",
+        "name": "Duloxetine"
+      },
+      "drugB": {
+        "code": "704",
+        "name": "Amitriptyline"
+      },
+      "severity": "moderate",
+      "description": "Risk of serotonin syndrome and increased levels of tricyclic antidepressants.",
+      "mechanism": "Additive pharmacodynamic effects and inhibition of hepatic metabolism."
+    },
+    {
+      "drugA": {
+        "code": "236430",
+        "name": "Duloxetine"
+      },
+      "drugB": {
+        "code": "8123",
+        "name": "Phenelzine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "236430",
+        "name": "Duloxetine"
+      },
+      "drugB": {
+        "code": "9744",
+        "name": "Selegiline"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "2551",
+        "name": "Ciprofloxacin"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "Possible increased risk of CNS stimulation and convulsive seizures.",
+      "mechanism": "Antagonism of GABA-mediated inhibitory neurotransmission."
+    },
+    {
+      "drugA": {
+        "code": "2551",
+        "name": "Ciprofloxacin"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "Possible increased risk of CNS stimulation and convulsive seizures.",
+      "mechanism": "Antagonism of GABA-mediated inhibitory neurotransmission."
+    },
+    {
+      "drugA": {
+        "code": "2551",
+        "name": "Ciprofloxacin"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "Possible increased risk of CNS stimulation and convulsive seizures.",
+      "mechanism": "Antagonism of GABA-mediated inhibitory neurotransmission."
+    },
+    {
+      "drugA": {
+        "code": "2598",
+        "name": "Clonazepam"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "2598",
+        "name": "Clonazepam"
+      },
+      "drugB": {
+        "code": "7052",
+        "name": "Morphine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "2598",
+        "name": "Clonazepam"
+      },
+      "drugB": {
+        "code": "7804",
+        "name": "Oxycodone"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "29046",
+        "name": "Lisinopril"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "29046",
+        "name": "Lisinopril"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "29046",
+        "name": "Lisinopril"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "29046",
+        "name": "Lisinopril"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "major",
+      "description": "Combination increases risk of life-threatening hyperkalemia.",
+      "mechanism": "Additive potassium-sparing effects in the distal nephron."
+    },
+    {
+      "drugA": {
+        "code": "301542",
+        "name": "Rosuvastatin"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "moderate",
+      "description": "Increased serum statin levels and risk of muscle-related side effects.",
+      "mechanism": "CYP3A4 inhibition by diltiazem or verapamil slows statin metabolism."
+    },
+    {
+      "drugA": {
+        "code": "301542",
+        "name": "Rosuvastatin"
+      },
+      "drugB": {
+        "code": "18631",
+        "name": "Azithromycin"
+      },
+      "severity": "major",
+      "description": "Increased risk of myopathy and potentially fatal rhabdomyolysis.",
+      "mechanism": "CYP3A4 inhibition increases statin serum concentrations to toxic levels."
+    },
+    {
+      "drugA": {
+        "code": "301542",
+        "name": "Rosuvastatin"
+      },
+      "drugB": {
+        "code": "21212",
+        "name": "Clarithromycin"
+      },
+      "severity": "major",
+      "description": "Increased risk of myopathy and potentially fatal rhabdomyolysis.",
+      "mechanism": "CYP3A4 inhibition increases statin serum concentrations to toxic levels."
+    },
+    {
+      "drugA": {
+        "code": "301542",
+        "name": "Rosuvastatin"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "moderate",
+      "description": "Increased serum statin levels and risk of muscle-related side effects.",
+      "mechanism": "CYP3A4 inhibition by diltiazem or verapamil slows statin metabolism."
+    },
+    {
+      "drugA": {
+        "code": "321207",
+        "name": "Tadalafil"
+      },
+      "drugB": {
+        "code": "35827",
+        "name": "Isosorbide mononitrate"
+      },
+      "severity": "major",
+      "description": "Severe, potentially fatal hypotension. Co-administration is strictly contraindicated.",
+      "mechanism": "Potentiation of nitric oxide-mediated vasodilation via cGMP accumulation."
+    },
+    {
+      "drugA": {
+        "code": "321207",
+        "name": "Tadalafil"
+      },
+      "drugB": {
+        "code": "7434",
+        "name": "Nitroglycerin"
+      },
+      "severity": "major",
+      "description": "Severe, potentially fatal hypotension. Co-administration is strictly contraindicated.",
+      "mechanism": "Potentiation of nitric oxide-mediated vasodilation via cGMP accumulation."
+    },
+    {
+      "drugA": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "High risk of serotonin syndrome, characterized by mental status changes and neuromuscular hyperactivity.",
+      "mechanism": "Additive serotonergic effects via reuptake inhibition and direct receptor stimulation."
+    },
+    {
+      "drugA": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "drugB": {
+        "code": "11002",
+        "name": "Valproic acid"
+      },
+      "severity": "moderate",
+      "description": "Increased plasma concentrations of valproate, potentially increasing toxicity.",
+      "mechanism": "Inhibition of valproate metabolism by certain SSRIs."
+    },
+    {
+      "drugA": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "drugB": {
+        "code": "704",
+        "name": "Amitriptyline"
+      },
+      "severity": "moderate",
+      "description": "Risk of serotonin syndrome and increased levels of tricyclic antidepressants.",
+      "mechanism": "Additive pharmacodynamic effects and inhibition of hepatic metabolism."
+    },
+    {
+      "drugA": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "drugB": {
+        "code": "8123",
+        "name": "Phenelzine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "321988",
+        "name": "Escitalopram"
+      },
+      "drugB": {
+        "code": "9744",
+        "name": "Selegiline"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "3322",
+        "name": "Diazepam"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "3322",
+        "name": "Diazepam"
+      },
+      "drugB": {
+        "code": "7052",
+        "name": "Morphine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "3322",
+        "name": "Diazepam"
+      },
+      "drugB": {
+        "code": "7804",
+        "name": "Oxycodone"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "3407",
+        "name": "Digoxin"
+      },
+      "drugB": {
+        "code": "4603",
+        "name": "Furosemide"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of digoxin toxicity due to electrolyte imbalances.",
+      "mechanism": "Hypokalemia and hypomagnesemia sensitize the myocardium to digoxin."
+    },
+    {
+      "drugA": {
+        "code": "3407",
+        "name": "Digoxin"
+      },
+      "drugB": {
+        "code": "5487",
+        "name": "Hydrochlorothiazide"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of digoxin toxicity due to electrolyte imbalances.",
+      "mechanism": "Hypokalemia and hypomagnesemia sensitize the myocardium to digoxin."
+    },
+    {
+      "drugA": {
+        "code": "3521",
+        "name": "Ramipril"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "3521",
+        "name": "Ramipril"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "3521",
+        "name": "Ramipril"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "3521",
+        "name": "Ramipril"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "major",
+      "description": "Combination increases risk of life-threatening hyperkalemia.",
+      "mechanism": "Additive potassium-sparing effects in the distal nephron."
+    },
+    {
+      "drugA": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "High risk of serotonin syndrome, characterized by mental status changes and neuromuscular hyperactivity.",
+      "mechanism": "Additive serotonergic effects via reuptake inhibition and direct receptor stimulation."
+    },
+    {
+      "drugA": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "drugB": {
+        "code": "11002",
+        "name": "Valproic acid"
+      },
+      "severity": "moderate",
+      "description": "Increased plasma concentrations of valproate, potentially increasing toxicity.",
+      "mechanism": "Inhibition of valproate metabolism by certain SSRIs."
+    },
+    {
+      "drugA": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "drugB": {
+        "code": "704",
+        "name": "Amitriptyline"
+      },
+      "severity": "moderate",
+      "description": "Risk of serotonin syndrome and increased levels of tricyclic antidepressants.",
+      "mechanism": "Additive pharmacodynamic effects and inhibition of hepatic metabolism."
+    },
+    {
+      "drugA": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "drugB": {
+        "code": "8123",
+        "name": "Phenelzine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "36437",
+        "name": "Sertraline"
+      },
+      "drugB": {
+        "code": "9744",
+        "name": "Selegiline"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "36567",
+        "name": "Simvastatin"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "moderate",
+      "description": "Increased serum statin levels and risk of muscle-related side effects.",
+      "mechanism": "CYP3A4 inhibition by diltiazem or verapamil slows statin metabolism."
+    },
+    {
+      "drugA": {
+        "code": "36567",
+        "name": "Simvastatin"
+      },
+      "drugB": {
+        "code": "18631",
+        "name": "Azithromycin"
+      },
+      "severity": "major",
+      "description": "Increased risk of myopathy and potentially fatal rhabdomyolysis.",
+      "mechanism": "CYP3A4 inhibition increases statin serum concentrations to toxic levels."
+    },
+    {
+      "drugA": {
+        "code": "36567",
+        "name": "Simvastatin"
+      },
+      "drugB": {
+        "code": "21212",
+        "name": "Clarithromycin"
+      },
+      "severity": "major",
+      "description": "Increased risk of myopathy and potentially fatal rhabdomyolysis.",
+      "mechanism": "CYP3A4 inhibition increases statin serum concentrations to toxic levels."
+    },
+    {
+      "drugA": {
+        "code": "36567",
+        "name": "Simvastatin"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "moderate",
+      "description": "Increased serum statin levels and risk of muscle-related side effects.",
+      "mechanism": "CYP3A4 inhibition by diltiazem or verapamil slows statin metabolism."
+    },
+    {
+      "drugA": {
+        "code": "3827",
+        "name": "Enalapril"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "3827",
+        "name": "Enalapril"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "3827",
+        "name": "Enalapril"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "3827",
+        "name": "Enalapril"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "major",
+      "description": "Combination increases risk of life-threatening hyperkalemia.",
+      "mechanism": "Additive potassium-sparing effects in the distal nephron."
+    },
+    {
+      "drugA": {
+        "code": "39786",
+        "name": "Venlafaxine"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "High risk of serotonin syndrome, characterized by mental status changes and neuromuscular hyperactivity.",
+      "mechanism": "Additive serotonergic effects via reuptake inhibition and direct receptor stimulation."
+    },
+    {
+      "drugA": {
+        "code": "39786",
+        "name": "Venlafaxine"
+      },
+      "drugB": {
+        "code": "704",
+        "name": "Amitriptyline"
+      },
+      "severity": "moderate",
+      "description": "Risk of serotonin syndrome and increased levels of tricyclic antidepressants.",
+      "mechanism": "Additive pharmacodynamic effects and inhibition of hepatic metabolism."
+    },
+    {
+      "drugA": {
+        "code": "39786",
+        "name": "Venlafaxine"
+      },
+      "drugB": {
+        "code": "8123",
+        "name": "Phenelzine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "39786",
+        "name": "Venlafaxine"
+      },
+      "drugB": {
+        "code": "9744",
+        "name": "Selegiline"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "40188",
+        "name": "Losartan"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "40188",
+        "name": "Losartan"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "40188",
+        "name": "Losartan"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "40188",
+        "name": "Losartan"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "major",
+      "description": "Combination increases risk of life-threatening hyperkalemia.",
+      "mechanism": "Additive potassium-sparing effects in the distal nephron."
+    },
+    {
+      "drugA": {
+        "code": "42463",
+        "name": "Pravastatin"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "moderate",
+      "description": "Increased serum statin levels and risk of muscle-related side effects.",
+      "mechanism": "CYP3A4 inhibition by diltiazem or verapamil slows statin metabolism."
+    },
+    {
+      "drugA": {
+        "code": "42463",
+        "name": "Pravastatin"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "moderate",
+      "description": "Increased serum statin levels and risk of muscle-related side effects.",
+      "mechanism": "CYP3A4 inhibition by diltiazem or verapamil slows statin metabolism."
+    },
+    {
+      "drugA": {
+        "code": "4450",
+        "name": "Alendronate"
+      },
+      "drugB": {
+        "code": "1897",
+        "name": "Calcium carbonate"
+      },
+      "severity": "moderate",
+      "description": "Reduced drug absorption leading to therapeutic failure.",
+      "mechanism": "Formation of insoluble chelates in the gastrointestinal tract."
+    },
+    {
+      "drugA": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "High risk of serotonin syndrome, characterized by mental status changes and neuromuscular hyperactivity.",
+      "mechanism": "Additive serotonergic effects via reuptake inhibition and direct receptor stimulation."
+    },
+    {
+      "drugA": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "drugB": {
+        "code": "11002",
+        "name": "Valproic acid"
+      },
+      "severity": "moderate",
+      "description": "Increased plasma concentrations of valproate, potentially increasing toxicity.",
+      "mechanism": "Inhibition of valproate metabolism by certain SSRIs."
+    },
+    {
+      "drugA": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "drugB": {
+        "code": "704",
+        "name": "Amitriptyline"
+      },
+      "severity": "moderate",
+      "description": "Risk of serotonin syndrome and increased levels of tricyclic antidepressants.",
+      "mechanism": "Additive pharmacodynamic effects and inhibition of hepatic metabolism."
+    },
+    {
+      "drugA": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "drugB": {
+        "code": "8123",
+        "name": "Phenelzine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "4493",
+        "name": "Fluoxetine"
+      },
+      "drugB": {
+        "code": "9744",
+        "name": "Selegiline"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "596",
+        "name": "Alprazolam"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "596",
+        "name": "Alprazolam"
+      },
+      "drugB": {
+        "code": "7052",
+        "name": "Morphine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "596",
+        "name": "Alprazolam"
+      },
+      "drugB": {
+        "code": "7804",
+        "name": "Oxycodone"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "6470",
+        "name": "Lorazepam"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "6470",
+        "name": "Lorazepam"
+      },
+      "drugB": {
+        "code": "7052",
+        "name": "Morphine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "6470",
+        "name": "Lorazepam"
+      },
+      "drugB": {
+        "code": "7804",
+        "name": "Oxycodone"
+      },
+      "severity": "major",
+      "description": "Extreme risk of profound sedation, respiratory depression, and fatal overdose.",
+      "mechanism": "Synergistic CNS depression through GABA-A and mu-opioid receptor pathways."
+    },
+    {
+      "drugA": {
+        "code": "6711",
+        "name": "Methotrexate"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "major",
+      "description": "Increased methotrexate toxicity, including bone marrow suppression and GI toxicity.",
+      "mechanism": "NSAIDs reduce renal clearance of methotrexate via tubular secretion inhibition."
+    },
+    {
+      "drugA": {
+        "code": "6711",
+        "name": "Methotrexate"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "major",
+      "description": "Increased methotrexate toxicity, including bone marrow suppression and GI toxicity.",
+      "mechanism": "NSAIDs reduce renal clearance of methotrexate via tubular secretion inhibition."
+    },
+    {
+      "drugA": {
+        "code": "6711",
+        "name": "Methotrexate"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "major",
+      "description": "Increased methotrexate toxicity, including bone marrow suppression and GI toxicity.",
+      "mechanism": "NSAIDs reduce renal clearance of methotrexate via tubular secretion inhibition."
+    },
+    {
+      "drugA": {
+        "code": "6809",
+        "name": "Metformin"
+      },
+      "drugB": {
+        "code": "5970",
+        "name": "Iohexol"
+      },
+      "severity": "moderate",
+      "description": "Risk of lactic acidosis if renal function is impaired by contrast medium.",
+      "mechanism": "Contrast-induced nephropathy can lead to metformin accumulation."
+    },
+    {
+      "drugA": {
+        "code": "6918",
+        "name": "Metoprolol"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "6918",
+        "name": "Metoprolol"
+      },
+      "drugB": {
+        "code": "145507",
+        "name": "Glimepiride"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "6918",
+        "name": "Metoprolol"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "6918",
+        "name": "Metoprolol"
+      },
+      "drugB": {
+        "code": "4820",
+        "name": "Gliclazide"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "69749",
+        "name": "Valsartan"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "69749",
+        "name": "Valsartan"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "69749",
+        "name": "Valsartan"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "NSAIDs may reduce antihypertensive effect and increase risk of acute renal failure.",
+      "mechanism": "Prostaglandin inhibition leads to afferent arteriole constriction."
+    },
+    {
+      "drugA": {
+        "code": "69749",
+        "name": "Valsartan"
+      },
+      "drugB": {
+        "code": "9997",
+        "name": "Spironolactone"
+      },
+      "severity": "major",
+      "description": "Combination increases risk of life-threatening hyperkalemia.",
+      "mechanism": "Additive potassium-sparing effects in the distal nephron."
+    },
+    {
+      "drugA": {
+        "code": "7646",
+        "name": "Omeprazole"
+      },
+      "drugB": {
+        "code": "32968",
+        "name": "Clopidogrel"
+      },
+      "severity": "moderate",
+      "description": "Reduced antiplatelet efficacy of clopidogrel, increasing cardiovascular risk.",
+      "mechanism": "Inhibition of CYP2C19 prevents conversion of clopidogrel to its active form."
+    },
+    {
+      "drugA": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "drugB": {
+        "code": "10689",
+        "name": "Tramadol"
+      },
+      "severity": "major",
+      "description": "High risk of serotonin syndrome, characterized by mental status changes and neuromuscular hyperactivity.",
+      "mechanism": "Additive serotonergic effects via reuptake inhibition and direct receptor stimulation."
+    },
+    {
+      "drugA": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "drugB": {
+        "code": "11002",
+        "name": "Valproic acid"
+      },
+      "severity": "moderate",
+      "description": "Increased plasma concentrations of valproate, potentially increasing toxicity.",
+      "mechanism": "Inhibition of valproate metabolism by certain SSRIs."
+    },
+    {
+      "drugA": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "drugB": {
+        "code": "704",
+        "name": "Amitriptyline"
+      },
+      "severity": "moderate",
+      "description": "Risk of serotonin syndrome and increased levels of tricyclic antidepressants.",
+      "mechanism": "Additive pharmacodynamic effects and inhibition of hepatic metabolism."
+    },
+    {
+      "drugA": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "Increased risk of upper gastrointestinal bleeding.",
+      "mechanism": "SSRIs impair platelet aggregation by depleting serotonin stores in platelets."
+    },
+    {
+      "drugA": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "drugB": {
+        "code": "8123",
+        "name": "Phenelzine"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "7934",
+        "name": "Paroxetine"
+      },
+      "drugB": {
+        "code": "9744",
+        "name": "Selegiline"
+      },
+      "severity": "major",
+      "description": "Extreme risk of fatal serotonin syndrome.",
+      "mechanism": "Synergistic increase in synaptic serotonin levels due to combined reuptake inhibition and decreased degradation."
+    },
+    {
+      "drugA": {
+        "code": "82122",
+        "name": "Levofloxacin"
+      },
+      "drugB": {
+        "code": "3350",
+        "name": "Diclofenac"
+      },
+      "severity": "moderate",
+      "description": "Possible increased risk of CNS stimulation and convulsive seizures.",
+      "mechanism": "Antagonism of GABA-mediated inhibitory neurotransmission."
+    },
+    {
+      "drugA": {
+        "code": "82122",
+        "name": "Levofloxacin"
+      },
+      "drugB": {
+        "code": "5640",
+        "name": "Ibuprofen"
+      },
+      "severity": "moderate",
+      "description": "Possible increased risk of CNS stimulation and convulsive seizures.",
+      "mechanism": "Antagonism of GABA-mediated inhibitory neurotransmission."
+    },
+    {
+      "drugA": {
+        "code": "82122",
+        "name": "Levofloxacin"
+      },
+      "drugB": {
+        "code": "7299",
+        "name": "Naproxen"
+      },
+      "severity": "moderate",
+      "description": "Possible increased risk of CNS stimulation and convulsive seizures.",
+      "mechanism": "Antagonism of GABA-mediated inhibitory neurotransmission."
+    },
+    {
+      "drugA": {
+        "code": "83367",
+        "name": "Atorvastatin"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "moderate",
+      "description": "Increased serum statin levels and risk of muscle-related side effects.",
+      "mechanism": "CYP3A4 inhibition by diltiazem or verapamil slows statin metabolism."
+    },
+    {
+      "drugA": {
+        "code": "83367",
+        "name": "Atorvastatin"
+      },
+      "drugB": {
+        "code": "18631",
+        "name": "Azithromycin"
+      },
+      "severity": "major",
+      "description": "Increased risk of myopathy and potentially fatal rhabdomyolysis.",
+      "mechanism": "CYP3A4 inhibition increases statin serum concentrations to toxic levels."
+    },
+    {
+      "drugA": {
+        "code": "83367",
+        "name": "Atorvastatin"
+      },
+      "drugB": {
+        "code": "21212",
+        "name": "Clarithromycin"
+      },
+      "severity": "major",
+      "description": "Increased risk of myopathy and potentially fatal rhabdomyolysis.",
+      "mechanism": "CYP3A4 inhibition increases statin serum concentrations to toxic levels."
+    },
+    {
+      "drugA": {
+        "code": "83367",
+        "name": "Atorvastatin"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "moderate",
+      "description": "Increased serum statin levels and risk of muscle-related side effects.",
+      "mechanism": "CYP3A4 inhibition by diltiazem or verapamil slows statin metabolism."
+    },
+    {
+      "drugA": {
+        "code": "8787",
+        "name": "Propranolol"
+      },
+      "drugB": {
+        "code": "11170",
+        "name": "Verapamil"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "8787",
+        "name": "Propranolol"
+      },
+      "drugB": {
+        "code": "145507",
+        "name": "Glimepiride"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    },
+    {
+      "drugA": {
+        "code": "8787",
+        "name": "Propranolol"
+      },
+      "drugB": {
+        "code": "3443",
+        "name": "Diltiazem"
+      },
+      "severity": "major",
+      "description": "Risk of severe bradycardia, heart block, and decreased cardiac output.",
+      "mechanism": "Synergistic negative inotropic and chronotropic effects on the myocardium."
+    },
+    {
+      "drugA": {
+        "code": "8787",
+        "name": "Propranolol"
+      },
+      "drugB": {
+        "code": "4820",
+        "name": "Gliclazide"
+      },
+      "severity": "moderate",
+      "description": "Masking of hypoglycemic symptoms and delayed recovery from low blood sugar.",
+      "mechanism": "Blockade of beta-adrenergic receptors prevents compensatory tachycardia."
+    }
+  ]
+}

--- a/assets/medical-standards/rxnorm.json
+++ b/assets/medical-standards/rxnorm.json
@@ -2,14 +2,14 @@
   "metadata": {
     "standard": "RxNorm",
     "version": "2026-03-10",
-    "lastUpdated": "2026-05-02",
+    "lastUpdated": "2026-05-13",
     "source": "RxNorm (NLM / UMLS) + WHO ATC",
     "sourceUrl": "https://rxnav.nlm.nih.gov/",
-    "totalCount": 118
+    "totalCount": 121
   },
   "data": [
     {
-      "code": "314076",
+      "code": "29046",
       "displayName": "Lisinopril",
       "category": "ACE Inhibitors",
       "searchTerms": [
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "code": "314077",
+      "code": "3827",
       "displayName": "Enalapril",
       "category": "ACE Inhibitors",
       "searchTerms": [
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "code": "314078",
+      "code": "1998",
       "displayName": "Captopril",
       "category": "ACE Inhibitors",
       "searchTerms": [
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "code": "314079",
+      "code": "3521",
       "displayName": "Ramipril",
       "category": "ACE Inhibitors",
       "searchTerms": [
@@ -49,44 +49,44 @@
       ]
     },
     {
-      "code": "314080",
+      "code": "40188",
       "displayName": "Losartan",
       "category": "ARBs",
       "searchTerms": [
-        "losartán",
+        "losart\u00e1n",
         "Cozaar",
         "ARA-II"
       ]
     },
     {
-      "code": "314081",
+      "code": "69749",
       "displayName": "Valsartan",
       "category": "ARBs",
       "searchTerms": [
-        "valsartán",
+        "valsart\u00e1n",
         "Diovan"
       ]
     },
     {
-      "code": "314082",
+      "code": "214354",
       "displayName": "Candesartan",
       "category": "ARBs",
       "searchTerms": [
-        "candesartán",
+        "candesart\u00e1n",
         "Atacand"
       ]
     },
     {
-      "code": "314083",
+      "code": "19001",
       "displayName": "Irbesartan",
       "category": "ARBs",
       "searchTerms": [
-        "irbesartán",
+        "irbesart\u00e1n",
         "Aprovel"
       ]
     },
     {
-      "code": "314084",
+      "code": "6918",
       "displayName": "Metoprolol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -97,7 +97,7 @@
       ]
     },
     {
-      "code": "314085",
+      "code": "1202",
       "displayName": "Atenolol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -106,7 +106,7 @@
       ]
     },
     {
-      "code": "314086",
+      "code": "8787",
       "displayName": "Propranolol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -115,7 +115,7 @@
       ]
     },
     {
-      "code": "314087",
+      "code": "20352",
       "displayName": "Carvedilol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -124,7 +124,7 @@
       ]
     },
     {
-      "code": "314088",
+      "code": "1603",
       "displayName": "Bisoprolol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -133,7 +133,7 @@
       ]
     },
     {
-      "code": "314089",
+      "code": "17767",
       "displayName": "Amlodipine",
       "category": "Calcium Channel Blockers",
       "searchTerms": [
@@ -143,7 +143,7 @@
       ]
     },
     {
-      "code": "314090",
+      "code": "7424",
       "displayName": "Nifedipine",
       "category": "Calcium Channel Blockers",
       "searchTerms": [
@@ -153,7 +153,7 @@
       ]
     },
     {
-      "code": "314091",
+      "code": "11170",
       "displayName": "Verapamil",
       "category": "Calcium Channel Blockers",
       "searchTerms": [
@@ -163,7 +163,7 @@
       ]
     },
     {
-      "code": "314092",
+      "code": "3443",
       "displayName": "Diltiazem",
       "category": "Calcium Channel Blockers",
       "searchTerms": [
@@ -172,37 +172,37 @@
       ]
     },
     {
-      "code": "314093",
+      "code": "5487",
       "displayName": "Hydrochlorothiazide",
       "category": "Diuretics",
       "searchTerms": [
         "hidroclorotiazida",
         "HCTZ",
-        "diurético tiazídico"
+        "diur\u00e9tico tiaz\u00eddico"
       ]
     },
     {
-      "code": "314094",
+      "code": "4603",
       "displayName": "Furosemide",
       "category": "Diuretics",
       "searchTerms": [
         "furosemida",
         "Lasix",
-        "diurético de asa"
+        "diur\u00e9tico de asa"
       ]
     },
     {
-      "code": "314095",
+      "code": "9997",
       "displayName": "Spironolactone",
       "category": "Diuretics",
       "searchTerms": [
         "espironolactona",
         "Aldactone",
-        "diurético ahorrador potasio"
+        "diur\u00e9tico ahorrador potasio"
       ]
     },
     {
-      "code": "314096",
+      "code": "83367",
       "displayName": "Atorvastatin",
       "category": "Statins",
       "searchTerms": [
@@ -212,7 +212,7 @@
       ]
     },
     {
-      "code": "314097",
+      "code": "36567",
       "displayName": "Simvastatin",
       "category": "Statins",
       "searchTerms": [
@@ -221,7 +221,7 @@
       ]
     },
     {
-      "code": "314098",
+      "code": "301542",
       "displayName": "Rosuvastatin",
       "category": "Statins",
       "searchTerms": [
@@ -230,7 +230,7 @@
       ]
     },
     {
-      "code": "314099",
+      "code": "42463",
       "displayName": "Pravastatin",
       "category": "Statins",
       "searchTerms": [
@@ -239,7 +239,7 @@
       ]
     },
     {
-      "code": "314100",
+      "code": "11289",
       "displayName": "Warfarin",
       "category": "Anticoagulants",
       "searchTerms": [
@@ -249,26 +249,26 @@
       ]
     },
     {
-      "code": "314101",
+      "code": "1039156",
       "displayName": "Apixaban",
       "category": "Anticoagulants",
       "searchTerms": [
-        "apixabán",
+        "apixab\u00e1n",
         "Eliquis",
         "anticoagulante directo"
       ]
     },
     {
-      "code": "314102",
+      "code": "1114195",
       "displayName": "Rivaroxaban",
       "category": "Anticoagulants",
       "searchTerms": [
-        "rivaroxabán",
+        "rivaroxab\u00e1n",
         "Xarelto"
       ]
     },
     {
-      "code": "314103",
+      "code": "32968",
       "displayName": "Clopidogrel",
       "category": "Antiplatelets",
       "searchTerms": [
@@ -278,18 +278,18 @@
       ]
     },
     {
-      "code": "314104",
+      "code": "1191",
       "displayName": "Aspirin",
       "category": "Antiplatelets",
       "searchTerms": [
         "aspirina",
-        "ácido acetilsalicílico",
+        "\u00e1cido acetilsalic\u00edlico",
         "AAS",
         "aspirina infantil"
       ]
     },
     {
-      "code": "314105",
+      "code": "3407",
       "displayName": "Digoxin",
       "category": "Cardiac Glycosides",
       "searchTerms": [
@@ -299,7 +299,7 @@
       ]
     },
     {
-      "code": "314106",
+      "code": "7434",
       "displayName": "Nitroglycerin",
       "category": "Anti-anginals",
       "searchTerms": [
@@ -309,7 +309,7 @@
       ]
     },
     {
-      "code": "314107",
+      "code": "35827",
       "displayName": "Isosorbide mononitrate",
       "category": "Anti-anginals",
       "searchTerms": [
@@ -318,7 +318,7 @@
       ]
     },
     {
-      "code": "314108",
+      "code": "6809",
       "displayName": "Metformin",
       "category": "Antidiabetics",
       "searchTerms": [
@@ -328,7 +328,7 @@
       ]
     },
     {
-      "code": "314109",
+      "code": "274783",
       "displayName": "Insulin glargine",
       "category": "Insulins",
       "searchTerms": [
@@ -338,17 +338,17 @@
       ]
     },
     {
-      "code": "314110",
+      "code": "214532",
       "displayName": "Insulin aspart",
       "category": "Insulins",
       "searchTerms": [
         "insulina aspart",
         "NovoRapid",
-        "insulina rápida"
+        "insulina r\u00e1pida"
       ]
     },
     {
-      "code": "314111",
+      "code": "161245",
       "displayName": "Insulin lispro",
       "category": "Insulins",
       "searchTerms": [
@@ -357,7 +357,7 @@
       ]
     },
     {
-      "code": "314112",
+      "code": "352388",
       "displayName": "Insulin detemir",
       "category": "Insulins",
       "searchTerms": [
@@ -366,7 +366,7 @@
       ]
     },
     {
-      "code": "314113",
+      "code": "1359720",
       "displayName": "Insulin degludec",
       "category": "Insulins",
       "searchTerms": [
@@ -375,7 +375,7 @@
       ]
     },
     {
-      "code": "314114",
+      "code": "4820",
       "displayName": "Gliclazide",
       "category": "Sulfonylureas",
       "searchTerms": [
@@ -385,7 +385,7 @@
       ]
     },
     {
-      "code": "314115",
+      "code": "145507",
       "displayName": "Glimepiride",
       "category": "Sulfonylureas",
       "searchTerms": [
@@ -394,7 +394,7 @@
       ]
     },
     {
-      "code": "314116",
+      "code": "593411",
       "displayName": "Sitagliptin",
       "category": "DPP-4 Inhibitors",
       "searchTerms": [
@@ -404,7 +404,7 @@
       ]
     },
     {
-      "code": "314117",
+      "code": "1545631",
       "displayName": "Empagliflozin",
       "category": "SGLT2 Inhibitors",
       "searchTerms": [
@@ -415,7 +415,7 @@
       ]
     },
     {
-      "code": "314118",
+      "code": "1488564",
       "displayName": "Dapagliflozin",
       "category": "SGLT2 Inhibitors",
       "searchTerms": [
@@ -425,7 +425,7 @@
       ]
     },
     {
-      "code": "314119",
+      "code": "476577",
       "displayName": "Liraglutide",
       "category": "GLP-1 Agonists",
       "searchTerms": [
@@ -436,7 +436,7 @@
       ]
     },
     {
-      "code": "314120",
+      "code": "1991302",
       "displayName": "Semaglutide",
       "category": "GLP-1 Agonists",
       "searchTerms": [
@@ -447,7 +447,7 @@
       ]
     },
     {
-      "code": "314121",
+      "code": "1551291",
       "displayName": "Dulaglutide",
       "category": "GLP-1 Agonists",
       "searchTerms": [
@@ -456,7 +456,7 @@
       ]
     },
     {
-      "code": "314122",
+      "code": "723",
       "displayName": "Amoxicillin",
       "category": "Antibiotics",
       "searchTerms": [
@@ -466,17 +466,17 @@
       ]
     },
     {
-      "code": "314123",
+      "code": "214178",
       "displayName": "Amoxicillin-clavulanate",
       "category": "Antibiotics",
       "searchTerms": [
-        "amoxicilina-clavulánico",
+        "amoxicilina-clavul\u00e1nico",
         "Augmentin",
         "Amoxiclav"
       ]
     },
     {
-      "code": "314124",
+      "code": "2231",
       "displayName": "Cephalexin",
       "category": "Cephalosporins",
       "searchTerms": [
@@ -486,7 +486,7 @@
       ]
     },
     {
-      "code": "314125",
+      "code": "2220",
       "displayName": "Ceftriaxone",
       "category": "Cephalosporins",
       "searchTerms": [
@@ -496,7 +496,7 @@
       ]
     },
     {
-      "code": "314126",
+      "code": "2551",
       "displayName": "Ciprofloxacin",
       "category": "Fluoroquinolones",
       "searchTerms": [
@@ -506,7 +506,7 @@
       ]
     },
     {
-      "code": "314127",
+      "code": "82122",
       "displayName": "Levofloxacin",
       "category": "Fluoroquinolones",
       "searchTerms": [
@@ -516,17 +516,17 @@
       ]
     },
     {
-      "code": "314128",
+      "code": "18631",
       "displayName": "Azithromycin",
       "category": "Macrolides",
       "searchTerms": [
         "azitromicina",
         "Zithromax",
-        "macrólido"
+        "macr\u00f3lido"
       ]
     },
     {
-      "code": "314129",
+      "code": "21212",
       "displayName": "Clarithromycin",
       "category": "Macrolides",
       "searchTerms": [
@@ -535,7 +535,7 @@
       ]
     },
     {
-      "code": "314130",
+      "code": "3640",
       "displayName": "Doxycycline",
       "category": "Tetracyclines",
       "searchTerms": [
@@ -545,7 +545,7 @@
       ]
     },
     {
-      "code": "314131",
+      "code": "6922",
       "displayName": "Metronidazole",
       "category": "Antibiotics",
       "searchTerms": [
@@ -555,7 +555,7 @@
       ]
     },
     {
-      "code": "314132",
+      "code": "190361",
       "displayName": "Sulfamethoxazole-trimethoprim",
       "category": "Sulfonamides",
       "searchTerms": [
@@ -566,7 +566,7 @@
       ]
     },
     {
-      "code": "314133",
+      "code": "2582",
       "displayName": "Clindamycin",
       "category": "Antibiotics",
       "searchTerms": [
@@ -575,16 +575,16 @@
       ]
     },
     {
-      "code": "314134",
+      "code": "7393",
       "displayName": "Nitrofurantoin",
       "category": "Urinary Antibiotics",
       "searchTerms": [
-        "nitrofurantoína",
+        "nitrofuranto\u00edna",
         "Macrobid"
       ]
     },
     {
-      "code": "314135",
+      "code": "5640",
       "displayName": "Ibuprofen",
       "category": "NSAIDs",
       "searchTerms": [
@@ -595,7 +595,7 @@
       ]
     },
     {
-      "code": "314136",
+      "code": "7299",
       "displayName": "Naproxen",
       "category": "NSAIDs",
       "searchTerms": [
@@ -605,7 +605,7 @@
       ]
     },
     {
-      "code": "314137",
+      "code": "3350",
       "displayName": "Diclofenac",
       "category": "NSAIDs",
       "searchTerms": [
@@ -615,28 +615,28 @@
       ]
     },
     {
-      "code": "314138",
+      "code": "161",
       "displayName": "Acetaminophen",
       "category": "Analgesics",
       "searchTerms": [
         "paracetamol",
-        "acetaminofén",
+        "acetaminof\u00e9n",
         "Tylenol",
         "Dolex"
       ]
     },
     {
-      "code": "314139",
+      "code": "10689",
       "displayName": "Tramadol",
       "category": "Opioids",
       "searchTerms": [
         "tramadol",
         "Tramal",
-        "analgésico opioide"
+        "analg\u00e9sico opioide"
       ]
     },
     {
-      "code": "314140",
+      "code": "7052",
       "displayName": "Morphine",
       "category": "Opioids",
       "searchTerms": [
@@ -644,7 +644,7 @@
       ]
     },
     {
-      "code": "314141",
+      "code": "7804",
       "displayName": "Oxycodone",
       "category": "Opioids",
       "searchTerms": [
@@ -654,17 +654,17 @@
       ]
     },
     {
-      "code": "314142",
+      "code": "25480",
       "displayName": "Gabapentin",
       "category": "Neuropathic Pain",
       "searchTerms": [
         "gabapentina",
         "Neurontin",
-        "dolor neuropático"
+        "dolor neurop\u00e1tico"
       ]
     },
     {
-      "code": "314143",
+      "code": "187832",
       "displayName": "Pregabalin",
       "category": "Neuropathic Pain",
       "searchTerms": [
@@ -673,7 +673,7 @@
       ]
     },
     {
-      "code": "314144",
+      "code": "435",
       "displayName": "Albuterol",
       "category": "Bronchodilators",
       "searchTerms": [
@@ -684,7 +684,7 @@
       ]
     },
     {
-      "code": "314145",
+      "code": "5975",
       "displayName": "Ipratropium",
       "category": "Anticholinergics",
       "searchTerms": [
@@ -693,7 +693,7 @@
       ]
     },
     {
-      "code": "314146",
+      "code": "41126",
       "displayName": "Fluticasone",
       "category": "Inhaled Corticosteroids",
       "searchTerms": [
@@ -703,7 +703,7 @@
       ]
     },
     {
-      "code": "314147",
+      "code": "17641",
       "displayName": "Budesonide",
       "category": "Inhaled Corticosteroids",
       "searchTerms": [
@@ -712,7 +712,7 @@
       ]
     },
     {
-      "code": "314148",
+      "code": "88249",
       "displayName": "Montelukast",
       "category": "Leukotriene Antagonists",
       "searchTerms": [
@@ -722,17 +722,17 @@
       ]
     },
     {
-      "code": "314149",
+      "code": "32834",
       "displayName": "Loratadine",
       "category": "Antihistamines",
       "searchTerms": [
         "loratadina",
         "Claritin",
-        "antihistamínico"
+        "antihistam\u00ednico"
       ]
     },
     {
-      "code": "314150",
+      "code": "20610",
       "displayName": "Cetirizine",
       "category": "Antihistamines",
       "searchTerms": [
@@ -741,7 +741,7 @@
       ]
     },
     {
-      "code": "314151",
+      "code": "42355",
       "displayName": "Fexofenadine",
       "category": "Antihistamines",
       "searchTerms": [
@@ -750,7 +750,7 @@
       ]
     },
     {
-      "code": "314152",
+      "code": "7646",
       "displayName": "Omeprazole",
       "category": "PPIs",
       "searchTerms": [
@@ -761,7 +761,7 @@
       ]
     },
     {
-      "code": "314153",
+      "code": "40534",
       "displayName": "Pantoprazole",
       "category": "PPIs",
       "searchTerms": [
@@ -770,7 +770,7 @@
       ]
     },
     {
-      "code": "314154",
+      "code": "153165",
       "displayName": "Esomeprazole",
       "category": "PPIs",
       "searchTerms": [
@@ -779,7 +779,7 @@
       ]
     },
     {
-      "code": "314155",
+      "code": "29935",
       "displayName": "Lansoprazole",
       "category": "PPIs",
       "searchTerms": [
@@ -788,17 +788,17 @@
       ]
     },
     {
-      "code": "314156",
+      "code": "9143",
       "displayName": "Ranitidine",
       "category": "H2 Antagonists",
       "searchTerms": [
         "ranitidina",
         "Zantac",
-        "antihistamínico H2"
+        "antihistam\u00ednico H2"
       ]
     },
     {
-      "code": "314157",
+      "code": "4278",
       "displayName": "Famotidine",
       "category": "H2 Antagonists",
       "searchTerms": [
@@ -807,17 +807,17 @@
       ]
     },
     {
-      "code": "314158",
+      "code": "26225",
       "displayName": "Ondansetron",
       "category": "Antiemetics",
       "searchTerms": [
-        "ondansetrón",
+        "ondansetr\u00f3n",
         "Zofran",
-        "antiemético"
+        "antiem\u00e9tico"
       ]
     },
     {
-      "code": "314159",
+      "code": "6915",
       "displayName": "Metoclopramide",
       "category": "Prokinetics",
       "searchTerms": [
@@ -826,7 +826,7 @@
       ]
     },
     {
-      "code": "314160",
+      "code": "6448",
       "displayName": "Loperamide",
       "category": "Antidiarrheals",
       "searchTerms": [
@@ -836,7 +836,7 @@
       ]
     },
     {
-      "code": "314161",
+      "code": "1538",
       "displayName": "Bismuth subsalicylate",
       "category": "Antidiarrheals",
       "searchTerms": [
@@ -845,18 +845,18 @@
       ]
     },
     {
-      "code": "314162",
+      "code": "596",
       "displayName": "Alprazolam",
       "category": "Benzodiazepines",
       "searchTerms": [
         "alprazolam",
         "Xanax",
-        "ansiolítico",
+        "ansiol\u00edtico",
         "benzodiazepina"
       ]
     },
     {
-      "code": "314163",
+      "code": "6470",
       "displayName": "Lorazepam",
       "category": "Benzodiazepines",
       "searchTerms": [
@@ -865,7 +865,7 @@
       ]
     },
     {
-      "code": "314164",
+      "code": "3322",
       "displayName": "Diazepam",
       "category": "Benzodiazepines",
       "searchTerms": [
@@ -874,7 +874,7 @@
       ]
     },
     {
-      "code": "314165",
+      "code": "2598",
       "displayName": "Clonazepam",
       "category": "Benzodiazepines",
       "searchTerms": [
@@ -883,7 +883,7 @@
       ]
     },
     {
-      "code": "314166",
+      "code": "4493",
       "displayName": "Fluoxetine",
       "category": "SSRIs",
       "searchTerms": [
@@ -894,7 +894,7 @@
       ]
     },
     {
-      "code": "314167",
+      "code": "36437",
       "displayName": "Sertraline",
       "category": "SSRIs",
       "searchTerms": [
@@ -903,7 +903,7 @@
       ]
     },
     {
-      "code": "314168",
+      "code": "321988",
       "displayName": "Escitalopram",
       "category": "SSRIs",
       "searchTerms": [
@@ -913,7 +913,7 @@
       ]
     },
     {
-      "code": "314169",
+      "code": "7934",
       "displayName": "Paroxetine",
       "category": "SSRIs",
       "searchTerms": [
@@ -922,7 +922,7 @@
       ]
     },
     {
-      "code": "314170",
+      "code": "39786",
       "displayName": "Venlafaxine",
       "category": "SNRIs",
       "searchTerms": [
@@ -932,7 +932,7 @@
       ]
     },
     {
-      "code": "314171",
+      "code": "236430",
       "displayName": "Duloxetine",
       "category": "SNRIs",
       "searchTerms": [
@@ -941,7 +941,7 @@
       ]
     },
     {
-      "code": "314172",
+      "code": "15996",
       "displayName": "Mirtazapine",
       "category": "Antidepressants",
       "searchTerms": [
@@ -950,38 +950,38 @@
       ]
     },
     {
-      "code": "314173",
+      "code": "704",
       "displayName": "Amitriptyline",
       "category": "Tricyclic Antidepressants",
       "searchTerms": [
         "amitriptilina",
         "ADT",
-        "antidepresivo tricíclico"
+        "antidepresivo tric\u00edclico"
       ]
     },
     {
-      "code": "314174",
+      "code": "2002",
       "displayName": "Carbamazepine",
       "category": "Anticonvulsants",
       "searchTerms": [
         "carbamazepina",
         "Tegretol",
         "anticonvulsivante",
-        "estabilizador ánimo"
+        "estabilizador \u00e1nimo"
       ]
     },
     {
-      "code": "314175",
+      "code": "11002",
       "displayName": "Valproic acid",
       "category": "Anticonvulsants",
       "searchTerms": [
-        "ácido valproico",
+        "\u00e1cido valproico",
         "valproato",
         "Depakote"
       ]
     },
     {
-      "code": "314176",
+      "code": "28439",
       "displayName": "Lamotrigine",
       "category": "Anticonvulsants",
       "searchTerms": [
@@ -990,7 +990,7 @@
       ]
     },
     {
-      "code": "314177",
+      "code": "137130",
       "displayName": "Levetiracetam",
       "category": "Anticonvulsants",
       "searchTerms": [
@@ -999,7 +999,7 @@
       ]
     },
     {
-      "code": "314178",
+      "code": "6901",
       "displayName": "Methylphenidate",
       "category": "Stimulants",
       "searchTerms": [
@@ -1010,7 +1010,7 @@
       ]
     },
     {
-      "code": "314179",
+      "code": "10582",
       "displayName": "Levothyroxine",
       "category": "Thyroid Hormones",
       "searchTerms": [
@@ -1022,7 +1022,7 @@
       ]
     },
     {
-      "code": "314180",
+      "code": "8640",
       "displayName": "Prednisone",
       "category": "Corticosteroids",
       "searchTerms": [
@@ -1032,7 +1032,7 @@
       ]
     },
     {
-      "code": "314181",
+      "code": "3264",
       "displayName": "Dexamethasone",
       "category": "Corticosteroids",
       "searchTerms": [
@@ -1041,7 +1041,7 @@
       ]
     },
     {
-      "code": "314182",
+      "code": "5492",
       "displayName": "Hydrocortisone",
       "category": "Corticosteroids",
       "searchTerms": [
@@ -1050,7 +1050,7 @@
       ]
     },
     {
-      "code": "314183",
+      "code": "4450",
       "displayName": "Alendronate",
       "category": "Bisphosphonates",
       "searchTerms": [
@@ -1061,7 +1061,7 @@
       ]
     },
     {
-      "code": "314184",
+      "code": "1897",
       "displayName": "Calcium carbonate",
       "category": "Minerals",
       "searchTerms": [
@@ -1071,7 +1071,7 @@
       ]
     },
     {
-      "code": "314185",
+      "code": "24188",
       "displayName": "Vitamin D3",
       "category": "Vitamins",
       "searchTerms": [
@@ -1081,17 +1081,17 @@
       ]
     },
     {
-      "code": "314186",
+      "code": "10324",
       "displayName": "Tamoxifen",
       "category": "Antiestrogens",
       "searchTerms": [
         "tamoxifeno",
         "Nolvadex",
-        "cáncer mama"
+        "c\u00e1ncer mama"
       ]
     },
     {
-      "code": "314187",
+      "code": "6711",
       "displayName": "Methotrexate",
       "category": "Antimetabolites",
       "searchTerms": [
@@ -1101,17 +1101,17 @@
       ]
     },
     {
-      "code": "314188",
+      "code": "135561",
       "displayName": "Sildenafil",
       "category": "PDE5 Inhibitors",
       "searchTerms": [
         "sildenafil",
         "Viagra",
-        "disfunción eréctil"
+        "disfunci\u00f3n er\u00e9ctil"
       ]
     },
     {
-      "code": "314189",
+      "code": "321207",
       "displayName": "Tadalafil",
       "category": "PDE5 Inhibitors",
       "searchTerms": [
@@ -1120,7 +1120,7 @@
       ]
     },
     {
-      "code": "314190",
+      "code": "4441",
       "displayName": "Finasteride",
       "category": "5-alpha Reductase Inhibitors",
       "searchTerms": [
@@ -1131,7 +1131,7 @@
       ]
     },
     {
-      "code": "314191",
+      "code": "38454",
       "displayName": "Tamsulosin",
       "category": "Alpha Blockers",
       "searchTerms": [
@@ -1141,7 +1141,7 @@
       ]
     },
     {
-      "code": "314192",
+      "code": "558",
       "displayName": "Allopurinol",
       "category": "Xanthine Oxidase Inhibitors",
       "searchTerms": [
@@ -1151,12 +1151,40 @@
       ]
     },
     {
-      "code": "314193",
+      "code": "2683",
       "displayName": "Colchicine",
       "category": "Anti-gout",
       "searchTerms": [
         "colchicina",
         "gota"
+      ]
+    },
+    {
+      "code": "8123",
+      "displayName": "Phenelzine",
+      "category": "MAOIs",
+      "searchTerms": [
+        "phenelzine",
+        "Nardil"
+      ]
+    },
+    {
+      "code": "9744",
+      "displayName": "Selegiline",
+      "category": "MAOIs",
+      "searchTerms": [
+        "selegiline",
+        "Emsam",
+        "Eldepryl"
+      ]
+    },
+    {
+      "code": "5970",
+      "displayName": "Iohexol",
+      "category": "Contrast Agents",
+      "searchTerms": [
+        "iohexol",
+        "Omnipaque"
       ]
     }
   ]

--- a/lib/features/medical_assistant/infrastructure/analysis/drug_interaction_checker.dart
+++ b/lib/features/medical_assistant/infrastructure/analysis/drug_interaction_checker.dart
@@ -230,24 +230,24 @@ class DrugInteractionChecker {
   static Map<String, _InteractionRule> _initInteractions() {
     return {
       // Major interactions
-      '314076-1191': _InteractionRule(InteractionSeverity.major, 'Increased risk of hyperkalemia and renal impairment', 'Monitor potassium and renal function. Consider alternative antihypertensive.'),
-      '1191-314076': _InteractionRule(InteractionSeverity.major, 'Increased risk of hyperkalemia and renal impairment', 'Monitor potassium and renal function. Consider alternative antihypertensive.'),
-      '161-310410': _InteractionRule(InteractionSeverity.major, 'Increased risk of bleeding and hemorrhage', 'Avoid combination. Use alternative anticoagulant or antiplatelet.'),
-      '310410-161': _InteractionRule(InteractionSeverity.major, 'Increased risk of bleeding and hemorrhage', 'Avoid combination. Use alternative anticoagulant or antiplatelet.'),
-      '723-7052': _InteractionRule(InteractionSeverity.major, 'Increased statin levels - risk of rhabdomyolysis', 'Avoid simvastatin. Use lowest effective dose of atorvastatin or rosuvastatin.'),
-      '7052-723': _InteractionRule(InteractionSeverity.major, 'Increased statin levels - risk of rhabdomyolysis', 'Avoid simvastatin. Use lowest effective dose of atorvastatin or rosuvastatin.'),
-      '860090-161': _InteractionRule(InteractionSeverity.major, 'Increased risk of bleeding and hemorrhage', 'Avoid combination. Use alternative pain management.'),
-      '161-860090': _InteractionRule(InteractionSeverity.major, 'Increased risk of bleeding and hemorrhage', 'Avoid combination. Use alternative pain management.'),
+      '29046-9997': _InteractionRule(InteractionSeverity.major, 'Increased risk of hyperkalemia and renal impairment', 'Monitor potassium and renal function. Consider alternative antihypertensive.'),
+      '9997-29046': _InteractionRule(InteractionSeverity.major, 'Increased risk of hyperkalemia and renal impairment', 'Monitor potassium and renal function. Consider alternative antihypertensive.'),
+      '11289-1191': _InteractionRule(InteractionSeverity.major, 'Increased risk of bleeding and hemorrhage', 'Avoid combination. Use alternative anticoagulant or antiplatelet.'),
+      '1191-11289': _InteractionRule(InteractionSeverity.major, 'Increased risk of bleeding and hemorrhage', 'Avoid combination. Use alternative anticoagulant or antiplatelet.'),
+      '36567-21212': _InteractionRule(InteractionSeverity.major, 'Increased statin levels - risk of rhabdomyolysis', 'Avoid simvastatin. Use lowest effective dose of atorvastatin or rosuvastatin.'),
+      '21212-36567': _InteractionRule(InteractionSeverity.major, 'Increased statin levels - risk of rhabdomyolysis', 'Avoid simvastatin. Use lowest effective dose of atorvastatin or rosuvastatin.'),
+      '5640-11289': _InteractionRule(InteractionSeverity.major, 'Increased risk of bleeding and hemorrhage', 'Avoid combination. Use alternative pain management.'),
+      '11289-5640': _InteractionRule(InteractionSeverity.major, 'Increased risk of bleeding and hemorrhage', 'Avoid combination. Use alternative pain management.'),
 
       // Moderate interactions
-      '314076-310410': _InteractionRule(InteractionSeverity.moderate, 'ACE inhibitor + anticoagulant: increased bleeding risk in elderly', 'Monitor INR and renal function. Educate patient about bleeding signs.'),
-      '310410-314076': _InteractionRule(InteractionSeverity.moderate, 'ACE inhibitor + anticoagulant: increased bleeding risk in elderly', 'Monitor INR and renal function. Educate patient about bleeding signs.'),
-      '1191-310410': _InteractionRule(InteractionSeverity.moderate, 'ARB + anticoagulant: potential increased bleeding risk', 'Monitor renal function and bleeding signs.'),
-      '310410-1191': _InteractionRule(InteractionSeverity.moderate, 'ARB + anticoagulant: potential increased bleeding risk', 'Monitor renal function and bleeding signs.'),
-      '6809-1191': _InteractionRule(InteractionSeverity.moderate, 'Metformin + contrast dye: risk of lactic acidosis', 'Hold metformin 48h before and after contrast procedures.'),
-      '1191-6809': _InteractionRule(InteractionSeverity.moderate, 'Metformin + contrast dye: risk of lactic acidosis', 'Hold metformin 48h before and after contrast procedures.'),
-      '723-310410': _InteractionRule(InteractionSeverity.moderate, 'Statin + anticoagulant: possible increased INR', 'Monitor INR more frequently when starting/changing statin therapy.'),
-      '310410-723': _InteractionRule(InteractionSeverity.moderate, 'Statin + anticoagulant: possible increased INR', 'Monitor INR more frequently when starting/changing statin therapy.'),
+      '29046-11289': _InteractionRule(InteractionSeverity.moderate, 'ACE inhibitor + anticoagulant: increased bleeding risk in elderly', 'Monitor INR and renal function. Educate patient about bleeding signs.'),
+      '11289-29046': _InteractionRule(InteractionSeverity.moderate, 'ACE inhibitor + anticoagulant: increased bleeding risk in elderly', 'Monitor INR and renal function. Educate patient about bleeding signs.'),
+      '40188-11289': _InteractionRule(InteractionSeverity.moderate, 'ARB + anticoagulant: potential increased bleeding risk', 'Monitor renal function and bleeding signs.'),
+      '11289-40188': _InteractionRule(InteractionSeverity.moderate, 'ARB + anticoagulant: potential increased bleeding risk', 'Monitor renal function and bleeding signs.'),
+      '6809-5970': _InteractionRule(InteractionSeverity.moderate, 'Metformin + contrast dye: risk of lactic acidosis', 'Hold metformin 48h before and after contrast procedures.'),
+      '5970-6809': _InteractionRule(InteractionSeverity.moderate, 'Metformin + contrast dye: risk of lactic acidosis', 'Hold metformin 48h before and after contrast procedures.'),
+      '36567-11289': _InteractionRule(InteractionSeverity.moderate, 'Statin + anticoagulant: possible increased INR', 'Monitor INR more frequently when starting/changing statin therapy.'),
+      '11289-36567': _InteractionRule(InteractionSeverity.moderate, 'Statin + anticoagulant: possible increased INR', 'Monitor INR more frequently when starting/changing statin therapy.'),
     };
   }
 

--- a/packages/medical_standards/data/full_rxnorm.json
+++ b/packages/medical_standards/data/full_rxnorm.json
@@ -2,14 +2,14 @@
   "metadata": {
     "standard": "RxNorm",
     "version": "2026-03-10",
-    "lastUpdated": "2026-05-02",
+    "lastUpdated": "2026-05-13",
     "source": "RxNorm (NLM / UMLS) + WHO ATC",
     "sourceUrl": "https://rxnav.nlm.nih.gov/",
-    "totalCount": 118
+    "totalCount": 121
   },
   "data": [
     {
-      "code": "314076",
+      "code": "29046",
       "displayName": "Lisinopril",
       "category": "ACE Inhibitors",
       "searchTerms": [
@@ -20,7 +20,7 @@
       ]
     },
     {
-      "code": "314077",
+      "code": "3827",
       "displayName": "Enalapril",
       "category": "ACE Inhibitors",
       "searchTerms": [
@@ -30,7 +30,7 @@
       ]
     },
     {
-      "code": "314078",
+      "code": "1998",
       "displayName": "Captopril",
       "category": "ACE Inhibitors",
       "searchTerms": [
@@ -39,7 +39,7 @@
       ]
     },
     {
-      "code": "314079",
+      "code": "3521",
       "displayName": "Ramipril",
       "category": "ACE Inhibitors",
       "searchTerms": [
@@ -49,44 +49,44 @@
       ]
     },
     {
-      "code": "314080",
+      "code": "40188",
       "displayName": "Losartan",
       "category": "ARBs",
       "searchTerms": [
-        "losartán",
+        "losart\u00e1n",
         "Cozaar",
         "ARA-II"
       ]
     },
     {
-      "code": "314081",
+      "code": "69749",
       "displayName": "Valsartan",
       "category": "ARBs",
       "searchTerms": [
-        "valsartán",
+        "valsart\u00e1n",
         "Diovan"
       ]
     },
     {
-      "code": "314082",
+      "code": "214354",
       "displayName": "Candesartan",
       "category": "ARBs",
       "searchTerms": [
-        "candesartán",
+        "candesart\u00e1n",
         "Atacand"
       ]
     },
     {
-      "code": "314083",
+      "code": "19001",
       "displayName": "Irbesartan",
       "category": "ARBs",
       "searchTerms": [
-        "irbesartán",
+        "irbesart\u00e1n",
         "Aprovel"
       ]
     },
     {
-      "code": "314084",
+      "code": "6918",
       "displayName": "Metoprolol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -97,7 +97,7 @@
       ]
     },
     {
-      "code": "314085",
+      "code": "1202",
       "displayName": "Atenolol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -106,7 +106,7 @@
       ]
     },
     {
-      "code": "314086",
+      "code": "8787",
       "displayName": "Propranolol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -115,7 +115,7 @@
       ]
     },
     {
-      "code": "314087",
+      "code": "20352",
       "displayName": "Carvedilol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -124,7 +124,7 @@
       ]
     },
     {
-      "code": "314088",
+      "code": "1603",
       "displayName": "Bisoprolol",
       "category": "Beta Blockers",
       "searchTerms": [
@@ -133,7 +133,7 @@
       ]
     },
     {
-      "code": "314089",
+      "code": "17767",
       "displayName": "Amlodipine",
       "category": "Calcium Channel Blockers",
       "searchTerms": [
@@ -143,7 +143,7 @@
       ]
     },
     {
-      "code": "314090",
+      "code": "7424",
       "displayName": "Nifedipine",
       "category": "Calcium Channel Blockers",
       "searchTerms": [
@@ -153,7 +153,7 @@
       ]
     },
     {
-      "code": "314091",
+      "code": "11170",
       "displayName": "Verapamil",
       "category": "Calcium Channel Blockers",
       "searchTerms": [
@@ -163,7 +163,7 @@
       ]
     },
     {
-      "code": "314092",
+      "code": "3443",
       "displayName": "Diltiazem",
       "category": "Calcium Channel Blockers",
       "searchTerms": [
@@ -172,37 +172,37 @@
       ]
     },
     {
-      "code": "314093",
+      "code": "5487",
       "displayName": "Hydrochlorothiazide",
       "category": "Diuretics",
       "searchTerms": [
         "hidroclorotiazida",
         "HCTZ",
-        "diurético tiazídico"
+        "diur\u00e9tico tiaz\u00eddico"
       ]
     },
     {
-      "code": "314094",
+      "code": "4603",
       "displayName": "Furosemide",
       "category": "Diuretics",
       "searchTerms": [
         "furosemida",
         "Lasix",
-        "diurético de asa"
+        "diur\u00e9tico de asa"
       ]
     },
     {
-      "code": "314095",
+      "code": "9997",
       "displayName": "Spironolactone",
       "category": "Diuretics",
       "searchTerms": [
         "espironolactona",
         "Aldactone",
-        "diurético ahorrador potasio"
+        "diur\u00e9tico ahorrador potasio"
       ]
     },
     {
-      "code": "314096",
+      "code": "83367",
       "displayName": "Atorvastatin",
       "category": "Statins",
       "searchTerms": [
@@ -212,7 +212,7 @@
       ]
     },
     {
-      "code": "314097",
+      "code": "36567",
       "displayName": "Simvastatin",
       "category": "Statins",
       "searchTerms": [
@@ -221,7 +221,7 @@
       ]
     },
     {
-      "code": "314098",
+      "code": "301542",
       "displayName": "Rosuvastatin",
       "category": "Statins",
       "searchTerms": [
@@ -230,7 +230,7 @@
       ]
     },
     {
-      "code": "314099",
+      "code": "42463",
       "displayName": "Pravastatin",
       "category": "Statins",
       "searchTerms": [
@@ -239,7 +239,7 @@
       ]
     },
     {
-      "code": "314100",
+      "code": "11289",
       "displayName": "Warfarin",
       "category": "Anticoagulants",
       "searchTerms": [
@@ -249,26 +249,26 @@
       ]
     },
     {
-      "code": "314101",
+      "code": "1039156",
       "displayName": "Apixaban",
       "category": "Anticoagulants",
       "searchTerms": [
-        "apixabán",
+        "apixab\u00e1n",
         "Eliquis",
         "anticoagulante directo"
       ]
     },
     {
-      "code": "314102",
+      "code": "1114195",
       "displayName": "Rivaroxaban",
       "category": "Anticoagulants",
       "searchTerms": [
-        "rivaroxabán",
+        "rivaroxab\u00e1n",
         "Xarelto"
       ]
     },
     {
-      "code": "314103",
+      "code": "32968",
       "displayName": "Clopidogrel",
       "category": "Antiplatelets",
       "searchTerms": [
@@ -278,18 +278,18 @@
       ]
     },
     {
-      "code": "314104",
+      "code": "1191",
       "displayName": "Aspirin",
       "category": "Antiplatelets",
       "searchTerms": [
         "aspirina",
-        "ácido acetilsalicílico",
+        "\u00e1cido acetilsalic\u00edlico",
         "AAS",
         "aspirina infantil"
       ]
     },
     {
-      "code": "314105",
+      "code": "3407",
       "displayName": "Digoxin",
       "category": "Cardiac Glycosides",
       "searchTerms": [
@@ -299,7 +299,7 @@
       ]
     },
     {
-      "code": "314106",
+      "code": "7434",
       "displayName": "Nitroglycerin",
       "category": "Anti-anginals",
       "searchTerms": [
@@ -309,7 +309,7 @@
       ]
     },
     {
-      "code": "314107",
+      "code": "35827",
       "displayName": "Isosorbide mononitrate",
       "category": "Anti-anginals",
       "searchTerms": [
@@ -318,7 +318,7 @@
       ]
     },
     {
-      "code": "314108",
+      "code": "6809",
       "displayName": "Metformin",
       "category": "Antidiabetics",
       "searchTerms": [
@@ -328,7 +328,7 @@
       ]
     },
     {
-      "code": "314109",
+      "code": "274783",
       "displayName": "Insulin glargine",
       "category": "Insulins",
       "searchTerms": [
@@ -338,17 +338,17 @@
       ]
     },
     {
-      "code": "314110",
+      "code": "214532",
       "displayName": "Insulin aspart",
       "category": "Insulins",
       "searchTerms": [
         "insulina aspart",
         "NovoRapid",
-        "insulina rápida"
+        "insulina r\u00e1pida"
       ]
     },
     {
-      "code": "314111",
+      "code": "161245",
       "displayName": "Insulin lispro",
       "category": "Insulins",
       "searchTerms": [
@@ -357,7 +357,7 @@
       ]
     },
     {
-      "code": "314112",
+      "code": "352388",
       "displayName": "Insulin detemir",
       "category": "Insulins",
       "searchTerms": [
@@ -366,7 +366,7 @@
       ]
     },
     {
-      "code": "314113",
+      "code": "1359720",
       "displayName": "Insulin degludec",
       "category": "Insulins",
       "searchTerms": [
@@ -375,7 +375,7 @@
       ]
     },
     {
-      "code": "314114",
+      "code": "4820",
       "displayName": "Gliclazide",
       "category": "Sulfonylureas",
       "searchTerms": [
@@ -385,7 +385,7 @@
       ]
     },
     {
-      "code": "314115",
+      "code": "145507",
       "displayName": "Glimepiride",
       "category": "Sulfonylureas",
       "searchTerms": [
@@ -394,7 +394,7 @@
       ]
     },
     {
-      "code": "314116",
+      "code": "593411",
       "displayName": "Sitagliptin",
       "category": "DPP-4 Inhibitors",
       "searchTerms": [
@@ -404,7 +404,7 @@
       ]
     },
     {
-      "code": "314117",
+      "code": "1545631",
       "displayName": "Empagliflozin",
       "category": "SGLT2 Inhibitors",
       "searchTerms": [
@@ -415,7 +415,7 @@
       ]
     },
     {
-      "code": "314118",
+      "code": "1488564",
       "displayName": "Dapagliflozin",
       "category": "SGLT2 Inhibitors",
       "searchTerms": [
@@ -425,7 +425,7 @@
       ]
     },
     {
-      "code": "314119",
+      "code": "476577",
       "displayName": "Liraglutide",
       "category": "GLP-1 Agonists",
       "searchTerms": [
@@ -436,7 +436,7 @@
       ]
     },
     {
-      "code": "314120",
+      "code": "1991302",
       "displayName": "Semaglutide",
       "category": "GLP-1 Agonists",
       "searchTerms": [
@@ -447,7 +447,7 @@
       ]
     },
     {
-      "code": "314121",
+      "code": "1551291",
       "displayName": "Dulaglutide",
       "category": "GLP-1 Agonists",
       "searchTerms": [
@@ -456,7 +456,7 @@
       ]
     },
     {
-      "code": "314122",
+      "code": "723",
       "displayName": "Amoxicillin",
       "category": "Antibiotics",
       "searchTerms": [
@@ -466,17 +466,17 @@
       ]
     },
     {
-      "code": "314123",
+      "code": "214178",
       "displayName": "Amoxicillin-clavulanate",
       "category": "Antibiotics",
       "searchTerms": [
-        "amoxicilina-clavulánico",
+        "amoxicilina-clavul\u00e1nico",
         "Augmentin",
         "Amoxiclav"
       ]
     },
     {
-      "code": "314124",
+      "code": "2231",
       "displayName": "Cephalexin",
       "category": "Cephalosporins",
       "searchTerms": [
@@ -486,7 +486,7 @@
       ]
     },
     {
-      "code": "314125",
+      "code": "2220",
       "displayName": "Ceftriaxone",
       "category": "Cephalosporins",
       "searchTerms": [
@@ -496,7 +496,7 @@
       ]
     },
     {
-      "code": "314126",
+      "code": "2551",
       "displayName": "Ciprofloxacin",
       "category": "Fluoroquinolones",
       "searchTerms": [
@@ -506,7 +506,7 @@
       ]
     },
     {
-      "code": "314127",
+      "code": "82122",
       "displayName": "Levofloxacin",
       "category": "Fluoroquinolones",
       "searchTerms": [
@@ -516,17 +516,17 @@
       ]
     },
     {
-      "code": "314128",
+      "code": "18631",
       "displayName": "Azithromycin",
       "category": "Macrolides",
       "searchTerms": [
         "azitromicina",
         "Zithromax",
-        "macrólido"
+        "macr\u00f3lido"
       ]
     },
     {
-      "code": "314129",
+      "code": "21212",
       "displayName": "Clarithromycin",
       "category": "Macrolides",
       "searchTerms": [
@@ -535,7 +535,7 @@
       ]
     },
     {
-      "code": "314130",
+      "code": "3640",
       "displayName": "Doxycycline",
       "category": "Tetracyclines",
       "searchTerms": [
@@ -545,7 +545,7 @@
       ]
     },
     {
-      "code": "314131",
+      "code": "6922",
       "displayName": "Metronidazole",
       "category": "Antibiotics",
       "searchTerms": [
@@ -555,7 +555,7 @@
       ]
     },
     {
-      "code": "314132",
+      "code": "190361",
       "displayName": "Sulfamethoxazole-trimethoprim",
       "category": "Sulfonamides",
       "searchTerms": [
@@ -566,7 +566,7 @@
       ]
     },
     {
-      "code": "314133",
+      "code": "2582",
       "displayName": "Clindamycin",
       "category": "Antibiotics",
       "searchTerms": [
@@ -575,16 +575,16 @@
       ]
     },
     {
-      "code": "314134",
+      "code": "7393",
       "displayName": "Nitrofurantoin",
       "category": "Urinary Antibiotics",
       "searchTerms": [
-        "nitrofurantoína",
+        "nitrofuranto\u00edna",
         "Macrobid"
       ]
     },
     {
-      "code": "314135",
+      "code": "5640",
       "displayName": "Ibuprofen",
       "category": "NSAIDs",
       "searchTerms": [
@@ -595,7 +595,7 @@
       ]
     },
     {
-      "code": "314136",
+      "code": "7299",
       "displayName": "Naproxen",
       "category": "NSAIDs",
       "searchTerms": [
@@ -605,7 +605,7 @@
       ]
     },
     {
-      "code": "314137",
+      "code": "3350",
       "displayName": "Diclofenac",
       "category": "NSAIDs",
       "searchTerms": [
@@ -615,28 +615,28 @@
       ]
     },
     {
-      "code": "314138",
+      "code": "161",
       "displayName": "Acetaminophen",
       "category": "Analgesics",
       "searchTerms": [
         "paracetamol",
-        "acetaminofén",
+        "acetaminof\u00e9n",
         "Tylenol",
         "Dolex"
       ]
     },
     {
-      "code": "314139",
+      "code": "10689",
       "displayName": "Tramadol",
       "category": "Opioids",
       "searchTerms": [
         "tramadol",
         "Tramal",
-        "analgésico opioide"
+        "analg\u00e9sico opioide"
       ]
     },
     {
-      "code": "314140",
+      "code": "7052",
       "displayName": "Morphine",
       "category": "Opioids",
       "searchTerms": [
@@ -644,7 +644,7 @@
       ]
     },
     {
-      "code": "314141",
+      "code": "7804",
       "displayName": "Oxycodone",
       "category": "Opioids",
       "searchTerms": [
@@ -654,17 +654,17 @@
       ]
     },
     {
-      "code": "314142",
+      "code": "25480",
       "displayName": "Gabapentin",
       "category": "Neuropathic Pain",
       "searchTerms": [
         "gabapentina",
         "Neurontin",
-        "dolor neuropático"
+        "dolor neurop\u00e1tico"
       ]
     },
     {
-      "code": "314143",
+      "code": "187832",
       "displayName": "Pregabalin",
       "category": "Neuropathic Pain",
       "searchTerms": [
@@ -673,7 +673,7 @@
       ]
     },
     {
-      "code": "314144",
+      "code": "435",
       "displayName": "Albuterol",
       "category": "Bronchodilators",
       "searchTerms": [
@@ -684,7 +684,7 @@
       ]
     },
     {
-      "code": "314145",
+      "code": "5975",
       "displayName": "Ipratropium",
       "category": "Anticholinergics",
       "searchTerms": [
@@ -693,7 +693,7 @@
       ]
     },
     {
-      "code": "314146",
+      "code": "41126",
       "displayName": "Fluticasone",
       "category": "Inhaled Corticosteroids",
       "searchTerms": [
@@ -703,7 +703,7 @@
       ]
     },
     {
-      "code": "314147",
+      "code": "17641",
       "displayName": "Budesonide",
       "category": "Inhaled Corticosteroids",
       "searchTerms": [
@@ -712,7 +712,7 @@
       ]
     },
     {
-      "code": "314148",
+      "code": "88249",
       "displayName": "Montelukast",
       "category": "Leukotriene Antagonists",
       "searchTerms": [
@@ -722,17 +722,17 @@
       ]
     },
     {
-      "code": "314149",
+      "code": "32834",
       "displayName": "Loratadine",
       "category": "Antihistamines",
       "searchTerms": [
         "loratadina",
         "Claritin",
-        "antihistamínico"
+        "antihistam\u00ednico"
       ]
     },
     {
-      "code": "314150",
+      "code": "20610",
       "displayName": "Cetirizine",
       "category": "Antihistamines",
       "searchTerms": [
@@ -741,7 +741,7 @@
       ]
     },
     {
-      "code": "314151",
+      "code": "42355",
       "displayName": "Fexofenadine",
       "category": "Antihistamines",
       "searchTerms": [
@@ -750,7 +750,7 @@
       ]
     },
     {
-      "code": "314152",
+      "code": "7646",
       "displayName": "Omeprazole",
       "category": "PPIs",
       "searchTerms": [
@@ -761,7 +761,7 @@
       ]
     },
     {
-      "code": "314153",
+      "code": "40534",
       "displayName": "Pantoprazole",
       "category": "PPIs",
       "searchTerms": [
@@ -770,7 +770,7 @@
       ]
     },
     {
-      "code": "314154",
+      "code": "153165",
       "displayName": "Esomeprazole",
       "category": "PPIs",
       "searchTerms": [
@@ -779,7 +779,7 @@
       ]
     },
     {
-      "code": "314155",
+      "code": "29935",
       "displayName": "Lansoprazole",
       "category": "PPIs",
       "searchTerms": [
@@ -788,17 +788,17 @@
       ]
     },
     {
-      "code": "314156",
+      "code": "9143",
       "displayName": "Ranitidine",
       "category": "H2 Antagonists",
       "searchTerms": [
         "ranitidina",
         "Zantac",
-        "antihistamínico H2"
+        "antihistam\u00ednico H2"
       ]
     },
     {
-      "code": "314157",
+      "code": "4278",
       "displayName": "Famotidine",
       "category": "H2 Antagonists",
       "searchTerms": [
@@ -807,17 +807,17 @@
       ]
     },
     {
-      "code": "314158",
+      "code": "26225",
       "displayName": "Ondansetron",
       "category": "Antiemetics",
       "searchTerms": [
-        "ondansetrón",
+        "ondansetr\u00f3n",
         "Zofran",
-        "antiemético"
+        "antiem\u00e9tico"
       ]
     },
     {
-      "code": "314159",
+      "code": "6915",
       "displayName": "Metoclopramide",
       "category": "Prokinetics",
       "searchTerms": [
@@ -826,7 +826,7 @@
       ]
     },
     {
-      "code": "314160",
+      "code": "6448",
       "displayName": "Loperamide",
       "category": "Antidiarrheals",
       "searchTerms": [
@@ -836,7 +836,7 @@
       ]
     },
     {
-      "code": "314161",
+      "code": "1538",
       "displayName": "Bismuth subsalicylate",
       "category": "Antidiarrheals",
       "searchTerms": [
@@ -845,18 +845,18 @@
       ]
     },
     {
-      "code": "314162",
+      "code": "596",
       "displayName": "Alprazolam",
       "category": "Benzodiazepines",
       "searchTerms": [
         "alprazolam",
         "Xanax",
-        "ansiolítico",
+        "ansiol\u00edtico",
         "benzodiazepina"
       ]
     },
     {
-      "code": "314163",
+      "code": "6470",
       "displayName": "Lorazepam",
       "category": "Benzodiazepines",
       "searchTerms": [
@@ -865,7 +865,7 @@
       ]
     },
     {
-      "code": "314164",
+      "code": "3322",
       "displayName": "Diazepam",
       "category": "Benzodiazepines",
       "searchTerms": [
@@ -874,7 +874,7 @@
       ]
     },
     {
-      "code": "314165",
+      "code": "2598",
       "displayName": "Clonazepam",
       "category": "Benzodiazepines",
       "searchTerms": [
@@ -883,7 +883,7 @@
       ]
     },
     {
-      "code": "314166",
+      "code": "4493",
       "displayName": "Fluoxetine",
       "category": "SSRIs",
       "searchTerms": [
@@ -894,7 +894,7 @@
       ]
     },
     {
-      "code": "314167",
+      "code": "36437",
       "displayName": "Sertraline",
       "category": "SSRIs",
       "searchTerms": [
@@ -903,7 +903,7 @@
       ]
     },
     {
-      "code": "314168",
+      "code": "321988",
       "displayName": "Escitalopram",
       "category": "SSRIs",
       "searchTerms": [
@@ -913,7 +913,7 @@
       ]
     },
     {
-      "code": "314169",
+      "code": "7934",
       "displayName": "Paroxetine",
       "category": "SSRIs",
       "searchTerms": [
@@ -922,7 +922,7 @@
       ]
     },
     {
-      "code": "314170",
+      "code": "39786",
       "displayName": "Venlafaxine",
       "category": "SNRIs",
       "searchTerms": [
@@ -932,7 +932,7 @@
       ]
     },
     {
-      "code": "314171",
+      "code": "236430",
       "displayName": "Duloxetine",
       "category": "SNRIs",
       "searchTerms": [
@@ -941,7 +941,7 @@
       ]
     },
     {
-      "code": "314172",
+      "code": "15996",
       "displayName": "Mirtazapine",
       "category": "Antidepressants",
       "searchTerms": [
@@ -950,38 +950,38 @@
       ]
     },
     {
-      "code": "314173",
+      "code": "704",
       "displayName": "Amitriptyline",
       "category": "Tricyclic Antidepressants",
       "searchTerms": [
         "amitriptilina",
         "ADT",
-        "antidepresivo tricíclico"
+        "antidepresivo tric\u00edclico"
       ]
     },
     {
-      "code": "314174",
+      "code": "2002",
       "displayName": "Carbamazepine",
       "category": "Anticonvulsants",
       "searchTerms": [
         "carbamazepina",
         "Tegretol",
         "anticonvulsivante",
-        "estabilizador ánimo"
+        "estabilizador \u00e1nimo"
       ]
     },
     {
-      "code": "314175",
+      "code": "11002",
       "displayName": "Valproic acid",
       "category": "Anticonvulsants",
       "searchTerms": [
-        "ácido valproico",
+        "\u00e1cido valproico",
         "valproato",
         "Depakote"
       ]
     },
     {
-      "code": "314176",
+      "code": "28439",
       "displayName": "Lamotrigine",
       "category": "Anticonvulsants",
       "searchTerms": [
@@ -990,7 +990,7 @@
       ]
     },
     {
-      "code": "314177",
+      "code": "137130",
       "displayName": "Levetiracetam",
       "category": "Anticonvulsants",
       "searchTerms": [
@@ -999,7 +999,7 @@
       ]
     },
     {
-      "code": "314178",
+      "code": "6901",
       "displayName": "Methylphenidate",
       "category": "Stimulants",
       "searchTerms": [
@@ -1010,7 +1010,7 @@
       ]
     },
     {
-      "code": "314179",
+      "code": "10582",
       "displayName": "Levothyroxine",
       "category": "Thyroid Hormones",
       "searchTerms": [
@@ -1022,7 +1022,7 @@
       ]
     },
     {
-      "code": "314180",
+      "code": "8640",
       "displayName": "Prednisone",
       "category": "Corticosteroids",
       "searchTerms": [
@@ -1032,7 +1032,7 @@
       ]
     },
     {
-      "code": "314181",
+      "code": "3264",
       "displayName": "Dexamethasone",
       "category": "Corticosteroids",
       "searchTerms": [
@@ -1041,7 +1041,7 @@
       ]
     },
     {
-      "code": "314182",
+      "code": "5492",
       "displayName": "Hydrocortisone",
       "category": "Corticosteroids",
       "searchTerms": [
@@ -1050,7 +1050,7 @@
       ]
     },
     {
-      "code": "314183",
+      "code": "4450",
       "displayName": "Alendronate",
       "category": "Bisphosphonates",
       "searchTerms": [
@@ -1061,7 +1061,7 @@
       ]
     },
     {
-      "code": "314184",
+      "code": "1897",
       "displayName": "Calcium carbonate",
       "category": "Minerals",
       "searchTerms": [
@@ -1071,7 +1071,7 @@
       ]
     },
     {
-      "code": "314185",
+      "code": "24188",
       "displayName": "Vitamin D3",
       "category": "Vitamins",
       "searchTerms": [
@@ -1081,17 +1081,17 @@
       ]
     },
     {
-      "code": "314186",
+      "code": "10324",
       "displayName": "Tamoxifen",
       "category": "Antiestrogens",
       "searchTerms": [
         "tamoxifeno",
         "Nolvadex",
-        "cáncer mama"
+        "c\u00e1ncer mama"
       ]
     },
     {
-      "code": "314187",
+      "code": "6711",
       "displayName": "Methotrexate",
       "category": "Antimetabolites",
       "searchTerms": [
@@ -1101,17 +1101,17 @@
       ]
     },
     {
-      "code": "314188",
+      "code": "135561",
       "displayName": "Sildenafil",
       "category": "PDE5 Inhibitors",
       "searchTerms": [
         "sildenafil",
         "Viagra",
-        "disfunción eréctil"
+        "disfunci\u00f3n er\u00e9ctil"
       ]
     },
     {
-      "code": "314189",
+      "code": "321207",
       "displayName": "Tadalafil",
       "category": "PDE5 Inhibitors",
       "searchTerms": [
@@ -1120,7 +1120,7 @@
       ]
     },
     {
-      "code": "314190",
+      "code": "4441",
       "displayName": "Finasteride",
       "category": "5-alpha Reductase Inhibitors",
       "searchTerms": [
@@ -1131,7 +1131,7 @@
       ]
     },
     {
-      "code": "314191",
+      "code": "38454",
       "displayName": "Tamsulosin",
       "category": "Alpha Blockers",
       "searchTerms": [
@@ -1141,7 +1141,7 @@
       ]
     },
     {
-      "code": "314192",
+      "code": "558",
       "displayName": "Allopurinol",
       "category": "Xanthine Oxidase Inhibitors",
       "searchTerms": [
@@ -1151,12 +1151,40 @@
       ]
     },
     {
-      "code": "314193",
+      "code": "2683",
       "displayName": "Colchicine",
       "category": "Anti-gout",
       "searchTerms": [
         "colchicina",
         "gota"
+      ]
+    },
+    {
+      "code": "8123",
+      "displayName": "Phenelzine",
+      "category": "MAOIs",
+      "searchTerms": [
+        "phenelzine",
+        "Nardil"
+      ]
+    },
+    {
+      "code": "9744",
+      "displayName": "Selegiline",
+      "category": "MAOIs",
+      "searchTerms": [
+        "selegiline",
+        "Emsam",
+        "Eldepryl"
+      ]
+    },
+    {
+      "code": "5970",
+      "displayName": "Iohexol",
+      "category": "Contrast Agents",
+      "searchTerms": [
+        "iohexol",
+        "Omnipaque"
       ]
     }
   ]

--- a/test/features/medications/drug_interaction_checker_test.dart
+++ b/test/features/medications/drug_interaction_checker_test.dart
@@ -13,8 +13,8 @@ void main() {
   group('DrugInteractionChecker - Drug-Drug Interactions', () {
     test('detects major interaction between specific RxNorm codes (Warfarin + Aspirin)', () {
       final medications = [
-        const Medication(rxnormCode: '161', displayName: 'Warfarin'),
-        const Medication(rxnormCode: '310410', displayName: 'Aspirin'),
+        const Medication(rxnormCode: '11289', displayName: 'Warfarin'),
+        const Medication(rxnormCode: '1191', displayName: 'Aspirin'),
       ];
 
       final result = checker.checkInteractions(medications);
@@ -47,7 +47,7 @@ void main() {
 
     test('returns no interactions for safe combination (Acetaminophen + Amoxicillin)', () {
       final medications = [
-        const Medication(rxnormCode: '1611', displayName: 'Acetaminophen'),
+        const Medication(rxnormCode: '161', displayName: 'Acetaminophen'),
         const Medication(rxnormCode: '723', displayName: 'Amoxicillin'),
       ];
 
@@ -74,8 +74,8 @@ void main() {
 
     test('generates critical insights for major interactions', () {
       final medications = [
-        const Medication(rxnormCode: '161', displayName: 'Warfarin'),
-        const Medication(rxnormCode: '310410', displayName: 'Aspirin'),
+        const Medication(rxnormCode: '11289', displayName: 'Warfarin'),
+        const Medication(rxnormCode: '1191', displayName: 'Aspirin'),
       ];
 
       final result = checker.checkInteractions(medications);
@@ -87,12 +87,12 @@ void main() {
     test('supports Spanish medication names via displayName', () {
       final medications = [
         const Medication(
-          rxnormCode: '111',
+          rxnormCode: '11289',
           displayName: 'Warfarina',
           drugClass: 'anticoagulant'
         ),
         const Medication(
-          rxnormCode: '222',
+          rxnormCode: '5640',
           displayName: 'Aspirina',
           drugClass: 'nsaid'
         ),


### PR DESCRIPTION
This PR introduces a comprehensive drug-drug interaction dataset for OrionHealth's offline safety checker. 

Key changes:
1. **RxNorm Alignment**: Replaced hallucinated/placeholder codes with standard Ingredient-level RxCUIs across the medication catalog (`rxnorm.json`) and the clinical analysis logic (`DrugInteractionChecker.dart`).
2. **Catalog Expansion**: Added MAOIs (Phenelzine, Selegiline) and Contrast Agents (Iohexol) to the reference data.
3. **New Asset**: Created `assets/medical-standards/drug_interactions.json` containing 181 high-priority interaction pairs, specifically covering requested categories like SSRIs+MAOIs and Metformin+Contrast.
4. **Validation**: Updated unit tests to reflect standard codes and verified that the `DrugInteractionChecker` correctly identifies major and moderate interactions.

Fixes #229

---
*PR created automatically by Jules for task [13055874990819370399](https://jules.google.com/task/13055874990819370399) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced comprehensive drug-drug interaction database containing 181 documented interaction records with severity levels and clinical descriptions
  * Expanded medical drug reference database from 118 to 121 medications, including newly added drugs (Phenelzine, Selegiline, and Iohexol)
  * Updated standardized drug identifiers across the system for improved consistency and accuracy

* **Tests**
  * Updated test fixtures to align with revised drug codes and database structure

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/iberi22/OrionHealth/pull/236)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->