### PR TITLE
Implement Medical Calendar Import

### DIFF
--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,7 @@
     <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" />
     <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" />
     <uses-permission android:name="android.permission.MANAGE_EXTERNAL_STORAGE" />
+    <uses-permission android:name="android.permission.READ_CALENDAR" />
 
     <application
         android:requestLegacyExternalStorage="true"

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -45,5 +45,7 @@
 	<true/>
 	<key>UIApplicationSupportsIndirectInputEvents</key>
 	<true/>
+	<key>NSCalendarsUsageDescription</key>
+	<string>OrionHealth necesita acceso a su calendario para importar citas médicas.</string>
 </dict>
 </plist>

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -8,167 +8,170 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:dio/dio.dart' as _i8;
+import 'package:dio/dio.dart' as _i9;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:isar/isar.dart' as _i14;
-import 'package:isar_agent_memory/isar_agent_memory.dart' as _i9;
-import 'package:medical_standards/medical_standards.dart' as _i22;
+import 'package:isar/isar.dart' as _i15;
+import 'package:isar_agent_memory/isar_agent_memory.dart' as _i10;
+import 'package:medical_standards/medical_standards.dart' as _i23;
 
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i54;
-import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
     as _i55;
+import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
+    as _i56;
 import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i58;
-import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
     as _i59;
-import '../../features/auth/application/auth_cubit.dart' as _i83;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i84;
-import '../../features/auth/domain/auth_service.dart' as _i62;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i60;
+import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
+    as _i60;
+import '../../features/auth/application/auth_cubit.dart' as _i86;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i85;
+import '../../features/auth/domain/auth_service.dart' as _i63;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i61;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
-    as _i61;
+    as _i62;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i3;
 import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
-    as _i63;
-import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i10;
-import '../../features/ble_sharing/domain/ble_sharing_service.dart' as _i4;
-import '../../features/health_data_import/application/health_import_cubit.dart'
-    as _i68;
-import '../../features/health_data_import/domain/services/health_data_import_service.dart'
-    as _i12;
-import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i85;
-import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i69;
-import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i70;
-import '../../features/health_record/infrastructure/services/file_picker_service.dart'
-    as _i11;
-import '../../features/health_record/infrastructure/services/image_picker_service.dart'
-    as _i13;
-import '../../features/health_record/infrastructure/services/ocr_service.dart'
-    as _i36;
-import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i80;
-import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
-    as _i23;
-import '../../features/local_agent/domain/services/llm_adapter.dart' as _i16;
-import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i49;
-import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i17;
-import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i72;
-import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i71;
-import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i18;
-import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i74;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i73;
-import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i86;
-import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i24;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
-    as _i25;
-import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i50;
-import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
-    as _i21;
-import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i87;
-import '../../features/local_agent/infrastructure/services/model_download_service.dart'
-    as _i35;
-import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i77;
-import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
-    as _i15;
-import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
-    as _i46;
-import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
-    as _i51;
-import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
     as _i64;
-import '../../features/medical_assistant/domain/services/health_context_service.dart'
-    as _i66;
-import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
+import '../../features/auth/infrastructure/services/encryption_service.dart'
+    as _i11;
+import '../../features/ble_sharing/domain/ble_sharing_service.dart' as _i4;
+import '../../features/calendar_import/data/calendar_repository.dart' as _i6;
+import '../../features/calendar_import/domain/calendar_import_cubit.dart'
     as _i65;
-import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
-    as _i67;
-import '../../features/medical_research/domain/services/medical_scraper_service.dart'
+import '../../features/health_data_import/application/health_import_cubit.dart'
+    as _i70;
+import '../../features/health_data_import/domain/services/health_data_import_service.dart'
+    as _i13;
+import '../../features/health_record/application/bloc/health_record_cubit.dart'
+    as _i87;
+import '../../features/health_record/domain/repositories/health_record_repository.dart'
+    as _i71;
+import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+    as _i72;
+import '../../features/health_record/infrastructure/services/file_picker_service.dart'
+    as _i12;
+import '../../features/health_record/infrastructure/services/image_picker_service.dart'
+    as _i14;
+import '../../features/health_record/infrastructure/services/ocr_service.dart'
+    as _i37;
+import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
+    as _i82;
+import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
+    as _i24;
+import '../../features/local_agent/domain/services/llm_adapter.dart' as _i17;
+import '../../features/local_agent/domain/services/vector_store_service.dart'
+    as _i50;
+import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
+    as _i18;
+import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
+    as _i74;
+import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+    as _i73;
+import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
+    as _i19;
+import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
+    as _i76;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i75;
+import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i88;
+import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
+    as _i25;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i26;
+import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
+    as _i51;
+import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
+    as _i22;
+import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
+    as _i89;
+import '../../features/local_agent/infrastructure/services/model_download_service.dart'
+    as _i36;
+import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
+    as _i79;
+import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
+    as _i16;
+import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
+    as _i47;
+import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
+    as _i52;
+import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
+    as _i66;
+import '../../features/medical_assistant/domain/services/health_context_service.dart'
+    as _i68;
+import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
+    as _i67;
+import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
+    as _i69;
+import '../../features/medical_research/domain/services/medical_scraper_service.dart'
+    as _i27;
 import '../../features/medical_research/domain/services/medical_standards_service.dart'
-    as _i28;
+    as _i29;
 import '../../features/medical_research/domain/services/medical_web_search_service.dart'
-    as _i30;
+    as _i31;
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i5;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i76;
-import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
-    as _i27;
-import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
-    as _i29;
-import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
-    as _i31;
-import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i32;
-import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i33;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i37;
-import '../../features/onboarding/application/sync_cubit.dart' as _i81;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i88;
-import '../../features/reports/domain/repositories/report_repository.dart'
-    as _i39;
-import '../../features/reports/domain/services/report_generation_service.dart'
     as _i78;
-import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
-    as _i40;
-import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i79;
-import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
+import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
+    as _i28;
+import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
+    as _i30;
+import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
+    as _i32;
+import '../../features/medications/domain/repositories/medication_repository.dart'
+    as _i33;
+import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
     as _i34;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i75;
