### PR TITLE
Clean up BLE sharing service unused code and imports

### DIFF
--- a/lib/features/ble_sharing/domain/ble_sharing_service.dart
+++ b/lib/features/ble_sharing/domain/ble_sharing_service.dart
@@ -33,7 +33,6 @@ class BleSharingService {
   BluetoothCharacteristic? _txCharacteristic;
   BluetoothCharacteristic? _rxCharacteristic;
   StreamSubscription? _rxSubscription;
-  StreamSubscription<List<ScanResult>>? _scanSubscription;
 
   // Completer for receiving data (signals when a full package is received)
   Completer<MedicalSharePackage?>? _receiveCompleter;
@@ -59,7 +58,6 @@ class BleSharingService {
     stopAdvertising();
     disconnect();
     _rxSubscription?.cancel();
-    _scanSubscription?.cancel();
     _stateController.close();
     _dataController.close();
   }
@@ -86,7 +84,7 @@ class BleSharingService {
     );
 
     final completer = Completer<void>();
-    _scanSubscription = FlutterBluePlus.scanResults.listen((scanResults) {
+    final scanSubscription = FlutterBluePlus.scanResults.listen((scanResults) {
       for (final r in scanResults) {
         final deviceId = r.device.remoteId.str;
         // Cache the BluetoothDevice reference for later connect()
@@ -108,8 +106,7 @@ class BleSharingService {
     });
 
     await completer.future.timeout(timeout, onTimeout: () {});
-    await _scanSubscription?.cancel();
-    _scanSubscription = null;
+    await scanSubscription.cancel();
     await FlutterBluePlus.stopScan();
 
     _stateController.add(BleServiceState.ready());

--- a/lib/features/health_sharing/infrastructure/ble_sharing_service.dart
+++ b/lib/features/health_sharing/infrastructure/ble_sharing_service.dart
@@ -1,6 +1,5 @@
 ﻿import 'dart:async';
 import 'dart:convert';
-import 'package:flutter/foundation.dart';
 import '../domain/entities/shared_health_package.dart';
 
 /// BLE Service UUID for OrionHealth sharing
@@ -150,10 +149,6 @@ class BleSharingService {
       // Simulate chunked transfer
       const chunkSize = 512;
       for (int i = 0; i < bytes.length; i += chunkSize) {
-        final chunk = bytes.sublist(
-          i,
-          i + chunkSize > bytes.length ? bytes.length : i + chunkSize,
-        );
         await Future.delayed(const Duration(milliseconds: 50));
       }
 


### PR DESCRIPTION
This submission cleans up unused imports and variables in two BLE sharing service files as requested in issue #09. Static analysis was performed to verify the removal of lint warnings. Unrelated failures in the project's test suite were noted but not introduced by these changes.

Fixes #312

---
*PR created automatically by Jules for task [11198848558943374813](https://jules.google.com/task/11198848558943374813) started by @iberi22*