### PR TITLE
Add PII Anonymization to Clinical Reasoner Path

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -25,8 +25,8 @@ import '../../features/appointments/domain/repositories/appointment_repository.d
     as _i64;
 import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
     as _i65;
-import '../../features/auth/application/auth_cubit.dart' as _i92;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i93;
+import '../../features/auth/application/auth_cubit.dart' as _i93;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i92;
 import '../../features/auth/domain/auth_service.dart' as _i68;
 import '../../features/auth/domain/repositories/auth_repository.dart' as _i66;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
@@ -67,21 +67,21 @@ import '../../features/local_agent/domain/services/llm_adapter.dart' as _i19;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
     as _i55;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i20;
+    as _i21;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
     as _i80;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
     as _i81;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i21;
+    as _i20;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
     as _i83;
 import '../../features/local_agent/infrastructure/llm_service.dart' as _i82;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart' as _i95;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i27;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i28;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i27;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
     as _i56;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
@@ -222,12 +222,12 @@ extension GetItInjectableX on _i1.GetIt {
     );
     gh.factory<_i18.LabAnalysisStrategy>(() => _i18.LabAnalysisStrategy());
     gh.lazySingleton<_i19.LlmAdapter>(
-      () => _i20.FlutterGemmaAdapter(),
-      instanceName: 'gemma',
+      () => _i20.OpenaiCompatibleAdapter(),
+      instanceName: 'openai',
     );
     gh.lazySingleton<_i19.LlmAdapter>(
-      () => _i21.OpenaiCompatibleAdapter(),
-      instanceName: 'openai',
+      () => _i21.FlutterGemmaAdapter(),
+      instanceName: 'gemma',
     );
     gh.lazySingleton<_i22.LlmSettingsRepository>(
         () => _i23.LlmSettingsRepositoryImpl(gh<_i17.Isar>()));
