### PR TITLE
Wire isar_agent_memory to return real user context

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -9,173 +9,186 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:dio/dio.dart' as _i10;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i52;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i56;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:http/http.dart' as _i7;
 import 'package:injectable/injectable.dart' as _i2;
 import 'package:isar/isar.dart' as _i17;
 import 'package:isar_agent_memory/isar_agent_memory.dart' as _i11;
-import 'package:medical_standards/medical_standards.dart' as _i25;
+import 'package:medical_standards/medical_standards.dart' as _i27;
 
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i60;
-import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
-    as _i61;
-import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i64;
-import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
     as _i65;
-import '../../features/auth/application/auth_cubit.dart' as _i92;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i93;
-import '../../features/auth/domain/auth_service.dart' as _i68;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i66;
+import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
+    as _i66;
+import '../../features/appointments/domain/repositories/appointment_repository.dart'
+    as _i69;
+import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
+    as _i70;
+import '../../features/auth/application/auth_cubit.dart' as _i99;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i98;
+import '../../features/auth/domain/auth_service.dart' as _i73;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i71;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
-    as _i67;
+    as _i72;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i3;
 import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
-    as _i69;
+    as _i74;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
     as _i12;
 import '../../features/ble_sharing/domain/ble_sharing_service.dart' as _i4;
 import '../../features/calendar_import/data/calendar_repository.dart' as _i6;
 import '../../features/calendar_import/domain/calendar_import_cubit.dart'
-    as _i70;
-import '../../features/eps_connection/data/oauth_repository.dart' as _i39;
-import '../../features/eps_connection/domain/eps_connection_cubit.dart' as _i73;
+    as _i75;
+import '../../features/eps_connection/data/oauth_repository.dart' as _i42;
+import '../../features/eps_connection/domain/eps_connection_cubit.dart' as _i78;
 import '../../features/health_data_import/application/health_import_cubit.dart'
-    as _i77;
+    as _i82;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i15;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i94;
+    as _i100;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i78;
+    as _i83;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i79;
+    as _i84;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i14;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
     as _i16;
 import '../../features/health_record/infrastructure/services/ocr_service.dart'
-    as _i40;
+    as _i43;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i89;
+    as _i95;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
-    as _i26;
-import '../../features/local_agent/domain/services/llm_adapter.dart' as _i19;
-import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i55;
-import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i20;
-import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i80;
-import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i81;
-import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i21;
-import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i83;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i82;
-import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i95;
-import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i27;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i28;
-import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i56;
-import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
-    as _i24;
-import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i96;
-import '../../features/local_agent/infrastructure/services/model_download_service.dart'
-    as _i38;
-import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
+import '../../features/local_agent/domain/services/llm_adapter.dart' as _i20;
+import '../../features/local_agent/domain/services/vector_store_service.dart'
+    as _i59;
+import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
+    as _i21;
+import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
     as _i86;
+import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+    as _i85;
+import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
+    as _i22;
+import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
+    as _i88;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i87;
+import '../../features/local_agent/infrastructure/rag_llm_service.dart'
+    as _i101;
+import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
+    as _i29;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i30;
+import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
+    as _i60;
+import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
+    as _i25;
+import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
+    as _i102;
+import '../../features/local_agent/infrastructure/services/model_download_service.dart'
+    as _i41;
+import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
+    as _i92;
+import '../../features/medical_assistant/application/medical_assistant_cubit.dart'
+    as _i90;
 import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
     as _i18;
 import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
-    as _i50;
+    as _i54;
 import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
-    as _i57;
+    as _i61;
 import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
-    as _i71;
-import '../../features/medical_assistant/domain/services/health_context_service.dart'
-    as _i75;
-import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
-    as _i72;
-import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
     as _i76;
-import '../../features/medical_research/domain/services/medical_scraper_service.dart'
-    as _i29;
-import '../../features/medical_research/domain/services/medical_standards_service.dart'
+import '../../features/medical_assistant/domain/services/health_context_service.dart'
+    as _i80;
+import '../../features/medical_assistant/domain/services/medical_analysis_service.dart'
+    as _i26;
+import '../../features/medical_assistant/infrastructure/analysis/lab_interpreter.dart'
+    as _i19;
+import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
+    as _i48;
+import '../../features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart'
+    as _i62;
+import '../../features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart'
     as _i31;
+import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
+    as _i77;
+import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
+    as _i81;
+import '../../features/medical_research/domain/services/medical_scraper_service.dart'
+    as _i32;
+import '../../features/medical_research/domain/services/medical_standards_service.dart'
+    as _i34;
 import '../../features/medical_research/domain/services/medical_web_search_service.dart'
-    as _i33;
+    as _i36;
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i5;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i85;
-import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
-    as _i30;
-import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
-    as _i32;
-import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
-    as _i34;
-import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i35;
-import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i36;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i41;
-import '../../features/onboarding/application/sync_cubit.dart' as _i90;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i97;
-import '../../features/reports/domain/repositories/report_repository.dart'
-    as _i43;
-import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i87;
-import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
-    as _i44;
-import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i88;
-import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
-    as _i37;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i84;
-import '../../features/settings/domain/repositories/llm_settings_repository.dart'
-    as _i22;
-import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i8;
-import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
-    as _i23;
-import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i46;
-import '../../features/ssi/domain/services/anoncreds_service.dart' as _i62;
-import '../../features/ssi/domain/services/ssi_service.dart' as _i48;
-import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
-    as _i47;
-import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
-    as _i63;
-import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
-    as _i45;
-import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
-    as _i49;
-import '../../features/sync/data/fhir_client.dart' as _i13;
-import '../../features/sync/data/sync_repository.dart' as _i51;
-import '../../features/sync/domain/sync_cubit.dart' as _i74;
-import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
     as _i91;