-import '../../features/settings/domain/repositories/llm_settings_repository.dart'
-    as _i19;
-import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i7;
-import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
-    as _i20;
-import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i42;
-import '../../features/ssi/domain/services/anoncreds_service.dart' as _i56;
-import '../../features/ssi/domain/services/ssi_service.dart' as _i44;
-import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
-    as _i43;
-import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
-    as _i57;
-import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i38;
+import '../../features/onboarding/application/sync_cubit.dart' as _i83;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i90;
+import '../../features/reports/domain/repositories/report_repository.dart'
+    as _i40;
+import '../../features/reports/domain/services/report_generation_service.dart'
+    as _i80;
+import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i41;
+import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+    as _i81;
+import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
+    as _i35;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i77;
+import '../../features/settings/domain/repositories/llm_settings_repository.dart'
+    as _i20;
+import '../../features/settings/domain/services/device_capability_service.dart'
+    as _i8;
+import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
+    as _i21;
+import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i43;
+import '../../features/ssi/domain/services/anoncreds_service.dart' as _i57;
+import '../../features/ssi/domain/services/ssi_service.dart' as _i45;
+import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
+    as _i44;
+import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
+    as _i58;
+import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
+    as _i42;
 import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
-    as _i45;
+    as _i46;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i82;
+    as _i84;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i47;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
     as _i48;
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+    as _i49;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i52;
-import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
     as _i53;
-import '../services/device_capability_service.dart' as _i6;
-import '../services/privacy_anonymizer.dart' as _i38;
-import 'database_module.dart' as _i91;
-import 'memory_module.dart' as _i90;
-import 'network_module.dart' as _i89;
+import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+    as _i54;
+import '../services/device_capability_service.dart' as _i7;
+import '../services/privacy_anonymizer.dart' as _i39;
+import 'database_module.dart' as _i93;
+import 'memory_module.dart' as _i92;
+import 'network_module.dart' as _i91;
 
-const String _mobile = 'mobile';
 const String _desktop = 'desktop';
 const String _test = 'test';
+const String _mobile = 'mobile';
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -187,221 +190,227 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i3.BiometricService>(() => _i3.BiometricService());
     gh.lazySingleton<_i4.BleSharingService>(() => _i4.BleSharingService());
     gh.lazySingleton<_i5.BotBypassHandler>(() => _i5.BotBypassHandler());
-    gh.lazySingleton<_i6.DeviceCapabilityService>(
-        () => _i6.DeviceCapabilityService());
+    gh.lazySingleton<_i6.CalendarRepository>(() => _i6.CalendarRepository());
     gh.lazySingleton<_i7.DeviceCapabilityService>(
         () => _i7.DeviceCapabilityService());
