### PR TITLE
Connect Home Screen Vitals and Indexing Status

### DIFF
--- a/lib/features/home/application/home_cubit.dart
+++ b/lib/features/home/application/home_cubit.dart
@@ -1,0 +1,56 @@
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../vitals/domain/repositories/vital_sign_repository.dart';
+import '../../local_agent/infrastructure/services/medical_indexing_service.dart';
+import 'home_state.dart';
+
+class HomeCubit extends Cubit<HomeState> {
+  final VitalSignRepository _vitalSignRepository;
+  final MedicalIndexingService _indexingService;
+  StreamSubscription<bool>? _indexingSubscription;
+
+  HomeCubit(this._vitalSignRepository, this._indexingService) : super(const HomeState()) {
+    _init();
+  }
+
+  void _init() {
+    emit(state.copyWith(isIndexing: !_indexingService.hasIndexed));
+
+    _indexingSubscription = _indexingService.statusStream.listen((isDone) {
+      emit(state.copyWith(
+        isIndexing: !isDone,
+        indexingError: false,
+      ));
+    });
+
+    loadVitals();
+  }
+
+  Future<void> retryIndexing() async {
+    emit(state.copyWith(isIndexing: true, indexingError: false));
+    try {
+      final result = await _indexingService.indexAll(force: true);
+      if (!result.success) {
+        emit(state.copyWith(isIndexing: false, indexingError: true));
+      }
+    } catch (e) {
+      emit(state.copyWith(isIndexing: false, indexingError: true));
+    }
+  }
+
+  Future<void> loadVitals() async {
+    emit(state.copyWith(isLoadingVitals: true));
+    try {
+      final vitals = await _vitalSignRepository.getLatestVitals();
+      emit(state.copyWith(latestVitals: vitals, isLoadingVitals: false));
+    } catch (e) {
+      emit(state.copyWith(error: e.toString(), isLoadingVitals: false));
+    }
+  }
+
+  @override
+  Future<void> close() {
+    _indexingSubscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/home/application/home_state.dart
+++ b/lib/features/home/application/home_state.dart
@@ -1,0 +1,37 @@
+import 'package:equatable/equatable.dart';
+import '../../vitals/domain/entities/vital_sign.dart';
+
+class HomeState extends Equatable {
+  final Map<VitalSignType, VitalSign?> latestVitals;
+  final bool isIndexing;
+  final bool isLoadingVitals;
+  final bool indexingError;
+  final String? error;
+
+  const HomeState({
+    this.latestVitals = const {},
+    this.isIndexing = false,
+    this.isLoadingVitals = true,
+    this.indexingError = false,
+    this.error,
+  });
+
+  HomeState copyWith({
+    Map<VitalSignType, VitalSign?>? latestVitals,
+    bool? isIndexing,
+    bool? isLoadingVitals,
+    bool? indexingError,
+    String? error,
+  }) {
+    return HomeState(
+      latestVitals: latestVitals ?? this.latestVitals,
+      isIndexing: isIndexing ?? this.isIndexing,
+      isLoadingVitals: isLoadingVitals ?? this.isLoadingVitals,
+      indexingError: indexingError ?? this.indexingError,
+      error: error ?? this.error,
+    );
+  }
+
+  @override
+  List<Object?> get props => [latestVitals, isIndexing, isLoadingVitals, indexingError, error];
+}

--- a/lib/features/local_agent/infrastructure/services/medical_indexing_service.dart
+++ b/lib/features/local_agent/infrastructure/services/medical_indexing_service.dart
@@ -26,6 +26,7 @@ class MedicalIndexingService {
   bool _hasIndexed = false;
   int _indexedCount = 0;
   int _errorCount = 0;
+  final StreamController<bool> _statusController = StreamController<bool>.broadcast();
 
   MedicalIndexingService(
     this._knowledgeRepo,
@@ -35,6 +36,9 @@ class MedicalIndexingService {
 
   /// Whether the full indexing pass has completed.
   bool get hasIndexed => _hasIndexed;
+
+  /// Stream of indexing status (true when done).
+  Stream<bool> get statusStream => _statusController.stream;
 
   /// How many documents were successfully indexed.
   int get indexedCount => _indexedCount;
@@ -48,6 +52,7 @@ class MedicalIndexingService {
   /// unless [force] is true.
   Future<IndexingResult> indexAll({bool force = false}) async {
     if (_hasIndexed && !force) {
+      _statusController.add(true);
       return IndexingResult(
         total: _indexedCount + _errorCount,
         indexed: _indexedCount,
@@ -55,6 +60,8 @@ class MedicalIndexingService {
         skipped: true,
       );
     }
+
+    _statusController.add(false);
 
     // 1. Ensure knowledge repo is initialized
     await _knowledgeRepo.initialize();
@@ -84,6 +91,7 @@ class MedicalIndexingService {
     _indexedCount = indexed;
     _errorCount = errors;
     _hasIndexed = true;
+    _statusController.add(true);
 
     // 4. Also index patient context
     // This is non-blocking to the medical standards indexing result

--- a/lib/features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart
+++ b/lib/features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart
@@ -1,10 +1,10 @@
 import '../../domain/entities/medical_query.dart';
 import '../../domain/entities/medical_insight.dart';
 import '../../domain/entities/ai_response.dart';
-import '../../domain/services/medical_analysis_service.dart';
 import '../../../../core/services/privacy_anonymizer.dart';
 import 'medical_response_generator.dart';
 import '../../../local_agent/infrastructure/llm_service.dart';
+import '../../domain/entities/analysis_response.dart';
 
 /// Adapter for medical LLM API integration.
 ///

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -3,11 +3,12 @@
 
 import 'dart:async';
 import 'package:flutter/material.dart';
-import 'package:flutter_localizations/flutter_localizations.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'l10n/app_localizations.dart';
 import 'core/di/injection.dart';
 import 'core/responsive/responsive_layout.dart';
 import 'core/theme/app_theme.dart';
+import 'core/widgets/glassmorphic_card.dart';
 
 import 'core/widgets/floating_assistant_button.dart';
 import 'core/widgets/page_header.dart';
@@ -16,9 +17,29 @@ import 'features/reports/presentation/pages/reports_page.dart';
 import 'features/user_profile/presentation/pages/user_profile_page.dart';
 import 'package:isar_agent_memory/isar_agent_memory.dart';
 import 'features/local_agent/infrastructure/services/medical_indexing_service.dart';
+import 'features/home/application/home_cubit.dart';
+import 'features/home/application/home_state.dart';
+import 'features/vitals/domain/entities/vital_sign.dart';
+import 'features/vitals/domain/repositories/vital_sign_repository.dart';
 
 class HomePage extends StatelessWidget {
   const HomePage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => HomeCubit(
+        getIt<VitalSignRepository>(),
+        getIt<MedicalIndexingService>(),
+      ),
+      child: const _HomePageView(),
+    );
+  }
+}
+
+class _HomePageView extends StatelessWidget {
+  const _HomePageView();
+
   @override
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
@@ -32,6 +53,7 @@ class HomePage extends StatelessWidget {
                 title: l10n.homeTitle,
                 subtitle: l10n.homeSubtitle,
               ),
+              const IndexingStatusBanner(),
               Padding(
                 padding: const EdgeInsets.symmetric(horizontal: 16.0),
                 child: Column(
@@ -53,43 +75,158 @@ class HomePage extends StatelessWidget {
   }
 }
 
-class _HealthStatusGrid extends StatelessWidget {
-  const _HealthStatusGrid();
+class IndexingStatusBanner extends StatefulWidget {
+  const IndexingStatusBanner({super.key});
+
+  @override
+  State<IndexingStatusBanner> createState() => _IndexingStatusBannerState();
+}
+
+class _IndexingStatusBannerState extends State<IndexingStatusBanner> {
+  bool _showSuccess = false;
+
   @override
   Widget build(BuildContext context) {
-    return GridView.count(
-      shrinkWrap: true,
-      physics: const NeverScrollableScrollPhysics(),
-      crossAxisCount: MediaQuery.of(context).size.width > 600 ? 4 : 2,
-      mainAxisSpacing: 12,
-      crossAxisSpacing: 12,
-      children: const [
-        _StatusCard(
-          icon: Icons.favorite,
-          label: 'Ritmo Cardíaco',
-          value: '72 bpm',
-          color: Colors.redAccent,
-        ),
-        _StatusCard(
-          icon: Icons.bloodtype,
-          label: 'Presión Arterial',
-          value: '120/80',
-          color: Colors.blueAccent,
-        ),
-        _StatusCard(
-          icon: Icons.thermostat,
-          label: 'Temperatura',
-          value: '36.5 °C',
-          color: Colors.orangeAccent,
-        ),
-        _StatusCard(
-          icon: Icons.water_drop,
-          label: 'Oxígeno (SpO2)',
-          value: '98%',
-          color: Colors.cyanAccent,
-        ),
-      ],
+    return BlocListener<HomeCubit, HomeState>(
+      listenWhen: (previous, current) => previous.isIndexing && !current.isIndexing,
+      listener: (context, state) {
+        setState(() => _showSuccess = true);
+        Future.delayed(const Duration(seconds: 3), () {
+          if (mounted) setState(() => _showSuccess = false);
+        });
+      },
+      child: BlocBuilder<HomeCubit, HomeState>(
+        builder: (context, state) {
+          if (state.isIndexing) {
+            return Container(
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              color: Colors.blue.withValues(alpha: 0.1),
+              child: const Row(
+                children: [
+                  SizedBox(
+                    width: 16,
+                    height: 16,
+                    child: CircularProgressIndicator(strokeWidth: 2),
+                  ),
+                  SizedBox(width: 12),
+                  Text(
+                    'Sincronizando estándares médicos...',
+                    style: TextStyle(fontSize: 12, color: Colors.blue),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          if (state.indexingError) {
+            return Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              color: Colors.red.withValues(alpha: 0.1),
+              child: Row(
+                children: [
+                  const Icon(Icons.error_outline, color: Colors.red, size: 16),
+                  const SizedBox(width: 12),
+                  const Expanded(
+                    child: Text(
+                      'Error sincronizando estándares médicos',
+                      style: TextStyle(fontSize: 12, color: Colors.red),
+                    ),
+                  ),
+                  TextButton(
+                    onPressed: () => context.read<HomeCubit>().retryIndexing(),
+                    style: TextButton.styleFrom(
+                      padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+                      minimumSize: Size.zero,
+                      tapTargetSize: MaterialTapTargetSize.shrinkWrap,
+                    ),
+                    child: const Text('Reintentar', style: TextStyle(fontSize: 12)),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          if (_showSuccess) {
+            return Container(
+              width: double.infinity,
+              padding: const EdgeInsets.symmetric(horizontal: 16, vertical: 8),
+              color: Colors.green.withValues(alpha: 0.1),
+              child: const Row(
+                children: [
+                  Icon(Icons.check_circle, color: Colors.green, size: 16),
+                  SizedBox(width: 12),
+                  Text(
+                    'Sincronización completada',
+                    style: TextStyle(fontSize: 12, color: Colors.green),
+                  ),
+                ],
+              ),
+            );
+          }
+
+          return const SizedBox.shrink();
+        },
+      ),
     );
+  }
+}
+
+class _HealthStatusGrid extends StatelessWidget {
+  const _HealthStatusGrid();
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocBuilder<HomeCubit, HomeState>(
+      builder: (context, state) {
+        final vitals = state.latestVitals;
+
+        return GridView.count(
+          shrinkWrap: true,
+          physics: const NeverScrollableScrollPhysics(),
+          crossAxisCount: MediaQuery.of(context).size.width > 600 ? 4 : 2,
+          mainAxisSpacing: 12,
+          crossAxisSpacing: 12,
+          children: [
+            _StatusCard(
+              icon: Icons.favorite,
+              label: 'Ritmo Cardíaco',
+              value: vitals[VitalSignType.heartRate]?.formattedValue ?? 'Sin datos',
+              color: Colors.redAccent,
+              onTap: () {
+                // Navigate to vitals or add vital
+              },
+            ),
+            _StatusCard(
+              icon: Icons.bloodtype,
+              label: 'Presión Arterial',
+              value: _formatBloodPressure(
+                vitals[VitalSignType.bloodPressureSystolic],
+                vitals[VitalSignType.bloodPressureDiastolic],
+              ),
+              color: Colors.blueAccent,
+            ),
+            _StatusCard(
+              icon: Icons.thermostat,
+              label: 'Temperatura',
+              value: vitals[VitalSignType.temperature]?.formattedValue ?? 'Sin datos',
+              color: Colors.orangeAccent,
+            ),
+            _StatusCard(
+              icon: Icons.water_drop,
+              label: 'Oxígeno (SpO2)',
+              value: vitals[VitalSignType.oxygenSaturation]?.formattedValue ?? 'Sin datos',
+              color: Colors.cyanAccent,
+            ),
+          ],
+        );
+      },
+    );
+  }
+
+  String _formatBloodPressure(VitalSign? systolic, VitalSign? diastolic) {
+    if (systolic == null || diastolic == null) return 'Sin datos';
+    return '${systolic.value?.toInt()}/${diastolic.value?.toInt()}';
   }
 }
 
@@ -98,11 +235,21 @@ class _StatusCard extends StatelessWidget {
   final String label;
   final String value;
   final Color color;
-  const _StatusCard({required this.icon, required this.label, required this.value, required this.color});
+  final VoidCallback? onTap;
+
+  const _StatusCard({
+    required this.icon,
+    required this.label,
+    required this.value,
+    required this.color,
+    this.onTap,
+  });
+
   @override
   Widget build(BuildContext context) {
     return GlassmorphicCard(
       padding: const EdgeInsets.all(12),
+      onTap: onTap,
       child: Column(
         mainAxisAlignment: MainAxisAlignment.center,
         children: [
@@ -110,7 +257,20 @@ class _StatusCard extends StatelessWidget {
           const SizedBox(height: 8),
           Text(label, style: const TextStyle(fontSize: 10, color: Colors.white54), textAlign: TextAlign.center),
           const SizedBox(height: 4),
-          Text(value, style: const TextStyle(fontSize: 16, fontWeight: FontWeight.bold)),
+          Text(
+            value,
+            style: TextStyle(
+              fontSize: value == 'Sin datos' ? 14 : 16,
+              fontWeight: FontWeight.bold,
+              color: value == 'Sin datos' ? Colors.white38 : Colors.white,
+            ),
+            textAlign: TextAlign.center,
+          ),
+          if (value == 'Sin datos')
+            Padding(
+              padding: const EdgeInsets.only(top: 4.0),
+                child: Icon(Icons.add_circle_outline, size: 14, color: color.withValues(alpha: 0.5)),
+            ),
         ],
       ),
     );
@@ -131,7 +291,7 @@ class _RecentInsightsSection extends StatelessWidget {
             children: [
               Container(
                 padding: const EdgeInsets.all(8),
-                decoration: BoxDecoration(color: Colors.greenAccent.withOpacity(0.5), shape: BoxShape.circle),
+                decoration: BoxDecoration(color: Colors.greenAccent.withValues(alpha: 0.5), shape: BoxShape.circle),
                 child: const Icon(Icons.auto_awesome, color: Colors.greenAccent),
               ),
               const SizedBox(width: 16),
@@ -161,9 +321,9 @@ class _LocalAgentPromo extends StatelessWidget {
       width: double.infinity,
       padding: const EdgeInsets.all(20),
       decoration: BoxDecoration(
-        gradient: LinearGradient(colors: [AppTheme.darkTheme.primaryColor.withOpacity(0.2), Colors.transparent]),
+        gradient: LinearGradient(colors: [AppTheme.darkTheme.primaryColor.withValues(alpha: 0.2), Colors.transparent]),
         borderRadius: BorderRadius.circular(16),
-        border: Border.all(color: AppTheme.darkTheme.primaryColor.withOpacity(0.3)),
+        border: Border.all(color: AppTheme.darkTheme.primaryColor.withValues(alpha: 0.3)),
       ),
       child: Column(
         crossAxisAlignment: CrossAxisAlignment.start,
@@ -298,10 +458,10 @@ class _MainNavigationPageState extends State<MainNavigationPage> {
   List<({IconData icon, IconData activeIcon, String label})> _getDestinations(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     return [
-      (icon: Icons.home_outlined, activeIcon: Icons.home, label: l10n.navHome),
-      (icon: Icons.calendar_month_outlined, activeIcon: Icons.calendar_month, label: l10n.navAppointments),
-      (icon: Icons.folder_shared_outlined, activeIcon: Icons.folder_shared, label: l10n.navFiles),
-      (icon: Icons.person_outline, activeIcon: Icons.person, label: l10n.navProfile),
+      (icon: Icons.home_outlined, activeIcon: Icons.home, label: l10n.home),
+      (icon: Icons.calendar_month_outlined, activeIcon: Icons.calendar_month, label: 'Citas'),
+      (icon: Icons.folder_shared_outlined, activeIcon: Icons.folder_shared, label: l10n.records),
+      (icon: Icons.person_outline, activeIcon: Icons.person, label: l10n.profile),
     ];
   }
 
@@ -346,7 +506,7 @@ class _MainNavigationPageState extends State<MainNavigationPage> {
                   });
                 },
                 labelType: MediaQuery.of(context).size.width > 900 ? NavigationRailLabelType.none : NavigationRailLabelType.all,
-                destinations: _destinations.map((d) => NavigationRailDestination(
+                destinations: destinations.map((d) => NavigationRailDestination(
                   icon: Icon(d.icon),
                   selectedIcon: Icon(d.activeIcon),
                   label: Text(d.label),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -157,10 +157,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1046,18 +1046,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1482,10 +1482,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/medical_assistant/application/medical_assistant_cubit_test.dart
+++ b/test/features/medical_assistant/application/medical_assistant_cubit_test.dart
@@ -9,6 +9,7 @@ import 'package:orionhealth_health/features/medical_assistant/domain/services/he
 import 'package:orionhealth_health/features/medical_assistant/domain/entities/ai_response.dart';
 import 'package:orionhealth_health/features/medical_assistant/domain/entities/medical_insight.dart';
 import 'package:orionhealth_health/features/medical_assistant/domain/entities/medical_query.dart';
+import 'package:orionhealth_health/features/medical_assistant/domain/entities/analysis_response.dart';
 import 'package:orionhealth_health/features/medical_assistant/infrastructure/analysis/lab_interpreter.dart';
 import 'package:orionhealth_health/features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart';
 import 'package:orionhealth_health/features/medical_assistant/infrastructure/analysis/risk_calculator.dart';

--- a/test/features/ssi/anoncreds_service_test.dart
+++ b/test/features/ssi/anoncreds_service_test.dart
@@ -22,6 +22,7 @@ void main() {
     when(() => mockRepository.getCredentials()).thenAnswer((_) async => []);
     when(() => mockRepository.getRevocationEntry(any(), any())).thenAnswer((_) async => null);
     when(() => mockRepository.saveRevocationEntry(any())).thenAnswer((_) async {});
+    when(() => mockRepository.saveCredential(any())).thenAnswer((_) async {});
   });
 
   setUpAll(() {
@@ -31,6 +32,15 @@ void main() {
       issuerPublicKey: 'key',
       revokedAt: DateTime.now(),
       issuerSignature: 'sig',
+    ));
+    registerFallbackValue(VerifiableCredential(
+      id: 'id',
+      issuer: 'issuer',
+      subject: 'subject',
+      type: 'type',
+      schemaId: 'schema',
+      claims: {},
+      issuanceDate: DateTime.now(),
     ));
   });
 

--- a/test/widgets/indexing_status_banner_test.dart
+++ b/test/widgets/indexing_status_banner_test.dart
@@ -1,0 +1,108 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/home/application/home_cubit.dart';
+import 'package:orionhealth_health/features/home/application/home_state.dart';
+import 'package:orionhealth_health/main.dart';
+
+class MockHomeCubit extends Mock implements HomeCubit {}
+
+void main() {
+  late MockHomeCubit mockHomeCubit;
+  late StreamController<HomeState> stateController;
+
+  setUp(() {
+    mockHomeCubit = MockHomeCubit();
+    stateController = StreamController<HomeState>.broadcast();
+
+    when(() => mockHomeCubit.state).thenReturn(const HomeState());
+    when(() => mockHomeCubit.stream).thenAnswer((_) => stateController.stream);
+    when(() => mockHomeCubit.close()).thenAnswer((_) async => stateController.close());
+  });
+
+  tearDown(() {
+    stateController.close();
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: Scaffold(
+        body: BlocProvider<HomeCubit>.value(
+          value: mockHomeCubit,
+          child: const IndexingStatusBanner(),
+        ),
+      ),
+    );
+  }
+
+  testWidgets('IndexingStatusBanner shows "Sincronizando..." when indexing is true', (WidgetTester tester) async {
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(isIndexing: true));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.text('Sincronizando estándares médicos...'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('IndexingStatusBanner shows success message when indexing finishes', (WidgetTester tester) async {
+    // Start with indexing
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(isIndexing: true));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    expect(find.text('Sincronizando estándares médicos...'), findsOneWidget);
+
+    // Emit state where indexing is false
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(isIndexing: false));
+    stateController.add(const HomeState(isIndexing: false));
+
+    await tester.pump(); // Start animation/rebuild
+
+    expect(find.text('Sincronización completada'), findsOneWidget);
+    expect(find.byIcon(Icons.check_circle), findsOneWidget);
+
+    // Drain timer to avoid pending timer error
+    await tester.pump(const Duration(seconds: 3));
+  });
+
+  testWidgets('IndexingStatusBanner hides after success message duration', (WidgetTester tester) async {
+    // Start with indexing
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(isIndexing: true));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    // Finish indexing
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(isIndexing: false));
+    stateController.add(const HomeState(isIndexing: false));
+
+    await tester.pump();
+    expect(find.text('Sincronización completada'), findsOneWidget);
+
+    // Wait for 3 seconds + some buffer
+    await tester.pump(const Duration(seconds: 3));
+
+    expect(find.text('Sincronización completada'), findsNothing);
+    expect(find.byType(Container), findsNothing); // Should be SizedBox.shrink()
+  });
+
+  testWidgets('IndexingStatusBanner shows error message and retry button when indexingError is true', (WidgetTester tester) async {
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(indexingError: true));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.text('Error sincronizando estándares médicos'), findsOneWidget);
+    expect(find.byIcon(Icons.error_outline), findsOneWidget);
+    expect(find.text('Reintentar'), findsOneWidget);
+  });
+
+  testWidgets('Retry button calls HomeCubit.retryIndexing', (WidgetTester tester) async {
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(indexingError: true));
+    when(() => mockHomeCubit.retryIndexing()).thenAnswer((_) async {});
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    await tester.tap(find.text('Reintentar'));
+    verify(() => mockHomeCubit.retryIndexing()).called(1);
+  });
+}


### PR DESCRIPTION
Connected the Home screen vitals grid to real patient data from VitalSignRepository and added a status banner to track the medical indexing process.

Key changes:
- MedicalIndexingService now emits its status via a broadcast stream.
- A new HomeCubit manages the dashboard state, including the latest vitals and indexing progress.
- The vitals grid now displays real values or a placeholder with an "add" icon if data is missing.
- The IndexingStatusBanner provides visual feedback during indexing, a success message upon completion, and a retry button if an error occurs.
- Fixed several pre-existing issues in the codebase that were causing compilation errors and test failures, ensuring a stable environment.
- Added comprehensive widget tests for the new IndexingStatusBanner.

Fixes #263

---
*PR created automatically by Jules for task [9776667908967789456](https://jules.google.com/task/9776667908967789456) started by @iberi22*