### PR TITLE
[chore] Update BLE stub warnings to proper unimplemented errors

### DIFF
--- a/lib/features/health_sharing/infrastructure/ble_sharing_service.dart
+++ b/lib/features/health_sharing/infrastructure/ble_sharing_service.dart
@@ -1,6 +1,4 @@
 ﻿import 'dart:async';
-import 'dart:convert';
-import 'package:flutter/foundation.dart';
 import '../domain/entities/shared_health_package.dart';
 
 /// BLE Service UUID for OrionHealth sharing
@@ -13,11 +11,6 @@ class BleSharingService {
   static const Duration connectionTimeout = Duration(seconds: 30);
   static const Duration transferTimeout = Duration(minutes: 3);
 
-  bool _isInitialized = false;
-  bool _isAdvertising = false;
-  bool _isScanning = false;
-  String? _connectedDeviceId;
-
   final _stateController = StreamController<BleSharingState>.broadcast();
   Stream<BleSharingState> get stateStream => _stateController.stream;
 
@@ -25,187 +18,55 @@ class BleSharingService {
   Stream<SharedHealthPackage> get incomingData => _dataController.stream;
 
   /// Initialize BLE adapter
+  // TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)
   Future<void> initialize() async {
-    if (_isInitialized) return;
-
-    // In production, use flutter_blue_plus:
-    // await FlutterBluePlus.startScan(timeout: scanTimeout);
-    // await FlutterBluePlus.startAdvertising(...);
-
-    _isInitialized = true;
-    _stateController.add(BleSharingState.ready());
+    throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');
   }
 
   /// Start advertising as a BLE server (to send data)
+  // TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)
   Future<void> startAdvertising(String nodeId) async {
-    if (!_isInitialized) await initialize();
-    if (_isAdvertising) return;
-
-    // In production:
-    // await FlutterBluePlus.startAdvertising(
-    //   services: [Guid(kOrionHealthServiceUuid)],
-    //   name: 'OrionHealth_$nodeId',
-    // );
-
-    _isAdvertising = true;
-    _stateController.add(BleSharingState.advertising(nodeId));
+    throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');
   }
 
   /// Stop advertising
+  // TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)
   Future<void> stopAdvertising() async {
-    if (!_isAdvertising) return;
-
-    // await FlutterBluePlus.stopAdvertising();
-
-    _isAdvertising = false;
-    _stateController.add(BleSharingState.ready());
+    throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');
   }
 
   /// Scan for nearby OrionHealth devices (to receive data)
+  // TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)
   Future<List<BleDevice>> scanForDevices({Duration timeout = const Duration(seconds: 10)}) async {
-    if (!_isInitialized) await initialize();
-    if (_isScanning) return [];
-
-    _isScanning = true;
-    _stateController.add(BleSharingState.scanning());
-
-    final devices = <BleDevice>[];
-
-    // In production:
-    // final scanResults = await FlutterBluePlus.startScan(timeout: timeout);
-    // for (final result in scanResults) {
-    //   if (result.advertisementData.serviceUuids.contains(Guid(kOrionHealthServiceUuid))) {
-    //     devices.add(BleDevice(
-    //       id: result.device.remoteId.str,
-    //       name: result.advertisementData.advName ?? 'OrionHealth',
-    //     ));
-    //   }
-    // }
-
-    // Simulated scan results
-    await Future.delayed(timeout);
-
-    _isScanning = false;
-    _stateController.add(BleSharingState.ready());
-
-    return devices;
+    throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');
   }
 
   /// Connect to a BLE device
+  // TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)
   Future<bool> connect(String deviceId) async {
-    _stateController.add(BleSharingState.connecting(deviceId));
-
-    try {
-      // In production:
-      // final device = FlutterBluePlus.deviceFromId(deviceId);
-      // await device.connect(timeout: connectionTimeout);
-      // _connectedDeviceId = deviceId;
-
-      await Future.delayed(const Duration(seconds: 2)); // Simulate connection
-
-      _connectedDeviceId = deviceId;
-      _stateController.add(BleSharingState.connected(deviceId));
-      return true;
-    } catch (e) {
-      _stateController.add(BleSharingState.error('Failed to connect: $e'));
-      return false;
-    }
+    throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');
   }
 
   /// Disconnect from current device
+  // TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)
   Future<void> disconnect() async {
-    if (_connectedDeviceId == null) return;
-
-    // In production:
-    // final device = FlutterBluePlus.deviceFromId(_connectedDeviceId!);
-    // await device.disconnect();
-
-    _connectedDeviceId = null;
-    _stateController.add(BleSharingState.ready());
+    throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');
   }
 
   /// Send data package to connected device
+  // TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)
   Future<SharingResult> sendData(SharedHealthPackage package) async {
-    if (_connectedDeviceId == null) {
-      return SharingResult(
-        success: false,
-        error: 'Not connected to any device',
-        bytesTransferred: 0,
-        transferTime: Duration.zero,
-      );
-    }
-
-    _stateController.add(BleSharingState.transferring('Sending...'));
-
-    final startTime = DateTime.now();
-
-    try {
-      final data = package.encode();
-      final bytes = utf8.encode(data);
-
-      // In production, write to BLE characteristic:
-      // final characteristic = device.getCharacteristic(Guid(kOrionHealthTxCharacteristic));
-      // await characteristic.write(utf8.encode(data));
-
-      // Simulate chunked transfer
-      const chunkSize = 512;
-      for (int i = 0; i < bytes.length; i += chunkSize) {
-        final chunk = bytes.sublist(
-          i,
-          i + chunkSize > bytes.length ? bytes.length : i + chunkSize,
-        );
-        await Future.delayed(const Duration(milliseconds: 50));
-      }
-
-      final transferTime = DateTime.now().difference(startTime);
-
-      _stateController.add(BleSharingState.completed(
-        bytes.length,
-        transferTime,
-      ));
-
-      return SharingResult(
-        success: true,
-        bytesTransferred: bytes.length,
-        transferTime: transferTime,
-      );
-    } catch (e) {
-      _stateController.add(BleSharingState.error('Transfer failed: $e'));
-      return SharingResult(
-        success: false,
-        error: e.toString(),
-        bytesTransferred: 0,
-        transferTime: DateTime.now().difference(startTime),
-      );
-    }
+    throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');
   }
 
   /// Receive data from connected device
+  // TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)
   Future<SharedHealthPackage?> receiveData() async {
-    if (_connectedDeviceId == null) return null;
-
-    _stateController.add(BleSharingState.transferring('Receiving...'));
-
-    try {
-      // In production, read from BLE characteristic:
-      // final characteristic = device.getCharacteristic(Guid(kOrionHealthRxCharacteristic));
-      // final data = await characteristic.read();
-      // return SharedHealthPackage.decode(utf8.decode(data));
-
-      await Future.delayed(const Duration(seconds: 2)); // Simulate receive
-
-      _stateController.add(BleSharingState.ready());
-      return null; // Would return actual package in production
-    } catch (e) {
-      _stateController.add(BleSharingState.error('Receive failed: $e'));
-      return null;
-    }
+    throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');
   }
 
   /// Clean up resources
   void dispose() {
-    stopAdvertising();
-    disconnect();
     _stateController.close();
     _dataController.close();
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
I have updated the `BleSharingService` in `lib/features/health_sharing/infrastructure/ble_sharing_service.dart` as requested. 

Key changes:
- Replaced the implementation of `initialize`, `startAdvertising`, `stopAdvertising`, `scanForDevices`, `connect`, `disconnect`, `sendData`, and `receiveData` with `throw UnimplementedError('BLE sharing — implement when NFC/BLE infra ready');`.
- Added `// TODO: Implement BLE sharing (ref: CODE_REVIEW_ANOMALIES.md)` above each modified method.
- Cleaned up the file by removing unused imports (`dart:convert`, `package:flutter/foundation.dart`) and unused private fields (`_isInitialized`, `_isAdvertising`, `_isScanning`, `_connectedDeviceId`).
- Modified `dispose()` to only close the stream controllers, removing calls to `stopAdvertising()` and `disconnect()` which would now throw errors.
- Verified that `dart analyze` passes for the modified file.
- Confirmed that the file correctly maintains its original BOM and CRLF line endings using a custom Python script for the update.

Fixes #320

---
*PR created automatically by Jules for task [14791495156623581329](https://jules.google.com/task/14791495156623581329) started by @iberi22*