-    gh.lazySingleton<_i8.Dio>(() => networkModule.dio);
-    gh.lazySingleton<_i9.EmbeddingsAdapter>(
+    gh.lazySingleton<_i8.DeviceCapabilityService>(
+        () => _i8.DeviceCapabilityService());
+    gh.lazySingleton<_i9.Dio>(() => networkModule.dio);
+    gh.lazySingleton<_i10.EmbeddingsAdapter>(
         () => memoryModule.embeddingsAdapter);
-    gh.lazySingleton<_i10.EncryptionService>(() => _i10.EncryptionService());
-    gh.lazySingleton<_i11.FilePickerService>(
-        () => _i11.FilePickerServiceImpl());
-    gh.lazySingleton<_i12.HealthDataImportService>(
-        () => _i12.HealthDataImportService());
-    gh.lazySingleton<_i13.ImagePickerService>(
-        () => _i13.ImagePickerServiceImpl());
-    await gh.factoryAsync<_i14.Isar>(
+    gh.lazySingleton<_i11.EncryptionService>(() => _i11.EncryptionService());
+    gh.lazySingleton<_i12.FilePickerService>(
+        () => _i12.FilePickerServiceImpl());
+    gh.lazySingleton<_i13.HealthDataImportService>(
+        () => _i13.HealthDataImportService());
+    gh.lazySingleton<_i14.ImagePickerService>(
+        () => _i14.ImagePickerServiceImpl());
+    await gh.factoryAsync<_i15.Isar>(
       () => databaseModule.isar,
       preResolve: true,
     );
-    gh.factory<_i15.LabAnalysisStrategy>(() => _i15.LabAnalysisStrategy());
-    gh.lazySingleton<_i16.LlmAdapter>(
-      () => _i17.FlutterGemmaAdapter(),
+    gh.factory<_i16.LabAnalysisStrategy>(() => _i16.LabAnalysisStrategy());
+    gh.lazySingleton<_i17.LlmAdapter>(
+      () => _i18.FlutterGemmaAdapter(),
       instanceName: 'gemma',
     );
-    gh.lazySingleton<_i16.LlmAdapter>(
-      () => _i18.OpenaiCompatibleAdapter(),
+    gh.lazySingleton<_i17.LlmAdapter>(
+      () => _i19.OpenaiCompatibleAdapter(),
       instanceName: 'openai',
     );
-    gh.lazySingleton<_i19.LlmSettingsRepository>(
-        () => _i20.LlmSettingsRepositoryImpl(gh<_i14.Isar>()));
-    gh.lazySingleton<_i21.LocalLlmService>(() => _i21.LocalLlmService());
-    gh.lazySingleton<_i22.MedicalContextProvider>(
+    gh.lazySingleton<_i20.LlmSettingsRepository>(
+        () => _i21.LlmSettingsRepositoryImpl(gh<_i15.Isar>()));
+    gh.lazySingleton<_i22.LocalLlmService>(() => _i22.LocalLlmService());
+    gh.lazySingleton<_i23.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
-    gh.factory<_i23.MedicalKnowledgeRepository>(
-      () => _i24.AssetMedicalKnowledgeRepository(),
+    gh.factory<_i24.MedicalKnowledgeRepository>(
+      () => _i25.AssetMedicalKnowledgeRepository(),
       registerFor: {_mobile},
     );
-    gh.factory<_i23.MedicalKnowledgeRepository>(
-      () => _i25.JsonMedicalKnowledgeRepository(),
+    gh.factory<_i24.MedicalKnowledgeRepository>(
+      () => _i26.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
     );
-    gh.lazySingleton<_i26.MedicalScraperService>(
-        () => _i27.MedicalScraperServiceImpl(
-              gh<_i8.Dio>(),
+    gh.lazySingleton<_i27.MedicalScraperService>(
+        () => _i28.MedicalScraperServiceImpl(
+              gh<_i9.Dio>(),
               gh<_i5.BotBypassHandler>(),
             ));
-    gh.lazySingleton<_i28.MedicalStandardsService>(() =>
-        _i29.MedicalStandardsServiceImpl(gh<_i22.MedicalContextProvider>()));
-    gh.lazySingleton<_i30.MedicalWebSearchService>(
-        () => _i31.MedicalWebSearchServiceImpl(gh<_i8.Dio>()));
-    gh.lazySingleton<_i32.MedicationRepository>(
-        () => _i33.IsarMedicationRepository(gh<_i14.Isar>()));
-    await gh.lazySingletonAsync<_i9.MemoryGraph>(
+    gh.lazySingleton<_i29.MedicalStandardsService>(() =>
+        _i30.MedicalStandardsServiceImpl(gh<_i23.MedicalContextProvider>()));
+    gh.lazySingleton<_i31.MedicalWebSearchService>(
+        () => _i32.MedicalWebSearchServiceImpl(gh<_i9.Dio>()));
+    gh.lazySingleton<_i33.MedicationRepository>(
+        () => _i34.IsarMedicationRepository(gh<_i15.Isar>()));
+    await gh.lazySingletonAsync<_i10.MemoryGraph>(
       () => memoryModule.memoryGraph(
-        gh<_i14.Isar>(),
-        gh<_i9.EmbeddingsAdapter>(),
+        gh<_i15.Isar>(),
+        gh<_i10.EmbeddingsAdapter>(),
       ),
       preResolve: true,
     );
-    gh.lazySingleton<_i34.MockReportGenerationService>(
-      () => _i34.MockReportGenerationService(),
+    gh.lazySingleton<_i35.MockReportGenerationService>(
+      () => _i35.MockReportGenerationService(),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i35.ModelDownloadService>(
-        () => _i35.ModelDownloadService());
-    gh.lazySingleton<_i36.OcrService>(() => _i36.MlKitOcrService());
-    gh.factory<_i37.OnboardingCubit>(() => _i37.OnboardingCubit());
-    gh.lazySingleton<_i38.PromptScrubber>(
-        () => _i38.PromptScrubber(gh<_i14.Isar>()));
-    gh.lazySingleton<_i39.ReportRepository>(
-        () => _i40.IsarReportRepository(gh<_i14.Isar>()));
-    gh.lazySingleton<_i41.SidetreeAnchorClient>(
-        () => _i41.SidetreeAnchorClient.create());
-    gh.lazySingleton<_i42.SsiRepository>(
-        () => _i43.IsarSsiRepository(gh<_i14.Isar>()));
-    gh.lazySingleton<_i44.SsiService>(() => _i45.SsiServiceImpl(
-          gh<_i42.SsiRepository>(),
-          gh<_i41.SidetreeAnchorClient>(),
+    gh.lazySingleton<_i36.ModelDownloadService>(
+        () => _i36.ModelDownloadService());
+    gh.lazySingleton<_i37.OcrService>(() => _i37.MlKitOcrService());
+    gh.factory<_i38.OnboardingCubit>(() => _i38.OnboardingCubit());
+    gh.lazySingleton<_i39.PromptScrubber>(
+        () => _i39.PromptScrubber(gh<_i15.Isar>()));
+    gh.lazySingleton<_i40.ReportRepository>(
+        () => _i41.IsarReportRepository(gh<_i15.Isar>()));
+    gh.lazySingleton<_i42.SidetreeAnchorClient>(
+        () => _i42.SidetreeAnchorClient.create());
+    gh.lazySingleton<_i43.SsiRepository>(
+        () => _i44.IsarSsiRepository(gh<_i15.Isar>()));
+    gh.lazySingleton<_i45.SsiService>(() => _i46.SsiServiceImpl(
+          gh<_i43.SsiRepository>(),
+          gh<_i42.SidetreeAnchorClient>(),
         ));
-    gh.factory<_i46.SymptomAnalysisStrategy>(
-        () => _i46.SymptomAnalysisStrategy());
-    gh.lazySingleton<_i22.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i47.UserProfileRepository>(
-        () => _i48.UserProfileRepositoryImpl(gh<_i14.Isar>()));
-    gh.lazySingleton<_i49.VectorStoreService>(() => _i50.IsarVectorStoreService(
-          gh<_i9.MemoryGraph>(),
-          gh<_i23.MedicalKnowledgeRepository>(),
+    gh.factory<_i47.SymptomAnalysisStrategy>(
+        () => _i47.SymptomAnalysisStrategy());
+    gh.lazySingleton<_i23.SyncService>(() => networkModule.syncService);
+    gh.lazySingleton<_i48.UserProfileRepository>(
+        () => _i49.UserProfileRepositoryImpl(gh<_i15.Isar>()));
+    gh.lazySingleton<_i50.VectorStoreService>(() => _i51.IsarVectorStoreService(
+          gh<_i10.MemoryGraph>(),
+          gh<_i24.MedicalKnowledgeRepository>(),
         ));
-    gh.factory<_i51.VitalAnalysisStrategy>(() => _i51.VitalAnalysisStrategy());
-    gh.lazySingleton<_i52.VitalSignRepository>(
-        () => _i53.VitalSignRepositoryImpl(gh<_i14.Isar>()));
-    gh.lazySingleton<_i54.AllergyRepository>(
-        () => _i55.IsarAllergyRepository(gh<_i14.Isar>()));
-    gh.lazySingleton<_i56.AnonCredsService>(
-        () => _i57.AnonCredsServiceImpl(gh<_i42.SsiRepository>()));
-    gh.lazySingleton<_i58.AppointmentRepository>(
-        () => _i59.IsarAppointmentRepository(gh<_i14.Isar>()));
-    gh.lazySingleton<_i60.AuthRepository>(
-        () => _i61.AuthRepositoryImpl(gh<_i14.Isar>()));
-    gh.lazySingleton<_i62.AuthService>(
-        () => _i62.AuthServiceImpl(gh<_i10.EncryptionService>()));
-    gh.lazySingleton<_i63.BleMedicalSharingService>(
-        () => _i63.BleMedicalSharingService(
+    gh.factory<_i52.VitalAnalysisStrategy>(() => _i52.VitalAnalysisStrategy());
+    gh.lazySingleton<_i53.VitalSignRepository>(
+        () => _i54.VitalSignRepositoryImpl(gh<_i15.Isar>()));
+    gh.lazySingleton<_i55.AllergyRepository>(
+        () => _i56.IsarAllergyRepository(gh<_i15.Isar>()));
+    gh.lazySingleton<_i57.AnonCredsService>(
+        () => _i58.AnonCredsServiceImpl(gh<_i43.SsiRepository>()));
+    gh.lazySingleton<_i59.AppointmentRepository>(
+        () => _i60.IsarAppointmentRepository(gh<_i15.Isar>()));
+    gh.lazySingleton<_i61.AuthRepository>(
+        () => _i62.AuthRepositoryImpl(gh<_i15.Isar>()));
+    gh.lazySingleton<_i63.AuthService>(
+        () => _i63.AuthServiceImpl(gh<_i11.EncryptionService>()));
+    gh.lazySingleton<_i64.BleMedicalSharingService>(
+        () => _i64.BleMedicalSharingService(
               gh<_i4.BleSharingService>(),
-              gh<_i10.EncryptionService>(),
-              gh<_i44.SsiService>(),
+              gh<_i11.EncryptionService>(),
+              gh<_i45.SsiService>(),
             ));
-    gh.lazySingleton<_i64.ClinicalReasonerService>(() =>
-        _i65.SymphonyClinicalReasonerService(
-            gh<_i23.MedicalKnowledgeRepository>()));
-    gh.lazySingleton<_i66.HealthContextService>(
-        () => _i67.IsarHealthContextService(
-              gh<_i52.VitalSignRepository>(),
-              gh<_i32.MedicationRepository>(),
-              gh<_i9.MemoryGraph>(),
-            ));
-    gh.factory<_i68.HealthImportCubit>(() => _i68.HealthImportCubit(
-          gh<_i12.HealthDataImportService>(),
-          gh<_i52.VitalSignRepository>(),
+    gh.factory<_i65.CalendarImportCubit>(() => _i65.CalendarImportCubit(
+          gh<_i6.CalendarRepository>(),
+          gh<_i59.AppointmentRepository>(),
+          gh<_i48.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i69.HealthRecordRepository>(
-        () => _i70.HealthRecordRepositoryImpl(gh<_i14.Isar>()));
-    gh.factory<_i16.LlmAdapter>(
-      () => _i71.MockLlmAdapter(gh<_i38.PromptScrubber>()),
+    gh.lazySingleton<_i66.ClinicalReasonerService>(() =>
+        _i67.SymphonyClinicalReasonerService(
+            gh<_i24.MedicalKnowledgeRepository>()));
+    gh.lazySingleton<_i68.HealthContextService>(
+        () => _i69.IsarHealthContextService(
+              gh<_i53.VitalSignRepository>(),
+              gh<_i33.MedicationRepository>(),
+              gh<_i10.MemoryGraph>(),
+            ));
+    gh.factory<_i70.HealthImportCubit>(() => _i70.HealthImportCubit(
+          gh<_i13.HealthDataImportService>(),
+          gh<_i53.VitalSignRepository>(),
+        ));
+    gh.lazySingleton<_i71.HealthRecordRepository>(
+        () => _i72.HealthRecordRepositoryImpl(gh<_i15.Isar>()));
+    gh.factory<_i17.LlmAdapter>(
+      () => _i73.MockLlmAdapter(gh<_i39.PromptScrubber>()),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i16.LlmAdapter>(
-      () => _i72.GeminiLlmAdapter(
-        scrubber: gh<_i38.PromptScrubber>(),
-        userProfileRepository: gh<_i47.UserProfileRepository>(),
+    gh.lazySingleton<_i17.LlmAdapter>(
+      () => _i74.GeminiLlmAdapter(
+        scrubber: gh<_i39.PromptScrubber>(),
+        userProfileRepository: gh<_i48.UserProfileRepository>(),
       ),
       instanceName: 'gemini',
     );
-    gh.lazySingleton<_i73.LlmService>(() => _i74.GemmaLlmService(
-          gh<_i49.VectorStoreService>(),
-          gh<_i47.UserProfileRepository>(),
-          gh<_i16.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i75.LlmService>(() => _i76.GemmaLlmService(
+          gh<_i50.VectorStoreService>(),
+          gh<_i48.UserProfileRepository>(),
+          gh<_i17.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i75.LlmSettingsCubit>(() => _i75.LlmSettingsCubit(
-          gh<_i19.LlmSettingsRepository>(),
-          gh<_i7.DeviceCapabilityService>(),
-          gh<_i16.LlmAdapter>(instanceName: 'gemma'),
+    gh.factory<_i77.LlmSettingsCubit>(() => _i77.LlmSettingsCubit(
+          gh<_i20.LlmSettingsRepository>(),
+          gh<_i8.DeviceCapabilityService>(),
+          gh<_i17.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.lazySingleton<_i76.MedicalResearchService>(
-        () => _i76.MedicalResearchService(
-              gh<_i30.MedicalWebSearchService>(),
-              gh<_i26.MedicalScraperService>(),
+    gh.lazySingleton<_i78.MedicalResearchService>(
+        () => _i78.MedicalResearchService(
+              gh<_i31.MedicalWebSearchService>(),
+              gh<_i27.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i77.PatientContextIndexer>(
-      () => _i77.PatientContextIndexer(
-        gh<_i14.Isar>(),
-        gh<_i49.VectorStoreService>(),
-        gh<_i69.HealthRecordRepository>(),
-        gh<_i32.MedicationRepository>(),
-        gh<_i54.AllergyRepository>(),
-        gh<_i52.VitalSignRepository>(),
-        gh<_i58.AppointmentRepository>(),
+    gh.lazySingleton<_i79.PatientContextIndexer>(
+      () => _i79.PatientContextIndexer(
+        gh<_i15.Isar>(),
+        gh<_i50.VectorStoreService>(),
+        gh<_i71.HealthRecordRepository>(),
+        gh<_i33.MedicationRepository>(),
+        gh<_i55.AllergyRepository>(),
+        gh<_i53.VitalSignRepository>(),
+        gh<_i59.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i78.ReportGenerationService>(
-        () => _i79.GemmaReportGenerationService(
-              gh<_i16.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i49.VectorStoreService>(),
-              gh<_i47.UserProfileRepository>(),
-              gh<_i38.PromptScrubber>(),
+    gh.lazySingleton<_i80.ReportGenerationService>(
+        () => _i81.GemmaReportGenerationService(
+              gh<_i17.LlmAdapter>(instanceName: 'gemma'),
+              gh<_i50.VectorStoreService>(),
+              gh<_i48.UserProfileRepository>(),
+              gh<_i39.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i80.SmartSearchUseCase>(
-        () => _i80.SmartSearchUseCase(gh<_i49.VectorStoreService>()));
-    gh.factory<_i81.SyncCubit>(() => _i81.SyncCubit(
-          gh<_i22.SyncService>(),
-          gh<_i49.VectorStoreService>(),
+    gh.lazySingleton<_i82.SmartSearchUseCase>(
+        () => _i82.SmartSearchUseCase(gh<_i50.VectorStoreService>()));
+    gh.factory<_i83.SyncCubit>(() => _i83.SyncCubit(
+          gh<_i23.SyncService>(),
+          gh<_i50.VectorStoreService>(),
         ));
-    gh.factory<_i82.UserProfileCubit>(
-        () => _i82.UserProfileCubit(gh<_i47.UserProfileRepository>()));
-    gh.factory<_i83.AuthCubit>(() => _i83.AuthCubit(gh<_i62.AuthService>()));
-    gh.factory<_i84.AuthCubit>(() => _i84.AuthCubit(
-          gh<_i60.AuthRepository>(),
-          gh<_i10.EncryptionService>(),
+    gh.factory<_i84.UserProfileCubit>(
+        () => _i84.UserProfileCubit(gh<_i48.UserProfileRepository>()));
+    gh.factory<_i85.AuthCubit>(() => _i85.AuthCubit(
+          gh<_i61.AuthRepository>(),
+          gh<_i11.EncryptionService>(),
           gh<_i3.BiometricService>(),
         ));
-    gh.factory<_i85.HealthRecordCubit>(() => _i85.HealthRecordCubit(
-          gh<_i69.HealthRecordRepository>(),
-          gh<_i11.FilePickerService>(),
-          gh<_i13.ImagePickerService>(),
-          gh<_i36.OcrService>(),
-          gh<_i49.VectorStoreService>(),
+    gh.factory<_i86.AuthCubit>(() => _i86.AuthCubit(gh<_i63.AuthService>()));
+    gh.factory<_i87.HealthRecordCubit>(() => _i87.HealthRecordCubit(
+          gh<_i71.HealthRecordRepository>(),
+          gh<_i12.FilePickerService>(),
+          gh<_i14.ImagePickerService>(),
+          gh<_i37.OcrService>(),
+          gh<_i50.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i73.LlmService>(
-      () => _i86.RagLlmService(
-        gh<_i49.VectorStoreService>(),
-        gh<_i76.MedicalResearchService>(),
-        gh<_i47.UserProfileRepository>(),
-        gh<_i16.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i75.LlmService>(
+      () => _i88.RagLlmService(
+        gh<_i50.VectorStoreService>(),
+        gh<_i78.MedicalResearchService>(),
+        gh<_i48.UserProfileRepository>(),
+        gh<_i17.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
-    gh.lazySingleton<_i87.MedicalIndexingService>(
-        () => _i87.MedicalIndexingService(
-              gh<_i23.MedicalKnowledgeRepository>(),
-              gh<_i49.VectorStoreService>(),
-              gh<_i77.PatientContextIndexer>(),
+    gh.lazySingleton<_i89.MedicalIndexingService>(
+        () => _i89.MedicalIndexingService(
+              gh<_i24.MedicalKnowledgeRepository>(),
+              gh<_i50.VectorStoreService>(),
+              gh<_i79.PatientContextIndexer>(),
             ));
-    gh.factory<_i88.ReportBloc>(() => _i88.ReportBloc(
-          gh<_i39.ReportRepository>(),
-          gh<_i78.ReportGenerationService>(),
+    gh.factory<_i90.ReportBloc>(() => _i90.ReportBloc(
+          gh<_i40.ReportRepository>(),
+          gh<_i80.ReportGenerationService>(),
         ));
     return this;
   }
 }
 
-class _$NetworkModule extends _i89.NetworkModule {}
+class _$NetworkModule extends _i91.NetworkModule {}
 
-class _$MemoryModule extends _i90.MemoryModule {}
+class _$MemoryModule extends _i92.MemoryModule {}
 
-class _$DatabaseModule extends _i91.DatabaseModule {}
+class _$DatabaseModule extends _i93.DatabaseModule {}

--- a/lib/features/appointments/presentation/pages/appointments_page.dart
+++ b/lib/features/appointments/presentation/pages/appointments_page.dart
@@ -4,6 +4,7 @@ import 'package:intl/intl.dart';
 import '../../../../core/di/injection.dart';
 import '../../../../core/theme/cyber_theme.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../../calendar_import/presentation/calendar_import_page.dart';
 import '../../domain/entities/appointment.dart';
 import '../../domain/repositories/appointment_repository.dart';
 
@@ -61,6 +62,19 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
       appBar: AppBar(
         title: const Text('Citas'),
         actions: [
+          IconButton(
+            icon: const Icon(Icons.calendar_month),
+            tooltip: 'Importar desde calendario',
+            onPressed: () async {
+              final result = await Navigator.push(
+                context,
+                MaterialPageRoute(builder: (context) => const CalendarImportPage()),
+              );
+              if (result == true) {
+                _loadAppointments();
+              }
+            },
+          ),
           IconButton(
             icon: const Icon(Icons.add),
             onPressed: () => _showAppointmentForm(),

--- a/lib/features/calendar_import/data/calendar_repository.dart
+++ b/lib/features/calendar_import/data/calendar_repository.dart
@@ -1,0 +1,110 @@
+import 'package:device_calendar/device_calendar.dart';
+import 'package:injectable/injectable.dart';
+import '../../appointments/domain/entities/appointment.dart';
+
+@lazySingleton
+class CalendarRepository {
+  final DeviceCalendarPlugin _deviceCalendarPlugin = DeviceCalendarPlugin();
+
+  final List<String> _medicalKeywords = [
+    "cita",
+    "médico",
+    "consulta",
+    "EPS",
+    "Sura",
+    "Comfama",
+    "Sanitas",
+    "doctor",
+    "especialista",
+    "control",
+    "examen",
+    "procedimiento",
+    "odontología",
+    "terapia",
+    "laboratorio",
+    "vacuna",
+  ];
+
+  Future<bool> hasPermissions() async {
+    var permissionsGranted = await _deviceCalendarPlugin.hasPermissions();
+    if (permissionsGranted.isSuccess && permissionsGranted.data!) {
+      return true;
+    }
+    return false;
+  }
+
+  Future<bool> requestPermissions() async {
+    var permissionsGranted = await _deviceCalendarPlugin.requestPermissions();
+    return permissionsGranted.isSuccess && permissionsGranted.data!;
+  }
+
+  Future<List<Appointment>> fetchMedicalEvents() async {
+    final calendarsResult = await _deviceCalendarPlugin.retrieveCalendars();
+    if (!calendarsResult.isSuccess || calendarsResult.data == null) {
+      return [];
+    }
+
+    final List<Appointment> medicalAppointments = [];
+    final now = DateTime.now();
+    final startDate = now.subtract(const Duration(days: 30));
+    final endDate = now.add(const Duration(days: 90));
+
+    for (var calendar in calendarsResult.data!) {
+      final eventsResult = await _deviceCalendarPlugin.retrieveEvents(
+        calendar.id,
+        RetrieveEventsParams(startDate: startDate, endDate: endDate),
+      );
+
+      if (eventsResult.isSuccess && eventsResult.data != null) {
+        for (var event in eventsResult.data!) {
+          if (_isMedicalEvent(event)) {
+            medicalAppointments.add(_mapEventToAppointment(event));
+          }
+        }
+      }
+    }
+
+    return medicalAppointments;
+  }
+
+  bool _isMedicalEvent(Event event) {
+    final title = event.title?.toLowerCase() ?? "";
+    final description = event.description?.toLowerCase() ?? "";
+
+    return _medicalKeywords.any((keyword) {
+      final k = keyword.toLowerCase();
+      return title.contains(k) || description.contains(k);
+    });
+  }
+
+  Appointment _mapEventToAppointment(Event event) {
+    // Simple parsing logic: use title as doctor name or specialty if recognizable
+    String doctorName = "Médico";
+    String specialty = "Consulta General";
+
+    final title = event.title ?? "Cita Médica";
+    if (title.contains("Dr.") || title.contains("Dra.")) {
+      final parts = title.split(" ");
+      final drIndex = parts.indexWhere((p) => p.contains("Dr.") || p.contains("Dra."));
+      if (drIndex != -1 && drIndex + 1 < parts.length) {
+        doctorName = parts.sublist(drIndex).join(" ");
+      }
+    }
+
+    // Try to guess specialty
+    for (var keyword in _medicalKeywords) {
+      if (title.toLowerCase().contains(keyword.toLowerCase())) {
+        specialty = keyword;
+        break;
+      }
+    }
+
+    return Appointment(
+      doctorName: doctorName,
+      specialty: specialty,
+      dateTime: event.start ?? DateTime.now(),
+      notes: "Importado de calendario: ${event.description ?? ''}",
+      status: AppointmentStatus.upcoming,
+    );
+  }
+}

--- a/lib/features/calendar_import/domain/calendar_import_cubit.dart
+++ b/lib/features/calendar_import/domain/calendar_import_cubit.dart
@@ -1,0 +1,99 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:injectable/injectable.dart';
+import 'package:medical_standards/medical_standards.dart';
+import '../../appointments/domain/entities/appointment.dart';
+import '../../appointments/domain/repositories/appointment_repository.dart';
+import '../../user_profile/domain/repositories/user_profile_repository.dart';
+import '../data/calendar_repository.dart';
+
+abstract class CalendarImportState {}
+
+class CalendarImportInitial extends CalendarImportState {}
+
+class CalendarImportLoading extends CalendarImportState {}
+
+class CalendarImportLoaded extends CalendarImportState {
+  final List<Appointment> foundAppointments;
+  CalendarImportLoaded(this.foundAppointments);
+}
+
+class CalendarImportSuccess extends CalendarImportState {
+  final int importedCount;
+  CalendarImportSuccess(this.importedCount);
+}
+
+class CalendarImportError extends CalendarImportState {
+  final String message;
+  CalendarImportError(this.message);
+}
+
+class CalendarImportPermissionDenied extends CalendarImportState {}
+
+@injectable
+class CalendarImportCubit extends Cubit<CalendarImportState> {
+  final CalendarRepository _calendarRepository;
+  final AppointmentRepository _appointmentRepository;
+  final UserProfileRepository _userProfileRepository;
+
+  CalendarImportCubit(
+    this._calendarRepository,
+    this._appointmentRepository,
+    this._userProfileRepository,
+  ) : super(CalendarImportInitial());
+
+  Future<void> scanCalendar() async {
+    emit(CalendarImportLoading());
+    try {
+      final hasPermission = await _calendarRepository.hasPermissions();
+      if (!hasPermission) {
+        final granted = await _calendarRepository.requestPermissions();
+        if (!granted) {
+          emit(CalendarImportPermissionDenied());
+          return;
+        }
+      }
+
+      final appointments = await _calendarRepository.fetchMedicalEvents();
+      emit(CalendarImportLoaded(appointments));
+    } catch (e) {
+      emit(CalendarImportError(e.toString()));
+    }
+  }
+
+  Future<void> importAppointments(List<Appointment> appointments) async {
+    emit(CalendarImportLoading());
+    try {
+      int count = 0;
+      final profile = await _userProfileRepository.getUserProfile();
+      final isConnected = profile?.uniqueId != null;
+
+      for (final app in appointments) {
+        await _appointmentRepository.saveAppointment(app);
+        count++;
+
+        if (isConnected) {
+          _syncWithFhir(app, profile!.uniqueId!);
+        }
+      }
+      emit(CalendarImportSuccess(count));
+    } catch (e) {
+      emit(CalendarImportError(e.toString()));
+    }
+  }
+
+  void _syncWithFhir(Appointment appointment, String patientId) {
+    // In a real application, this would call a FHIR API.
+    // Here we use the FhirAppointment builder from medical_standards to prepare the data.
+    final fhirAppointment = FhirAppointment(
+      id: 'app-${appointment.id}',
+      status: 'booked',
+      start: appointment.dateTime,
+      description: '${appointment.specialty} con ${appointment.doctorName}',
+      participantActorDisplay: 'Patient/$patientId',
+    );
+
+    // Mock FHIR sync log
+    // ignore: avoid_print
+    print('Syncing to FHIR: ${fhirAppointment.toJson()}');
+  }
+}

--- a/lib/features/calendar_import/presentation/calendar_import_page.dart
+++ b/lib/features/calendar_import/presentation/calendar_import_page.dart
@@ -1,0 +1,179 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:intl/intl.dart';
+import '../../../../core/di/injection.dart';
+import '../../../../core/theme/cyber_theme.dart';
+import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../appointments/domain/entities/appointment.dart';
+import '../domain/calendar_import_cubit.dart';
+
+class CalendarImportPage extends StatelessWidget {
+  const CalendarImportPage({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return BlocProvider(
+      create: (context) => getIt<CalendarImportCubit>()..scanCalendar(),
+      child: Scaffold(
+        appBar: AppBar(
+          title: const Text('Importar Citas'),
+        ),
+        body: BlocConsumer<CalendarImportCubit, CalendarImportState>(
+          listener: (context, state) {
+            if (state is CalendarImportSuccess) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Se importaron ${state.importedCount} citas con éxito')),
+              );
+              Navigator.pop(context, true);
+            } else if (state is CalendarImportError) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                SnackBar(content: Text('Error: ${state.message}')),
+              );
+            } else if (state is CalendarImportPermissionDenied) {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(content: Text('Permiso de calendario denegado')),
+              );
+            }
+          },
+          builder: (context, state) {
+            if (state is CalendarImportLoading) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            if (state is CalendarImportLoaded) {
+              return _CalendarEventsList(appointments: state.foundAppointments);
+            }
+
+            if (state is CalendarImportPermissionDenied) {
+              return Center(
+                child: Column(
+                  mainAxisAlignment: MainAxisAlignment.center,
+                  children: [
+                    const Icon(Icons.calendar_today_outlined, size: 64, color: Colors.grey),
+                    const SizedBox(height: 16),
+                    const Text('Se requiere permiso para acceder al calendario'),
+                    const SizedBox(height: 16),
+                    ElevatedButton(
+                      onPressed: () => context.read<CalendarImportCubit>().scanCalendar(),
+                      child: const Text('Solicitar Permiso'),
+                    ),
+                  ],
+                ),
+              );
+            }
+
+            return const Center(child: Text('Iniciando escaneo...'));
+          },
+        ),
+      ),
+    );
+  }
+}
+
+class _CalendarEventsList extends StatefulWidget {
+  final List<Appointment> appointments;
+
+  const _CalendarEventsList({required this.appointments});
+
+  @override
+  State<_CalendarEventsList> createState() => _CalendarEventsListState();
+}
+
+class _CalendarEventsListState extends State<_CalendarEventsList> {
+  late List<bool> _selected;
+
+  @override
+  void initState() {
+    super.initState();
+    _selected = List.generate(widget.appointments.length, (index) => true);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    if (widget.appointments.isEmpty) {
+      return Center(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: [
+            const Icon(Icons.search_off, size: 64, color: Colors.grey),
+            const SizedBox(height: 16),
+            const Text('No se encontraron citas médicas en tu calendario'),
+            const SizedBox(height: 16),
+            TextButton(
+              onPressed: () => context.read<CalendarImportCubit>().scanCalendar(),
+              child: const Text('Reintentar'),
+            ),
+          ],
+        ),
+      );
+    }
+
+    return Column(
+      children: [
+        const Padding(
+          padding: EdgeInsets.all(16.0),
+          child: Text(
+            'Hemos encontrado los siguientes eventos médicos. Selecciona los que desees importar:',
+            style: TextStyle(color: Colors.white70),
+          ),
+        ),
+        Expanded(
+          child: ListView.builder(
+            itemCount: widget.appointments.length,
+            itemBuilder: (context, index) {
+              final app = widget.appointments[index];
+              return Padding(
+                padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6.0),
+                child: GlassmorphicCard(
+                  child: CheckboxListTile(
+                    value: _selected[index],
+                    onChanged: (val) => setState(() => _selected[index] = val!),
+                    title: Text(
+                      app.doctorName,
+                      style: const TextStyle(fontWeight: FontWeight.bold),
+                    ),
+                    subtitle: Column(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Text(app.specialty, style: const TextStyle(color: CyberTheme.secondary)),
+                        Text(
+                          DateFormat('dd MMM yyyy, hh:mm a', 'es').format(app.dateTime),
+                          style: const TextStyle(fontSize: 12, color: Colors.white54),
+                        ),
+                      ],
+                    ),
+                    activeColor: CyberTheme.primary,
+                    checkColor: Colors.black,
+                  ),
+                ),
+              );
+            },
+          ),
+        ),
+        Padding(
+          padding: const EdgeInsets.all(20.0),
+          child: ElevatedButton(
+            onPressed: _selected.contains(true)
+                ? () {
+                    final toImport = <Appointment>[];
+                    for (int i = 0; i < _selected.length; i++) {
+                      if (_selected[i]) {
+                        toImport.add(widget.appointments[i]);
+                      }
+                    }
+                    context.read<CalendarImportCubit>().importAppointments(toImport);
+                  }
+                : null,
+            style: ElevatedButton.styleFrom(
+              backgroundColor: CyberTheme.primary,
+              foregroundColor: Colors.black,
+              minimumSize: const Size.fromHeight(50),
+              shape: RoundedRectangleBorder(borderRadius: BorderRadius.circular(12)),
+            ),
+            child: const Text('IMPORTAR SELECCIONADOS', style: TextStyle(fontWeight: FontWeight.bold)),
+          ),
+        ),
+      ],
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -2,6 +2,7 @@
 // SPDX-FileCopyrightText: 2025 SouthWest AI Labs
 
 import 'dart:async';
+import 'package:timezone/data/latest.dart' as tz;
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -481,6 +482,7 @@ class _LocalAgentPromo extends StatelessWidget {
 void main() async {
   runZonedGuarded(() async {
     WidgetsFlutterBinding.ensureInitialized();
+    tz.initializeTimeZones();
 
     // Global error handlers
     FlutterError.onError = (details) {

--- a/packages/medical_standards/lib/fhir/fhir.dart
+++ b/packages/medical_standards/lib/fhir/fhir.dart
@@ -89,6 +89,55 @@ class FhirObservation {
   };
 }
 
+/// FHIR Appointment status
+enum FhirAppointmentStatus {
+  proposed,
+  pending,
+  booked,
+  arrived,
+  fulfilled,
+  cancelled,
+  noshow,
+  enteredInError,
+  checkedIn,
+  waitlist,
+}
+
+/// FHIR Appointment builder
+class FhirAppointment {
+  final String id;
+  final String status;
+  final DateTime start;
+  final DateTime? end;
+  final String description;
+  final String? participantActorDisplay;
+
+  FhirAppointment({
+    required this.id,
+    required this.status,
+    required this.start,
+    this.end,
+    required this.description,
+    this.participantActorDisplay,
+  });
+
+  Map<String, dynamic> toJson() => {
+        'resourceType': 'Appointment',
+        'id': id,
+        'status': status,
+        'start': start.toIso8601String(),
+        if (end != null) 'end': end!.toIso8601String(),
+        'description': description,
+        if (participantActorDisplay != null)
+          'participant': [
+            {
+              'actor': {'display': participantActorDisplay},
+              'status': 'accepted'
+            }
+          ],
+      };
+}
+
 /// FHIR Condition builder
 class FhirCondition {
   final String id;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -165,10 +165,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -265,6 +265,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.7.11"
+  device_calendar:
+    dependency: "direct main"
+    description:
+      name: device_calendar
+      sha256: "683fb93ec302b6a65c0ce57df40ff9dcc2404f59c67a2f8b93e59318c8a0a225"
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.3.3"
   device_info_plus:
     dependency: "direct main"
     description:
@@ -1054,18 +1062,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1454,6 +1462,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.10.1"
+  sprintf:
+    dependency: transitive
+    description:
+      name: sprintf
+      sha256: "1fc9ffe69d4df602376b52949af107d8f5703b77cda567c4d7d86a0693120f23"
+      url: "https://pub.dev"
+    source: hosted
+    version: "7.0.0"
   stack_trace:
     dependency: transitive
     description:
@@ -1506,10 +1522,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:
@@ -1518,6 +1534,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.5"
+  timezone:
+    dependency: transitive
+    description:
+      name: timezone
+      sha256: "2236ec079a174ce07434e89fcd3fcda430025eb7692244139a9cf54fdcf1fc7d"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.9.4"
   timing:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -76,6 +76,7 @@ dependencies:
   pointycastle: ^3.9.1
   google_generative_ai: ^0.4.7
   path: ^1.9.1
+  device_calendar: ^4.3.3
 
 dev_dependencies:
   flutter_test:

--- a/test/features/calendar_import/domain/calendar_import_cubit_test.dart
+++ b/test/features/calendar_import/domain/calendar_import_cubit_test.dart
@@ -1,0 +1,108 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+import 'package:orionhealth_health/features/appointments/domain/repositories/appointment_repository.dart';
+import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
+import 'package:orionhealth_health/features/calendar_import/data/calendar_repository.dart';
+import 'package:orionhealth_health/features/calendar_import/domain/calendar_import_cubit.dart';
+
+class MockCalendarRepository extends Mock implements CalendarRepository {}
+class MockAppointmentRepository extends Mock implements AppointmentRepository {}
+class MockUserProfileRepository extends Mock implements UserProfileRepository {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(Appointment(
+      doctorName: '',
+      specialty: '',
+      dateTime: DateTime.now(),
+      status: AppointmentStatus.upcoming,
+    ));
+  });
+
+  late CalendarImportCubit cubit;
+  late MockCalendarRepository mockCalendarRepository;
+  late MockAppointmentRepository mockAppointmentRepository;
+  late MockUserProfileRepository mockUserProfileRepository;
+
+  setUp(() {
+    mockCalendarRepository = MockCalendarRepository();
+    mockAppointmentRepository = MockAppointmentRepository();
+    mockUserProfileRepository = MockUserProfileRepository();
+    cubit = CalendarImportCubit(
+      mockCalendarRepository,
+      mockAppointmentRepository,
+      mockUserProfileRepository,
+    );
+  });
+
+  test('initial state is CalendarImportInitial', () {
+    expect(cubit.state, isA<CalendarImportInitial>());
+  });
+
+  group('scanCalendar', () {
+    test('emits [Loading, Loaded] when permissions are granted and events found', () async {
+      final appointments = [
+        Appointment(
+          doctorName: 'Dr. Smith',
+          specialty: 'Cardiology',
+          dateTime: DateTime.now(),
+          status: AppointmentStatus.upcoming,
+        )
+      ];
+
+      when(() => mockCalendarRepository.hasPermissions()).thenAnswer((_) async => true);
+      when(() => mockCalendarRepository.fetchMedicalEvents()).thenAnswer((_) async => appointments);
+
+      final expectedStates = [
+        isA<CalendarImportLoading>(),
+        isA<CalendarImportLoaded>(),
+      ];
+
+      expectLater(cubit.stream, emitsInOrder(expectedStates));
+
+      await cubit.scanCalendar();
+    });
+
+    test('emits [Loading, PermissionDenied] when permissions are not granted', () async {
+      when(() => mockCalendarRepository.hasPermissions()).thenAnswer((_) async => false);
+      when(() => mockCalendarRepository.requestPermissions()).thenAnswer((_) async => false);
+
+      final expectedStates = [
+        isA<CalendarImportLoading>(),
+        isA<CalendarImportPermissionDenied>(),
+      ];
+
+      expectLater(cubit.stream, emitsInOrder(expectedStates));
+
+      await cubit.scanCalendar();
+    });
+  });
+
+  group('importAppointments', () {
+    test('emits [Loading, Success] when appointments are saved', () async {
+      final appointments = [
+        Appointment(
+          doctorName: 'Dr. Smith',
+          specialty: 'Cardiology',
+          dateTime: DateTime.now(),
+          status: AppointmentStatus.upcoming,
+        )
+      ];
+
+      when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => null);
+      when(() => mockAppointmentRepository.saveAppointment(any())).thenAnswer((_) async => {});
+
+      final expectedStates = [
+        isA<CalendarImportLoading>(),
+        isA<CalendarImportSuccess>(),
+      ];
+
+      expectLater(cubit.stream, emitsInOrder(expectedStates));
+
+      await cubit.importAppointments(appointments);
+
+      verify(() => mockAppointmentRepository.saveAppointment(any())).called(1);
+    });
+  });
+}


### PR DESCRIPTION
This PR implements the medical calendar import feature. It allows users to scan their device's native calendar for events matching medical keywords (e.g., 'cita', 'médico', 'doctor') and import them as appointments within OrionHealth.

Key changes:
- Infrastructure: Added `device_calendar` and configured necessary permissions.
- Domain: Created `FhirAppointment` model and `CalendarImportCubit`.
- Data: Implemented `CalendarRepository` for native calendar access and filtering.
- UI: Added `CalendarImportPage` and an entry point in `AppointmentsPage`.
- Stability: Added `timezone` initialization in `main.dart`.
- Testing: Added unit tests for the cubit.

Fixes #301

---
*PR created automatically by Jules for task [16836406608352268115](https://jules.google.com/task/16836406608352268115) started by @iberi22*