-import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
+import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
+    as _i33;
+import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
+    as _i35;
+import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
+    as _i37;
+import '../../features/medications/domain/repositories/medication_repository.dart'
+    as _i38;
+import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+    as _i39;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i44;
+import '../../features/onboarding/application/sync_cubit.dart' as _i96;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i103;
+import '../../features/reports/domain/repositories/report_repository.dart'
+    as _i46;
+import '../../features/reports/domain/services/report_generation_service.dart'
+    as _i93;
+import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
+    as _i47;
+import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+    as _i94;
+import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
+    as _i40;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i89;
+import '../../features/settings/domain/repositories/llm_settings_repository.dart'
+    as _i23;
+import '../../features/settings/domain/services/device_capability_service.dart'
+    as _i9;
+import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
+    as _i24;
+import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i50;
+import '../../features/ssi/domain/services/anoncreds_service.dart' as _i67;
+import '../../features/ssi/domain/services/ssi_service.dart' as _i52;
+import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
+    as _i51;
+import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
+    as _i68;
+import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
+    as _i49;
+import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
     as _i53;
+import '../../features/sync/data/fhir_client.dart' as _i13;
+import '../../features/sync/data/sync_repository.dart' as _i55;
+import '../../features/sync/domain/sync_cubit.dart' as _i79;
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i97;
+import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
+    as _i57;
 import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
-    as _i54;
-import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
     as _i58;
+import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+    as _i63;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
-    as _i59;
-import '../services/device_capability_service.dart' as _i9;
-import '../services/privacy_anonymizer.dart' as _i42;
-import 'database_module.dart' as _i101;
-import 'fhir_module.dart' as _i98;
-import 'memory_module.dart' as _i100;
-import 'network_module.dart' as _i99;
+    as _i64;
+import '../services/device_capability_service.dart' as _i8;
+import '../services/privacy_anonymizer.dart' as _i45;
+import 'database_module.dart' as _i107;
+import 'fhir_module.dart' as _i104;
+import 'memory_module.dart' as _i106;
+import 'network_module.dart' as _i105;
 
 const String _mobile = 'mobile';
 const String _desktop = 'desktop';
@@ -221,41 +234,45 @@ extension GetItInjectableX on _i1.GetIt {
       preResolve: true,
     );
     gh.factory<_i18.LabAnalysisStrategy>(() => _i18.LabAnalysisStrategy());
