### PR TITLE
fix(ssi): remove duplicate Isar UserProfile collection (#280)

### DIFF
--- a/lib/features/onboarding/domain/entities/user_profile.dart
+++ b/lib/features/onboarding/domain/entities/user_profile.dart
@@ -1,14 +1,7 @@
 import 'package:equatable/equatable.dart';
-import 'package:isar/isar.dart';
 
-part 'user_profile.g.dart';
-
-/// User profile entity for onboarding
-@collection
+/// User profile entity for onboarding (plain Dart model, NOT Isar collection)
 class UserProfile extends Equatable {
-  Id get isarId => id;
-
-  @override
   final int id;
 
   final String? name;


### PR DESCRIPTION
## Fix
Onboarding UserProfile ya no es Isar collection para evitar conflicto con el UserProfile principal.

## Cambios
- onboarding UserProfile: removido @collection, ahora es modelo plano
- Actualizados imports donde se usaba