### PR TITLE
Fix unused_import and unnecessary_non_null_assertion warnings

### DIFF
--- a/lib/features/health_sharing/infrastructure/ble_sharing_service.dart
+++ b/lib/features/health_sharing/infrastructure/ble_sharing_service.dart
@@ -1,6 +1,5 @@
 ﻿import 'dart:async';
 import 'dart:convert';
-import 'package:flutter/foundation.dart';
 import '../domain/entities/shared_health_package.dart';
 
 /// BLE Service UUID for OrionHealth sharing
@@ -150,10 +149,9 @@ class BleSharingService {
       // Simulate chunked transfer
       const chunkSize = 512;
       for (int i = 0; i < bytes.length; i += chunkSize) {
-        final chunk = bytes.sublist(
-          i,
-          i + chunkSize > bytes.length ? bytes.length : i + chunkSize,
-        );
+        // In production, write chunk to characteristic:
+        // final chunk = bytes.sublist(i, i + chunkSize > bytes.length ? bytes.length : i + chunkSize);
+        // await characteristic.write(chunk);
         await Future.delayed(const Duration(milliseconds: 50));
       }
 

--- a/lib/features/medical_assistant/infrastructure/services/health_context_service_impl.dart
+++ b/lib/features/medical_assistant/infrastructure/services/health_context_service_impl.dart
@@ -93,11 +93,11 @@ class IsarHealthContextService implements HealthContextService {
 
     for (final entry in latestVitals.entries) {
       final vital = entry.value;
-      if (vital?.value == null) continue;
+      if (vital == null) continue;
 
       // Map VitalSignType enum to string keys expected by the clinical engine
       final key = _vitalTypeToKey(entry.key);
-      result[key] = vital!.value!;
+      result[key] = vital.value;
     }
     return result;
   }


### PR DESCRIPTION
This PR fixes several analyzer warnings reported in the project.

In `lib/features/health_sharing/infrastructure/ble_sharing_service.dart`:
- Removed the unused `package:flutter/foundation.dart` import.
- Removed the unused local variable `chunk` in the simulated data transfer loop and cleaned up the redundant `bytes.sublist` call.

In `lib/features/medical_assistant/infrastructure/services/health_context_service_impl.dart`:
- Removed unnecessary non-null assertions `!` from `vital!.value!`.
- Simplified the null check from `if (vital?.value == null)` to `if (vital == null)` since `value` is non-nullable.

Verified that these specific warnings are resolved using `dart analyze`.

Fixes #322

---
*PR created automatically by Jules for task [2709689927490137863](https://jules.google.com/task/2709689927490137863) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Removed unused dependencies in Bluetooth services
  * Improved null safety handling in health data processing

<!-- end of auto-generated comment: release notes by coderabbit.ai -->