### PR TITLE
Complete AnonCreds Revocation Flow

### DIFF
--- a/lib/features/ssi/domain/services/anoncreds_service.dart
+++ b/lib/features/ssi/domain/services/anoncreds_service.dart
@@ -53,6 +53,12 @@ abstract class AnonCredsService {
   /// Future verifications can check non-revocation via the registry.
   Future<void> revokeCredential(String credentialId, AnonCredsKeyPair issuerKeys);
 
+  /// Check if a specific credential has been revoked.
+  ///
+  /// Returns true if a valid revocation entry exists for the given
+  /// [issuerPublicKey] and [credentialIndex].
+  Future<bool> isCredentialRevoked(String issuerPublicKey, int credentialIndex);
+
   /// Check if the service is available.
   Future<bool> isAvailable();
 }

--- a/lib/features/ssi/infrastructure/services/anoncreds_service_impl.dart
+++ b/lib/features/ssi/infrastructure/services/anoncreds_service_impl.dart
@@ -149,6 +149,9 @@ class AnonCredsServiceImpl implements AnonCredsService {
     AnonCredsPresentation presentation, {
     String? expectedLinkSecret,
   }) async {
+    // Explicitly check if the presented credential has been marked as revoked
+    if (presentation.credential.isRevoked) return false;
+
     final proof = _parseProof(presentation.credential.proof);
     if (proof == null) return false;
 
@@ -191,34 +194,11 @@ class AnonCredsServiceImpl implements AnonCredsService {
       if (entry.value != _hashValue(actualClaim.toString())) return false;
     }
 
-    // Check non-revocation
+    // Check non-revocation registry
     final credentialIndex = proof['credentialIndex'] as int?;
     if (credentialIndex != null) {
-      final revocationEntry = await _repository.getRevocationEntry(
-        issuerKeyB64,
-        credentialIndex,
-      );
-
-      if (revocationEntry != null) {
-        // Verify revocation signature
-        final dataToVerify = '${revocationEntry.issuerPublicKey}:${revocationEntry.credentialIndex}:${revocationEntry.revokedAt.toIso8601String()}';
-        final publicKey = SimplePublicKey(
-          _decodeBase64Url(revocationEntry.issuerPublicKey),
-          type: KeyPairType.ed25519,
-        );
-
-        final isSignatureValid = await _ed25519.verify(
-          utf8.encode(dataToVerify),
-          signature: Signature(
-            _decodeBase64Url(revocationEntry.issuerSignature),
-            publicKey: publicKey,
-          ),
-        );
-
-        if (isSignatureValid) {
-          return false; // Credential is validly revoked
-        }
-      }
+      final isRevoked = await isCredentialRevoked(issuerKeyB64, credentialIndex);
+      if (isRevoked) return false;
     }
 
     return true;
@@ -234,7 +214,7 @@ class AnonCredsServiceImpl implements AnonCredsService {
     final credentialIndex = proof?['credentialIndex'] as int?;
     if (credentialIndex == null) return;
 
-    final revokedAt = DateTime.now();
+    final revokedAt = DateTime.now().toUtc();
     final dataToSign = '${issuerKeys.publicKey}:$credentialIndex:${revokedAt.toIso8601String()}';
 
     final keyPair = _reconstructKeyPair(
@@ -256,6 +236,50 @@ class AnonCredsServiceImpl implements AnonCredsService {
     );
 
     await _repository.saveRevocationEntry(entry);
+
+    // Also update the local credential record for standard SSI consistency
+    final revokedVc = VerifiableCredential(
+      id: credential.id,
+      issuer: credential.issuer,
+      subject: credential.subject,
+      type: credential.type,
+      schemaId: credential.schemaId,
+      claims: credential.claims,
+      issuanceDate: credential.issuanceDate,
+      expirationDate: credential.expirationDate,
+      proof: credential.proof,
+      isRevoked: true,
+    );
+    await _repository.saveCredential(revokedVc);
+  }
+
+  @override
+  Future<bool> isCredentialRevoked(
+      String issuerPublicKey, int credentialIndex) async {
+    final revocationEntry = await _repository.getRevocationEntry(
+      issuerPublicKey,
+      credentialIndex,
+    );
+
+    if (revocationEntry == null) return false;
+
+    // Verify revocation signature
+    final dataToVerify =
+        '${revocationEntry.issuerPublicKey}:${revocationEntry.credentialIndex}:${revocationEntry.revokedAt.toUtc().toIso8601String()}';
+    final publicKey = SimplePublicKey(
+      _decodeBase64Url(revocationEntry.issuerPublicKey),
+      type: KeyPairType.ed25519,
+    );
+
+    final isSignatureValid = await _ed25519.verify(
+      utf8.encode(dataToVerify),
+      signature: Signature(
+        _decodeBase64Url(revocationEntry.issuerSignature),
+        publicKey: publicKey,
+      ),
+    );
+
+    return isSignatureValid;
   }
 
   @override

--- a/test/features/ssi/anoncreds_revocation_test.dart
+++ b/test/features/ssi/anoncreds_revocation_test.dart
@@ -1,0 +1,99 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/ssi/domain/entities/verifiable_credential.dart';
+import 'package:orionhealth_health/features/ssi/domain/entities/did.dart';
+import 'package:orionhealth_health/features/ssi/domain/entities/revocation_entry.dart';
+import 'package:orionhealth_health/features/ssi/domain/repositories/ssi_repository.dart';
+import 'package:orionhealth_health/features/ssi/infrastructure/services/anoncreds_service_impl.dart';
+
+class FakeSsiRepository implements SsiRepository {
+  final Map<String, VerifiableCredential> _credentials = {};
+  final Map<String, RevocationEntry> _revocations = {};
+
+  @override
+  Future<void> saveDid(Did did, Map<String, dynamic> didDocument) async {}
+  @override
+  Future<List<Did>> getDids() async => [];
+  @override
+  Future<Map<String, dynamic>?> getDidDocument(String did) async => null;
+
+  @override
+  Future<void> saveCredential(VerifiableCredential credential) async {
+    _credentials[credential.id] = credential;
+  }
+
+  @override
+  Future<List<VerifiableCredential>> getCredentials() async => _credentials.values.toList();
+
+  @override
+  Future<VerifiableCredential?> getCredentialById(String credentialId) async => _credentials[credentialId];
+
+  @override
+  Future<void> deleteCredential(String credentialId) async {
+    _credentials.remove(credentialId);
+  }
+
+  @override
+  Future<void> saveRevocationEntry(RevocationEntry entry) async {
+    _revocations['${entry.issuerPublicKey}_${entry.credentialIndex}'] = entry;
+  }
+
+  @override
+  Future<RevocationEntry?> getRevocationEntry(String issuerPublicKey, int credentialIndex) async {
+    return _revocations['${issuerPublicKey}_$credentialIndex'];
+  }
+}
+
+void main() {
+  late AnonCredsServiceImpl service;
+  late FakeSsiRepository repository;
+
+  setUp(() {
+    repository = FakeSsiRepository();
+    service = AnonCredsServiceImpl(repository);
+  });
+
+  test('Revocation flow', () async {
+    final issuerKeys = await service.generateIssuerKeys();
+
+    final vc = VerifiableCredential(
+      id: 'vc:123',
+      issuer: 'did:orion:issuer',
+      subject: 'did:orion:subject',
+      type: 'TestCredential',
+      schemaId: 'schema:1',
+      claims: {'name': 'Alice'},
+      issuanceDate: DateTime.now(),
+    );
+
+    // 1. Issue
+    final anonCredsVc = await service.issueCredential(
+      credential: vc,
+      issuerKeys: issuerKeys,
+    );
+
+    // We must save it for revocation to find it by ID
+    await repository.saveCredential(anonCredsVc);
+
+    // 2. Create presentation
+    final presentation = await service.createPresentation(
+      credential: anonCredsVc,
+      disclosedFields: ['name'],
+    );
+
+    // 3. Verify (should be valid)
+    expect(await service.verifyPresentation(presentation), isTrue);
+
+    // 4. Revoke
+    await service.revokeCredential(anonCredsVc.id, issuerKeys);
+
+    // Check explicit revocation method
+    final proof = jsonDecode(anonCredsVc.proof!);
+    final index = proof['credentialIndex'] as int;
+    expect(await service.isCredentialRevoked(issuerKeys.publicKey, index), isTrue);
+
+    // 5. Verify (should be invalid)
+    final isValidAfterRevocation = await service.verifyPresentation(presentation);
+    expect(isValidAfterRevocation, isFalse);
+  });
+}


### PR DESCRIPTION
This PR completes the AnonCreds revocation flow within the SSI module. 

Key changes include:
1. **Interface Update**: Added `isCredentialRevoked` to `AnonCredsService` to allow verifiers to explicitly check a credential's status against the issuer's registry.
2. **Synchronized Revocation**: Updated `AnonCredsServiceImpl.revokeCredential` to not only create a signed `RevocationEntry` but also update the `isRevoked` flag on the local `VerifiableCredential` record, ensuring architectural consistency.
3. **Robust Verification**: Refactored `verifyPresentation` to perform a multi-layered check:
   - An early exit if the holder's presented credential is already marked as revoked.
   - A cryptographic check against the local repository's revocation registry using the `credentialIndex`.
4. **Cryptographic Integrity**: Normalized all revocation timestamps to UTC before signing/verifying to ensure deterministic behavior across different timezones.
5. **Testing**: Introduced `test/features/ssi/anoncreds_revocation_test.dart` which covers the full lifecycle of issuance, revocation, and presentation verification.

These changes bring the PoC closer to a production-ready SSI implementation by fulfilling the non-revocation requirements of the AnonCreds standard.

Fixes #244

---
*PR created automatically by Jules for task [9388018266482747212](https://jules.google.com/task/9388018266482747212) started by @iberi22*