### PR TITLE
Integrate MedicalAssistantPage as default AI assistant

### DIFF
--- a/lib/core/widgets/floating_assistant_button.dart
+++ b/lib/core/widgets/floating_assistant_button.dart
@@ -1,7 +1,5 @@
 import 'package:flutter/material.dart';
-import '../../features/ai_assistant/presentation/pages/chat_page.dart';
-import '../../features/local_agent/infrastructure/llm_service.dart';
-import '../di/injection.dart';
+import '../../features/medical_assistant/presentation/pages/medical_assistant_page.dart';
 
 /// A floating action button with pulse animation for the AI medical assistant.
 /// 
@@ -96,9 +94,7 @@ class _FloatingAssistantButtonState extends State<FloatingAssistantButton>
   void _openAssistant() {
     Navigator.of(context).push(
       MaterialPageRoute(
-        builder: (context) => ChatPage(
-          llmService: getIt<LlmService>(),
-        ),
+        builder: (context) => const MedicalAssistantPage(),
       ),
     );
   }

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -15,6 +15,7 @@ import 'core/widgets/glassmorphic_card.dart';
 import 'core/widgets/page_header.dart';
 import 'features/health_record/presentation/pages/health_record_staging_page.dart';
 import 'features/reports/presentation/pages/reports_page.dart';
+import 'features/medical_assistant/presentation/pages/medical_assistant_page.dart';
 import 'features/user_profile/presentation/pages/user_profile_page.dart';
 import 'package:isar_agent_memory/isar_agent_memory.dart';
 import 'features/local_agent/infrastructure/services/medical_indexing_service.dart';
@@ -359,7 +360,12 @@ class _LocalAgentPromo extends StatelessWidget {
           const Text('Pregúntame cualquier cosa sobre tus registros médicos. No salen de tu dispositivo.', style: TextStyle(color: Colors.white70)),
           const SizedBox(height: 16),
           ElevatedButton.icon(
-            onPressed: () {},
+            onPressed: () {
+              Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const MedicalAssistantPage()),
+              );
+            },
             icon: const Icon(Icons.chat_bubble_outline),
             label: const Text('Iniciar Consulta'),
             style: ElevatedButton.styleFrom(backgroundColor: AppTheme.darkTheme.primaryColor, foregroundColor: Colors.black),


### PR DESCRIPTION
This PR replaces the legacy `ChatPage` with the clinical-grade `MedicalAssistantPage` across the application's primary entry points (the global floating button and the home screen promo card).

Key changes:
1.  **Navigation logic**: Changed `Navigator.push` targets in `lib/core/widgets/floating_assistant_button.dart` and `lib/main.dart`.
2.  **Code cleanup**: Removed unused `LlmService` injection and `ChatPage` imports in the floating button.
3.  **Dependency Alignment**: Ensured `MedicalAssistantPage` is correctly instantiated with its required `MultiBlocProvider`.

Fixes #270

---
*PR created automatically by Jules for task [11406318747392510914](https://jules.google.com/task/11406318747392510914) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Medical assistant consultation page is now accessible through the floating assistant button and start consultation button, enabling users to initiate consultations directly from these interface elements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->