### PR TITLE
fix(medical): correct unit parameter references (#278)

### DIFF
--- a/lib/features/medical_assistant/domain/services/medical_analysis_service.dart
+++ b/lib/features/medical_assistant/domain/services/medical_analysis_service.dart
@@ -116,7 +116,7 @@ class MedicalAnalysisService {
   SafeAnalysisResponse analyzeLabWithConfidence({
     required String labCode,
     required double value,
-    required String unit,
+    String? unit,
     String? patientCondition,
   }) {
     final loinc = LoincCommonLabs.findByCode(labCode);


### PR DESCRIPTION
## Fix
Corregidas referencias al parametro 'unit' en MedicalAnalysisService.

## Cambios
- medical_analysis_service.dart: 'unit' cambiado a nullable

## Compilation
El codigo ahora compila correctamente con la entidad VitalSign actual.