-    gh.lazySingleton<_i19.LlmAdapter>(
-      () => _i20.FlutterGemmaAdapter(),
+    gh.factory<_i19.LabInterpreter>(() => _i19.LabInterpreter());
+    gh.lazySingleton<_i20.LlmAdapter>(
+      () => _i21.FlutterGemmaAdapter(),
       instanceName: 'gemma',
     );
-    gh.lazySingleton<_i19.LlmAdapter>(
-      () => _i21.OpenaiCompatibleAdapter(),
+    gh.lazySingleton<_i20.LlmAdapter>(
+      () => _i22.OpenaiCompatibleAdapter(),
       instanceName: 'openai',
     );
-    gh.lazySingleton<_i22.LlmSettingsRepository>(
-        () => _i23.LlmSettingsRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i24.LocalLlmService>(() => _i24.LocalLlmService());
-    gh.lazySingleton<_i25.MedicalContextProvider>(
+    gh.lazySingleton<_i23.LlmSettingsRepository>(
+        () => _i24.LlmSettingsRepositoryImpl(gh<_i17.Isar>()));
+    gh.lazySingleton<_i25.LocalLlmService>(() => _i25.LocalLlmService());
+    gh.factory<_i26.MedicalAnalysisService>(
+        () => _i26.MedicalAnalysisService());
+    gh.lazySingleton<_i27.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
-    gh.factory<_i26.MedicalKnowledgeRepository>(
-      () => _i27.AssetMedicalKnowledgeRepository(),
+    gh.factory<_i28.MedicalKnowledgeRepository>(
+      () => _i29.AssetMedicalKnowledgeRepository(),
       registerFor: {_mobile},
     );
-    gh.factory<_i26.MedicalKnowledgeRepository>(
-      () => _i28.JsonMedicalKnowledgeRepository(),
+    gh.factory<_i28.MedicalKnowledgeRepository>(
+      () => _i30.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
     );
-    gh.lazySingleton<_i29.MedicalScraperService>(
-        () => _i30.MedicalScraperServiceImpl(
+    gh.factory<_i31.MedicalLlmAdapter>(() => _i31.MedicalLlmAdapter());
+    gh.lazySingleton<_i32.MedicalScraperService>(
+        () => _i33.MedicalScraperServiceImpl(
               gh<_i10.Dio>(),
               gh<_i5.BotBypassHandler>(),
             ));
-    gh.lazySingleton<_i31.MedicalStandardsService>(() =>
-        _i32.MedicalStandardsServiceImpl(gh<_i25.MedicalContextProvider>()));
-    gh.lazySingleton<_i33.MedicalWebSearchService>(
-        () => _i34.MedicalWebSearchServiceImpl(gh<_i10.Dio>()));
-    gh.lazySingleton<_i35.MedicationRepository>(
-        () => _i36.IsarMedicationRepository(gh<_i17.Isar>()));
+    gh.lazySingleton<_i34.MedicalStandardsService>(() =>
+        _i35.MedicalStandardsServiceImpl(gh<_i27.MedicalContextProvider>()));
+    gh.lazySingleton<_i36.MedicalWebSearchService>(
+        () => _i37.MedicalWebSearchServiceImpl(gh<_i10.Dio>()));
+    gh.lazySingleton<_i38.MedicationRepository>(
+        () => _i39.IsarMedicationRepository(gh<_i17.Isar>()));
     await gh.lazySingletonAsync<_i11.MemoryGraph>(
       () => memoryModule.memoryGraph(
         gh<_i17.Isar>(),
@@ -263,179 +280,190 @@ extension GetItInjectableX on _i1.GetIt {
       ),
       preResolve: true,
     );
-    gh.lazySingleton<_i37.MockReportGenerationService>(
-      () => _i37.MockReportGenerationService(),
+    gh.lazySingleton<_i40.MockReportGenerationService>(
+      () => _i40.MockReportGenerationService(),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i38.ModelDownloadService>(
-        () => _i38.ModelDownloadService());
-    gh.lazySingleton<_i39.OAuthRepository>(() => _i39.OAuthRepositoryImpl());
-    gh.lazySingleton<_i40.OcrService>(() => _i40.MlKitOcrService());
-    gh.factory<_i41.OnboardingCubit>(() => _i41.OnboardingCubit());
-    gh.lazySingleton<_i42.PromptScrubber>(
-        () => _i42.PromptScrubber(gh<_i17.Isar>()));
-    gh.lazySingleton<_i43.ReportRepository>(
-        () => _i44.IsarReportRepository(gh<_i17.Isar>()));
-    gh.lazySingleton<_i45.SidetreeAnchorClient>(
-        () => _i45.SidetreeAnchorClient.create());
-    gh.lazySingleton<_i46.SsiRepository>(
-        () => _i47.IsarSsiRepository(gh<_i17.Isar>()));
-    gh.lazySingleton<_i48.SsiService>(() => _i49.SsiServiceImpl(
-          gh<_i46.SsiRepository>(),
-          gh<_i45.SidetreeAnchorClient>(),
+    gh.lazySingleton<_i41.ModelDownloadService>(
+        () => _i41.ModelDownloadService());
+    gh.lazySingleton<_i42.OAuthRepository>(() => _i42.OAuthRepositoryImpl());
+    gh.lazySingleton<_i43.OcrService>(() => _i43.MlKitOcrService());
+    gh.factory<_i44.OnboardingCubit>(() => _i44.OnboardingCubit());
+    gh.lazySingleton<_i45.PromptScrubber>(
+        () => _i45.PromptScrubber(gh<_i17.Isar>()));
+    gh.lazySingleton<_i46.ReportRepository>(
+        () => _i47.IsarReportRepository(gh<_i17.Isar>()));
+    gh.factory<_i48.RiskCalculator>(() => _i48.RiskCalculator());
+    gh.lazySingleton<_i49.SidetreeAnchorClient>(
+        () => _i49.SidetreeAnchorClient.create());
+    gh.lazySingleton<_i50.SsiRepository>(
+        () => _i51.IsarSsiRepository(gh<_i17.Isar>()));
+    gh.lazySingleton<_i52.SsiService>(() => _i53.SsiServiceImpl(
+          gh<_i50.SsiRepository>(),
+          gh<_i49.SidetreeAnchorClient>(),
         ));
-    gh.factory<_i50.SymptomAnalysisStrategy>(
-        () => _i50.SymptomAnalysisStrategy());
-    gh.lazySingleton<_i51.SyncRepository>(() => _i51.SyncRepository(
+    gh.factory<_i54.SymptomAnalysisStrategy>(
+        () => _i54.SymptomAnalysisStrategy());
+    gh.lazySingleton<_i55.SyncRepository>(() => _i55.SyncRepository(
           gh<_i13.FhirClient>(),
           gh<_i17.Isar>(),
-          gh<_i52.FlutterSecureStorage>(),
+          gh<_i56.FlutterSecureStorage>(),
         ));
-    gh.lazySingleton<_i25.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i53.UserProfileRepository>(
-        () => _i54.UserProfileRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i55.VectorStoreService>(() => _i56.IsarVectorStoreService(
+    gh.lazySingleton<_i27.SyncService>(() => networkModule.syncService);
+    gh.lazySingleton<_i57.UserProfileRepository>(
+        () => _i58.UserProfileRepositoryImpl(gh<_i17.Isar>()));
+    gh.lazySingleton<_i59.VectorStoreService>(() => _i60.IsarVectorStoreService(
           gh<_i11.MemoryGraph>(),
-          gh<_i26.MedicalKnowledgeRepository>(),
+          gh<_i28.MedicalKnowledgeRepository>(),
         ));
-    gh.factory<_i57.VitalAnalysisStrategy>(() => _i57.VitalAnalysisStrategy());
-    gh.lazySingleton<_i58.VitalSignRepository>(
-        () => _i59.VitalSignRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i60.AllergyRepository>(
-        () => _i61.IsarAllergyRepository(gh<_i17.Isar>()));
-    gh.lazySingleton<_i62.AnonCredsService>(
-        () => _i63.AnonCredsServiceImpl(gh<_i46.SsiRepository>()));
-    gh.lazySingleton<_i64.AppointmentRepository>(
-        () => _i65.IsarAppointmentRepository(gh<_i17.Isar>()));
-    gh.lazySingleton<_i66.AuthRepository>(
-        () => _i67.AuthRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i68.AuthService>(
-        () => _i68.AuthServiceImpl(gh<_i12.EncryptionService>()));
-    gh.lazySingleton<_i69.BleMedicalSharingService>(
-        () => _i69.BleMedicalSharingService(
+    gh.factory<_i61.VitalAnalysisStrategy>(() => _i61.VitalAnalysisStrategy());
+    gh.factory<_i62.VitalSignAnalyzer>(() => _i62.VitalSignAnalyzer());
+    gh.lazySingleton<_i63.VitalSignRepository>(
+        () => _i64.VitalSignRepositoryImpl(gh<_i17.Isar>()));
+    gh.lazySingleton<_i65.AllergyRepository>(
+        () => _i66.IsarAllergyRepository(gh<_i17.Isar>()));
+    gh.lazySingleton<_i67.AnonCredsService>(
+        () => _i68.AnonCredsServiceImpl(gh<_i50.SsiRepository>()));
+    gh.lazySingleton<_i69.AppointmentRepository>(
+        () => _i70.IsarAppointmentRepository(gh<_i17.Isar>()));
+    gh.lazySingleton<_i71.AuthRepository>(
+        () => _i72.AuthRepositoryImpl(gh<_i17.Isar>()));
+    gh.lazySingleton<_i73.AuthService>(
+        () => _i73.AuthServiceImpl(gh<_i12.EncryptionService>()));
+    gh.lazySingleton<_i74.BleMedicalSharingService>(
+        () => _i74.BleMedicalSharingService(
               gh<_i4.BleSharingService>(),
               gh<_i12.EncryptionService>(),
-              gh<_i48.SsiService>(),
+              gh<_i52.SsiService>(),
             ));
-    gh.factory<_i70.CalendarImportCubit>(() => _i70.CalendarImportCubit(
+    gh.factory<_i75.CalendarImportCubit>(() => _i75.CalendarImportCubit(
           gh<_i6.CalendarRepository>(),
-          gh<_i64.AppointmentRepository>(),
-          gh<_i53.UserProfileRepository>(),
+          gh<_i69.AppointmentRepository>(),
+          gh<_i57.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i71.ClinicalReasonerService>(() =>
-        _i72.SymphonyClinicalReasonerService(
-            gh<_i26.MedicalKnowledgeRepository>()));
-    gh.factory<_i73.EpsConnectionCubit>(() => _i73.EpsConnectionCubit(
-          gh<_i39.OAuthRepository>(),
-          gh<_i53.UserProfileRepository>(),
+    gh.lazySingleton<_i76.ClinicalReasonerService>(() =>
+        _i77.SymphonyClinicalReasonerService(
+            gh<_i28.MedicalKnowledgeRepository>()));
+    gh.factory<_i78.EpsConnectionCubit>(() => _i78.EpsConnectionCubit(
+          gh<_i42.OAuthRepository>(),
+          gh<_i57.UserProfileRepository>(),
         ));
-    gh.factory<_i74.FhirSyncCubit>(
-        () => _i74.FhirSyncCubit(gh<_i51.SyncRepository>()));
-    gh.lazySingleton<_i75.HealthContextService>(
-        () => _i76.IsarHealthContextService(
-              gh<_i58.VitalSignRepository>(),
-              gh<_i35.MedicationRepository>(),
+    gh.factory<_i79.FhirSyncCubit>(
+        () => _i79.FhirSyncCubit(gh<_i55.SyncRepository>()));
+    gh.lazySingleton<_i80.HealthContextService>(
+        () => _i81.IsarHealthContextService(
+              gh<_i63.VitalSignRepository>(),
+              gh<_i38.MedicationRepository>(),
+              gh<_i57.UserProfileRepository>(),
               gh<_i11.MemoryGraph>(),
             ));
-    gh.factory<_i77.HealthImportCubit>(() => _i77.HealthImportCubit(
+    gh.factory<_i82.HealthImportCubit>(() => _i82.HealthImportCubit(
           gh<_i15.HealthDataImportService>(),
-          gh<_i58.VitalSignRepository>(),
+          gh<_i63.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i78.HealthRecordRepository>(
-        () => _i79.HealthRecordRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i19.LlmAdapter>(
-      () => _i80.GeminiLlmAdapter(
-        scrubber: gh<_i42.PromptScrubber>(),
-        userProfileRepository: gh<_i53.UserProfileRepository>(),
+    gh.lazySingleton<_i83.HealthRecordRepository>(
+        () => _i84.HealthRecordRepositoryImpl(gh<_i17.Isar>()));
+    gh.factory<_i20.LlmAdapter>(
+      () => _i85.MockLlmAdapter(gh<_i45.PromptScrubber>()),
+      instanceName: 'mock',
+    );
+    gh.lazySingleton<_i20.LlmAdapter>(
+      () => _i86.GeminiLlmAdapter(
+        scrubber: gh<_i45.PromptScrubber>(),
+        userProfileRepository: gh<_i57.UserProfileRepository>(),
       ),
       instanceName: 'gemini',
     );
-    gh.factory<_i19.LlmAdapter>(
-      () => _i81.MockLlmAdapter(gh<_i42.PromptScrubber>()),
-      instanceName: 'mock',
-    );
-    gh.lazySingleton<_i82.LlmService>(() => _i83.GemmaLlmService(
-          gh<_i55.VectorStoreService>(),
-          gh<_i53.UserProfileRepository>(),
-          gh<_i19.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i87.LlmService>(() => _i88.GemmaLlmService(
+          gh<_i59.VectorStoreService>(),
+          gh<_i57.UserProfileRepository>(),
+          gh<_i20.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i84.LlmSettingsCubit>(() => _i84.LlmSettingsCubit(
-          gh<_i22.LlmSettingsRepository>(),
-          gh<_i8.DeviceCapabilityService>(),
-          gh<_i19.LlmAdapter>(instanceName: 'gemma'),
+    gh.factory<_i89.LlmSettingsCubit>(() => _i89.LlmSettingsCubit(
+          gh<_i23.LlmSettingsRepository>(),
+          gh<_i9.DeviceCapabilityService>(),
+          gh<_i20.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.lazySingleton<_i85.MedicalResearchService>(
-        () => _i85.MedicalResearchService(
-              gh<_i33.MedicalWebSearchService>(),
-              gh<_i29.MedicalScraperService>(),
+    gh.factory<_i90.MedicalAssistantCubit>(() => _i90.MedicalAssistantCubit(
+          llmAdapter: gh<_i31.MedicalLlmAdapter>(),
+          analysisService: gh<_i26.MedicalAnalysisService>(),
+          healthContextService: gh<_i80.HealthContextService>(),
+          labInterpreter: gh<_i19.LabInterpreter>(),
+          vitalAnalyzer: gh<_i62.VitalSignAnalyzer>(),
+          riskCalculator: gh<_i48.RiskCalculator>(),
+        ));
+    gh.lazySingleton<_i91.MedicalResearchService>(
+        () => _i91.MedicalResearchService(
+              gh<_i36.MedicalWebSearchService>(),
+              gh<_i32.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i86.PatientContextIndexer>(
-      () => _i86.PatientContextIndexer(
+    gh.lazySingleton<_i92.PatientContextIndexer>(
+      () => _i92.PatientContextIndexer(
         gh<_i17.Isar>(),
-        gh<_i55.VectorStoreService>(),
-        gh<_i78.HealthRecordRepository>(),
-        gh<_i35.MedicationRepository>(),
-        gh<_i60.AllergyRepository>(),
-        gh<_i58.VitalSignRepository>(),
-        gh<_i64.AppointmentRepository>(),
+        gh<_i59.VectorStoreService>(),
+        gh<_i83.HealthRecordRepository>(),
+        gh<_i38.MedicationRepository>(),
+        gh<_i65.AllergyRepository>(),
+        gh<_i63.VitalSignRepository>(),
+        gh<_i69.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i87.ReportGenerationService>(
-        () => _i88.GemmaReportGenerationService(
-              gh<_i19.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i55.VectorStoreService>(),
-              gh<_i53.UserProfileRepository>(),
-              gh<_i42.PromptScrubber>(),
+    gh.lazySingleton<_i93.ReportGenerationService>(
+        () => _i94.GemmaReportGenerationService(
+              gh<_i20.LlmAdapter>(instanceName: 'gemma'),
+              gh<_i59.VectorStoreService>(),
+              gh<_i57.UserProfileRepository>(),
+              gh<_i45.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i89.SmartSearchUseCase>(
-        () => _i89.SmartSearchUseCase(gh<_i55.VectorStoreService>()));
-    gh.factory<_i90.SyncCubit>(() => _i90.SyncCubit(
-          gh<_i25.SyncService>(),
-          gh<_i55.VectorStoreService>(),
+    gh.lazySingleton<_i95.SmartSearchUseCase>(
+        () => _i95.SmartSearchUseCase(gh<_i59.VectorStoreService>()));
+    gh.factory<_i96.SyncCubit>(() => _i96.SyncCubit(
+          gh<_i27.SyncService>(),
+          gh<_i59.VectorStoreService>(),
         ));
-    gh.factory<_i91.UserProfileCubit>(
-        () => _i91.UserProfileCubit(gh<_i53.UserProfileRepository>()));
-    gh.factory<_i92.AuthCubit>(() => _i92.AuthCubit(gh<_i68.AuthService>()));
-    gh.factory<_i93.AuthCubit>(() => _i93.AuthCubit(
-          gh<_i66.AuthRepository>(),
+    gh.factory<_i97.UserProfileCubit>(
+        () => _i97.UserProfileCubit(gh<_i57.UserProfileRepository>()));
+    gh.factory<_i98.AuthCubit>(() => _i98.AuthCubit(
+          gh<_i71.AuthRepository>(),
           gh<_i12.EncryptionService>(),
           gh<_i3.BiometricService>(),
         ));
-    gh.factory<_i94.HealthRecordCubit>(() => _i94.HealthRecordCubit(
-          gh<_i78.HealthRecordRepository>(),
+    gh.factory<_i99.AuthCubit>(() => _i99.AuthCubit(gh<_i73.AuthService>()));
+    gh.factory<_i100.HealthRecordCubit>(() => _i100.HealthRecordCubit(
+          gh<_i83.HealthRecordRepository>(),
           gh<_i14.FilePickerService>(),
           gh<_i16.ImagePickerService>(),
-          gh<_i40.OcrService>(),
-          gh<_i55.VectorStoreService>(),
+          gh<_i43.OcrService>(),
+          gh<_i59.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i82.LlmService>(
-      () => _i95.RagLlmService(
-        gh<_i55.VectorStoreService>(),
-        gh<_i85.MedicalResearchService>(),
-        gh<_i53.UserProfileRepository>(),
-        gh<_i19.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i87.LlmService>(
+      () => _i101.RagLlmService(
+        gh<_i59.VectorStoreService>(),
+        gh<_i91.MedicalResearchService>(),
+        gh<_i57.UserProfileRepository>(),
+        gh<_i20.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
-    gh.lazySingleton<_i96.MedicalIndexingService>(
-        () => _i96.MedicalIndexingService(
-              gh<_i26.MedicalKnowledgeRepository>(),
-              gh<_i55.VectorStoreService>(),
-              gh<_i86.PatientContextIndexer>(),
+    gh.lazySingleton<_i102.MedicalIndexingService>(
+        () => _i102.MedicalIndexingService(
+              gh<_i28.MedicalKnowledgeRepository>(),
+              gh<_i59.VectorStoreService>(),
+              gh<_i92.PatientContextIndexer>(),
             ));
-    gh.factory<_i97.ReportBloc>(() => _i97.ReportBloc(
-          gh<_i43.ReportRepository>(),
-          gh<_i87.ReportGenerationService>(),
+    gh.factory<_i103.ReportBloc>(() => _i103.ReportBloc(
+          gh<_i46.ReportRepository>(),
+          gh<_i93.ReportGenerationService>(),
         ));
     return this;
   }
 }
 
-class _$FhirModule extends _i98.FhirModule {}
+class _$FhirModule extends _i104.FhirModule {}
 
-class _$NetworkModule extends _i99.NetworkModule {}
+class _$NetworkModule extends _i105.NetworkModule {}
 
-class _$MemoryModule extends _i100.MemoryModule {}
+class _$MemoryModule extends _i106.MemoryModule {}
 
-class _$DatabaseModule extends _i101.DatabaseModule {}
+class _$DatabaseModule extends _i107.DatabaseModule {}

--- a/lib/features/medical_assistant/application/medical_assistant_cubit.dart
+++ b/lib/features/medical_assistant/application/medical_assistant_cubit.dart
@@ -1,5 +1,6 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
+import 'package:injectable/injectable.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 import '../domain/entities/medical_query.dart';
@@ -7,6 +8,7 @@ import '../domain/entities/medical_insight.dart';
 import '../domain/entities/ai_response.dart';
 import '../domain/entities/analysis_response.dart';
 import '../domain/services/medical_analysis_service.dart';
+import '../domain/services/health_context_service.dart';
 import '../infrastructure/llm/medical_llm_adapter.dart';
 import '../infrastructure/analysis/lab_interpreter.dart';
 import '../infrastructure/analysis/vital_sign_analyzer.dart';
@@ -53,20 +55,24 @@ class MedicalAssistantError extends MedicalAssistantState {
 }
 
 // Cubit
+@injectable
 class MedicalAssistantCubit extends Cubit<MedicalAssistantState> {
   final MedicalLlmAdapter _llmAdapter;
   final MedicalAnalysisService _analysisService;
+  final HealthContextService _healthContextService;
   final LabInterpreter _labInterpreter;
   final VitalSignAnalyzer _vitalAnalyzer;
   final RiskCalculator _riskCalculator;
   MedicalAssistantCubit({
     MedicalLlmAdapter? llmAdapter,
     MedicalAnalysisService? analysisService,
+    required HealthContextService healthContextService,
     LabInterpreter? labInterpreter,
     VitalSignAnalyzer? vitalAnalyzer,
     RiskCalculator? riskCalculator,
   })  : _llmAdapter = llmAdapter ?? MedicalLlmAdapter(),
         _analysisService = analysisService ?? MedicalAnalysisService(),
+        _healthContextService = healthContextService,
         _labInterpreter = labInterpreter ?? LabInterpreter(),
         _vitalAnalyzer = vitalAnalyzer ?? VitalSignAnalyzer(),
         _riskCalculator = riskCalculator ?? RiskCalculator(),
@@ -94,12 +100,12 @@ class MedicalAssistantCubit extends Cubit<MedicalAssistantState> {
       );
 
       // Gather user context from memory
-      final userContext = await _getUserContext(userId);
-      final chronicConditions =
-          userContext['conditions'] as List<Icd10Code>? ?? [];
-      final labValues =
-          userContext['labs'] as Map<String, double>? ?? {};
-      final vitals = userContext['vitals'] as Map<String, double>? ?? {};
+      final healthContext = await _healthContextService.getContextForUser(userId ?? 'default');
+      final userContext = healthContext.toContextMap();
+
+      final chronicConditions = healthContext.conditions;
+      final labValues = healthContext.labValues;
+      final vitals = healthContext.vitals;
 
       // ---- Lab Analysis ----
       emit(const MedicalAssistantLoading(message: 'Analizando laboratorios...'));
@@ -243,17 +249,4 @@ class MedicalAssistantCubit extends Cubit<MedicalAssistantState> {
     return tags;
   }
 
-  Future<Map<String, dynamic>> _getUserContext(String? userId) async {
-    if (userId == null) {
-      return {};
-    }
-
-    // Stub: would query user health data from local repositories
-    return {
-      'conditions': <Icd10Code>[],
-      'labs': <String, double>{},
-      'vitals': <String, double>{},
-      'medications': <String>[],
-    };
-  }
 }

--- a/lib/features/medical_assistant/domain/services/medical_analysis_service.dart
+++ b/lib/features/medical_assistant/domain/services/medical_analysis_service.dart
@@ -1,9 +1,11 @@
+import 'package:injectable/injectable.dart';
 import 'package:medical_standards/medical_standards.dart';
 import '../entities/medical_insight.dart';
 import '../entities/ai_response.dart';
 import '../entities/analysis_response.dart';
 
 /// Domain service for medical analysis orchestration
+@injectable
 /// 
 /// IMPORTANT: All analysis follows strict confidence rules:
 /// - AI NEVER says "you have X" unless 90%+ confidence

--- a/lib/features/medical_assistant/infrastructure/analysis/lab_interpreter.dart
+++ b/lib/features/medical_assistant/infrastructure/analysis/lab_interpreter.dart
@@ -1,7 +1,9 @@
+import 'package:injectable/injectable.dart';
 import 'package:medical_standards/medical_standards.dart';
 import '../../domain/entities/medical_insight.dart';
 
 /// Interprets laboratory results using LOINC codes and clinical guidelines
+@injectable
 class LabInterpreter {
   /// Interpret a single lab value
   LabInterpretation interpret({

--- a/lib/features/medical_assistant/infrastructure/analysis/risk_calculator.dart
+++ b/lib/features/medical_assistant/infrastructure/analysis/risk_calculator.dart
@@ -1,7 +1,9 @@
+import 'package:injectable/injectable.dart';
 import 'package:medical_standards/medical_standards.dart';
 import '../../domain/entities/medical_insight.dart';
 
 /// Calculates various health risk scores
+@injectable
 class RiskCalculator {
   /// Calculate 10-year ASCVD risk (American College of Cardiology/AHA)
   /// Uses the Pooled Cohort Equations

--- a/lib/features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart
+++ b/lib/features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart
@@ -1,7 +1,9 @@
+import 'package:injectable/injectable.dart';
 import 'package:medical_standards/medical_standards.dart';
 import '../../domain/entities/medical_insight.dart';
 
 /// Analyzes vital signs against clinical guidelines
+@injectable
 class VitalSignAnalyzer {
   /// Analyze blood pressure reading
   VitalSignInterpretation analyzeBloodPressure({

--- a/lib/features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart
+++ b/lib/features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart
@@ -1,3 +1,4 @@
+import 'package:injectable/injectable.dart';
 import '../../domain/entities/medical_query.dart';
 import '../../domain/entities/medical_insight.dart';
 import '../../domain/entities/ai_response.dart';
@@ -6,6 +7,7 @@ import '../../domain/services/medical_analysis_service.dart';
 import 'medical_response_generator.dart';
 
 /// Adapter for medical LLM API integration.
+@injectable
 ///
 /// Enforces strict confidence-based responses:
 /// - AI NEVER diagnoses below 90% confidence

--- a/lib/features/medical_assistant/infrastructure/services/health_context_service_impl.dart
+++ b/lib/features/medical_assistant/infrastructure/services/health_context_service_impl.dart
@@ -1,10 +1,13 @@
 import 'package:injectable/injectable.dart';
+import 'package:isar/isar.dart';
 import 'package:isar_agent_memory/isar_agent_memory.dart';
 import 'package:medical_standards/medical_standards.dart' show Icd10Code;
+import 'package:health_wallet/health_wallet.dart' show LabResult;
 
 import '../../../vitals/domain/repositories/vital_sign_repository.dart';
 import '../../../vitals/domain/entities/vital_sign.dart';
 import '../../../medications/domain/repositories/medication_repository.dart';
+import '../../../user_profile/domain/repositories/user_profile_repository.dart';
 import '../../domain/services/health_context_service.dart';
 import '../../../../core/services/app_logger.dart';
 
@@ -13,7 +16,8 @@ import '../../../../core/services/app_logger.dart';
 /// Strategy (Option A — Typed Repos + MemoryGraph for notes):
 /// - Structured vitals → [VitalSignRepository.getLatestVitals()]
 /// - Active medications → [MedicationRepository.getAllMedications()]
-/// - Conditions → derived from VitalSign notes + memory tags
+/// - Conditions → from [UserProfileRepository]
+/// - Labs → from Isar [LabResult] collection
 /// - Episodic notes → [MemoryGraph.hybridSearch] with user tag
 ///
 /// All reads are non-blocking. Failures are gracefully caught and logged.
@@ -24,11 +28,13 @@ class IsarHealthContextService implements HealthContextService {
 
   final VitalSignRepository _vitalRepo;
   final MedicationRepository _medicationRepo;
+  final UserProfileRepository _userProfileRepo;
   final MemoryGraph _memoryGraph;
 
   IsarHealthContextService(
     this._vitalRepo,
     this._medicationRepo,
+    this._userProfileRepo,
     this._memoryGraph,
   );
 
@@ -40,16 +46,20 @@ class IsarHealthContextService implements HealthContextService {
       // 1. Latest vitals → Map<String, double>
       final vitalsMap = await _loadVitals();
 
-      // 2. Active medications → List<String> (names for now, RxNorm lookup optional)
+      // 2. Active medications → List<String>
       final medications = await _loadMedications();
 
-      // 3. Conditions — currently no dedicated repo; derive from memory tags
-      final conditions = <Icd10Code>[];
+      // 3. Conditions from UserProfile
+      final conditions = await _loadConditions();
 
-      // 4. Episodic notes from MemoryGraph (free-text health notes)
+      // 4. Lab results from Isar
+      final labs = await _loadLabs();
+
+      // 5. Episodic notes from MemoryGraph (free-text health notes)
       final notes = await _loadEpisodicNotes(userId);
 
       final ctx = HealthContext(
+        labValues: labs,
         vitals: vitalsMap,
         conditions: conditions,
         medications: medications,
@@ -57,7 +67,7 @@ class IsarHealthContextService implements HealthContextService {
       );
 
       AppLogger.i(_tag,
-          'Context ready: ${vitalsMap.length} vitals, ${medications.length} meds, ${notes.length} notes');
+          'Context ready: ${labs.length} labs, ${vitalsMap.length} vitals, ${medications.length} meds, ${notes.length} notes');
       return ctx;
     } catch (e, st) {
       AppLogger.e(_tag, 'Failed to load context — returning empty', error: e, stackTrace: st);
@@ -121,6 +131,38 @@ class IsarHealthContextService implements HealthContextService {
     } catch (e) {
       AppLogger.w(_tag, 'Memory search failed for notes: $e');
       return [];
+    }
+  }
+
+  Future<List<Icd10Code>> _loadConditions() async {
+    try {
+      final profile = await _userProfileRepo.getUserProfile();
+      if (profile == null) return [];
+
+      return profile.medicalConditions
+          .map((code) => Icd10Code.findByCode(code))
+          .whereType<Icd10Code>()
+          .toList();
+    } catch (e) {
+      AppLogger.e(_tag, 'Failed to load conditions', error: e);
+      return [];
+    }
+  }
+
+  Future<Map<String, double>> _loadLabs() async {
+    try {
+      final labs = await _memoryGraph.isar.labResults.where().findAll();
+      final Map<String, double> result = {};
+      for (final lab in labs) {
+        final val = double.tryParse(lab.resultValue);
+        if (val != null) {
+          result[lab.loincCode] = val;
+        }
+      }
+      return result;
+    } catch (e) {
+      AppLogger.e(_tag, 'Failed to load labs', error: e);
+      return {};
     }
   }
 

--- a/lib/features/medical_assistant/presentation/pages/medical_assistant_page.dart
+++ b/lib/features/medical_assistant/presentation/pages/medical_assistant_page.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 
+import '../../../../core/di/injection.dart';
 import '../../application/medical_assistant_cubit.dart';
 import '../../domain/entities/medical_insight.dart';
 import '../../domain/entities/ai_response.dart';
@@ -15,7 +16,7 @@ class MedicalAssistantPage extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return BlocProvider(
-      create: (_) => MedicalAssistantCubit(),
+      create: (_) => getIt<MedicalAssistantCubit>(),
       child: const _MedicalAssistantView(),
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR connects the `MedicalAssistant` feature to the real user health data stored in Isar and `isar_agent_memory`. 

Key changes:
1.  **`HealthContextService`**: Now retrieves real medical conditions from the user profile and lab results from the local database.
2.  **`MedicalAssistantCubit`**: Switched from using a local stub method to the centralized `HealthContextService`. It now receives a fully populated `HealthContext` including labs, vitals, and conditions.
3.  **Dependency Injection**: Fixed missing registrations by annotating medical analysis strategies and adapters with `@injectable`. Updated the UI to use the DI-managed cubit.
4.  **Data Mapping**: Added logic to map stored ICD-10 strings to domain objects and parse lab result values.

Fixes #309

---
*PR created automatically by Jules for task [9708263708862556839](https://jules.google.com/task/9708263708862556839) started by @iberi22*