@@ -235,15 +235,15 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i25.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
     gh.factory<_i26.MedicalKnowledgeRepository>(
-      () => _i27.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
-    );
-    gh.factory<_i26.MedicalKnowledgeRepository>(
-      () => _i28.JsonMedicalKnowledgeRepository(),
+      () => _i27.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
+    );
+    gh.factory<_i26.MedicalKnowledgeRepository>(
+      () => _i28.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
     );
     gh.lazySingleton<_i29.MedicalScraperService>(
         () => _i30.MedicalScraperServiceImpl(
@@ -322,9 +322,11 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i64.AppointmentRepository>(),
           gh<_i53.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i71.ClinicalReasonerService>(() =>
-        _i72.SymphonyClinicalReasonerService(
-            gh<_i26.MedicalKnowledgeRepository>()));
+    gh.lazySingleton<_i71.ClinicalReasonerService>(
+        () => _i72.SymphonyClinicalReasonerService(
+              gh<_i26.MedicalKnowledgeRepository>(),
+              gh<_i42.PromptScrubber>(),
+            ));
     gh.factory<_i73.EpsConnectionCubit>(() => _i73.EpsConnectionCubit(
           gh<_i39.OAuthRepository>(),
           gh<_i53.UserProfileRepository>(),
@@ -396,12 +398,12 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.factory<_i91.UserProfileCubit>(
         () => _i91.UserProfileCubit(gh<_i53.UserProfileRepository>()));
-    gh.factory<_i92.AuthCubit>(() => _i92.AuthCubit(gh<_i68.AuthService>()));
-    gh.factory<_i93.AuthCubit>(() => _i93.AuthCubit(
+    gh.factory<_i92.AuthCubit>(() => _i92.AuthCubit(
           gh<_i66.AuthRepository>(),
           gh<_i12.EncryptionService>(),
           gh<_i3.BiometricService>(),
         ));
+    gh.factory<_i93.AuthCubit>(() => _i93.AuthCubit(gh<_i68.AuthService>()));
     gh.factory<_i94.HealthRecordCubit>(() => _i94.HealthRecordCubit(
           gh<_i78.HealthRecordRepository>(),
           gh<_i14.FilePickerService>(),

--- a/lib/features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart
+++ b/lib/features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart
@@ -1,5 +1,6 @@
 
 import 'package:injectable/injectable.dart';
+import '../../../../core/services/privacy_anonymizer.dart';
 import '../../../local_agent/domain/entities/medical_code.dart';
 import '../../../local_agent/domain/repositories/medical_knowledge_repository.dart';
 import '../../domain/services/clinical_reasoner_service.dart';
@@ -7,8 +8,9 @@ import '../../domain/services/clinical_reasoner_service.dart';
 @LazySingleton(as: ClinicalReasonerService)
 class SymphonyClinicalReasonerService implements ClinicalReasonerService {
   final MedicalKnowledgeRepository _repository;
+  final PromptScrubber _scrubber;
 
-  SymphonyClinicalReasonerService(this._repository);
+  SymphonyClinicalReasonerService(this._repository, this._scrubber);
 
   int _levenshteinDistance(String s1, String s2) {
     if (s1 == s2) return 0;
@@ -83,10 +85,12 @@ class SymphonyClinicalReasonerService implements ClinicalReasonerService {
 
   @override
   Future<List<DiagnosticMatch>> analyzeSymptoms(String text) async {
+    final scrubbedText = await _scrubber.scrub(text, apiName: 'clinical-reasoner');
+
     final matches = <DiagnosticMatch>[];
     final mappings = _repository.getSymptomMappings();
-    final lowerText = text.toLowerCase();
-    final normalizedText = _normalize(text);
+    final lowerText = scrubbedText.toLowerCase();
+    final normalizedText = _normalize(scrubbedText);
 
     // Tokenize the input text with their start indices
     final tokens = <_SymptomToken>[];

--- a/test/features/medical_assistant/infrastructure/services/clinical_reasoner_service_test.dart
+++ b/test/features/medical_assistant/infrastructure/services/clinical_reasoner_service_test.dart
@@ -1,18 +1,26 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/core/services/privacy_anonymizer.dart';
 import 'package:orionhealth_health/features/local_agent/domain/entities/medical_code.dart';
 import 'package:orionhealth_health/features/local_agent/domain/repositories/medical_knowledge_repository.dart';
 import 'package:orionhealth_health/features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart';
 
 class MockMedicalKnowledgeRepository extends Mock implements MedicalKnowledgeRepository {}
+class MockPromptScrubber extends Mock implements PromptScrubber {}
 
 void main() {
   late MockMedicalKnowledgeRepository mockRepo;
+  late MockPromptScrubber mockScrubber;
   late SymphonyClinicalReasonerService reasoner;
 
   setUp(() {
     mockRepo = MockMedicalKnowledgeRepository();
-    reasoner = SymphonyClinicalReasonerService(mockRepo);
+    mockScrubber = MockPromptScrubber();
+    reasoner = SymphonyClinicalReasonerService(mockRepo, mockScrubber);
+
+    // Default scrubber behavior (no-op)
+    when(() => mockScrubber.scrub(any(), apiName: any(named: 'apiName')))
+        .thenAnswer((invocation) async => invocation.positionalArguments[0] as String);
   });
 
   group('ClinicalReasonerService', () {
@@ -277,6 +285,36 @@ void main() {
 
       expect(results.isNotEmpty, true);
       expect(results.first.code.code, 'J45');
+    });
+
+    test('analyzeSymptoms scrubs PII from input before processing', () async {
+      // Arrange
+      final piiInput = 'Mi correo es test@example.com y tengo fiebre';
+      final scrubbedInput = 'Mi correo es [EMAIL] y tengo fiebre';
+
+      when(() => mockScrubber.scrub(piiInput, apiName: 'clinical-reasoner'))
+          .thenAnswer((_) async => scrubbedInput);
+
+      final symptomsMapping = [
+        {
+          "symptom": "Fiebre",
+          "matches": [
+            {"code": "R50.9", "score": 0.7, "reason": "Temperatura alta"}
+          ]
+        }
+      ];
+
+      when(() => mockRepo.getSymptomMappings()).thenReturn(symptomsMapping);
+      when(() => mockRepo.searchByCode('R50.9')).thenAnswer((_) async =>
+        MedicalCode(code: 'R50.9', displayName: 'Fiebre', category: 'Symptom', standard: 'ICD-10'));
+
+      // Act
+      final results = await reasoner.analyzeSymptoms(piiInput);
+
+      // Assert
+      verify(() => mockScrubber.scrub(piiInput, apiName: 'clinical-reasoner')).called(1);
+      expect(results.isNotEmpty, true);
+      expect(results.first.code.code, 'R50.9');
     });
   });
 }


### PR DESCRIPTION
This change ensures that user-provided symptom text is anonymized (redacting PII like emails and phone numbers) before it reaches the clinical reasoning engine. 

Key changes:
- `SymphonyClinicalReasonerService` now depends on `PromptScrubber`.
- `analyzeSymptoms` calls `_scrubber.scrub()` at the beginning of the method.
- `ClinicalReasonerService` unit tests now include a verification step for the scrubbing logic.
- Updated the dependency injection configuration to reflect the new constructor parameter.

Fixes #314

---
*PR created automatically by Jules for task [14125329997411640962](https://jules.google.com/task/14125329997411640962) started by @iberi22*