### PR TITLE
[feat] Add VitalSigns and LabResult medical schemas + SchemaRegistry (SSI)

### DIFF
--- a/lib/features/ssi/domain/entities/credential_schema.dart
+++ b/lib/features/ssi/domain/entities/credential_schema.dart
@@ -50,6 +50,57 @@ class CredentialSchema {
     attributes: ['medicationName', 'dosage', 'frequency', 'prescribingDoctor', 'pharmacy', 'datePrescribed'],
   );
 
+  /// Composite Vital Signs credential bundling multiple vital readings
+  /// into a single verifiable credential. Includes common vitals such as
+  /// heart rate, blood pressure, temperature, SpO₂, and respiratory rate
+  /// for holistic sharing in clinical contexts.
+  static const vitalSignsCredential = CredentialSchema(
+    id: 'orion:schemas:VitalSignsCredential:v1',
+    name: 'Vital Signs Credential',
+    version: '1.0.0',
+    attributes: [
+      'heartRate',
+      'systolic',
+      'diastolic',
+      'bodyTemperature',
+      'temperatureSite',
+      'spo2',
+      'respiratoryRate',
+      'recordedAt',
+      'patientPosition',
+    ],
+    attributeTypes: {
+      'heartRate': 'number',
+      'systolic': 'number',
+      'diastolic': 'number',
+      'bodyTemperature': 'number',
+      'spo2': 'number',
+      'respiratoryRate': 'number',
+    },
+  );
+
+  /// Composite Lab Result credential bundling multiple lab test readings
+  /// into a single verifiable credential. Supports common lab panels
+  /// such as basic metabolic panel, lipid panel, and complete blood count.
+  static const labResultCredentialV2 = CredentialSchema(
+    id: 'orion:schemas:LabResultCredential:v2',
+    name: 'Lab Result Credential (Composite)',
+    version: '2.0.0',
+    attributes: [
+      'testName',
+      'resultValue',
+      'referenceRange',
+      'testDate',
+      'labName',
+      'interpretation',
+      'specimenType',
+      'performingProvider',
+    ],
+    attributeTypes: {
+      'resultValue': 'number',
+    },
+  );
+
   Map<String, dynamic> toJson() => {
         'id': id,
         'name': name,

--- a/lib/features/ssi/domain/services/schema_registry.dart
+++ b/lib/features/ssi/domain/services/schema_registry.dart
@@ -16,9 +16,15 @@ class SchemaRegistry {
     CredentialSchema.labResultCredential.id: CredentialSchema.labResultCredential,
     CredentialSchema.prescriptionCredential.id: CredentialSchema.prescriptionCredential,
 
-    // ── Vital Signs schemas ────────────────────────────────────────
+    // ── Composite Vital Signs schema (bundled) ─────────────────────
+    CredentialSchema.vitalSignsCredential.id: CredentialSchema.vitalSignsCredential,
+
+    // ── Composite Lab Result schema (v2 with specimen info) ────────
+    CredentialSchema.labResultCredentialV2.id: CredentialSchema.labResultCredentialV2,
+
+    // ── Vital Signs sub-schemas (individual measurements) ──────────
     ..._vitalSignSchemas,
-    // ── Lab Result schemas ─────────────────────────────────────────
+    // ── Lab Result sub-schemas (individual tests) ──────────────────
     ..._labResultSchemas,
   };
 

--- a/test/features/ssi/schema_registry_test.dart
+++ b/test/features/ssi/schema_registry_test.dart
@@ -1,0 +1,109 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/ssi/domain/entities/credential_schema.dart';
+import 'package:orionhealth_health/features/ssi/domain/services/schema_registry.dart';
+
+void main() {
+  late SchemaRegistry registry;
+
+  setUp(() {
+    registry = SchemaRegistry();
+  });
+
+  group('SchemaRegistry', () {
+    test('resolves core medical schemas by ID', () {
+      final vaccination = registry.getSchema('orion:schemas:VaccinationCredential:v1');
+      expect(vaccination, isNotNull);
+      expect(vaccination!.name, 'Vaccination Credential');
+    });
+
+    test('resolves composite vital signs schema', () {
+      final vitals = registry.getSchema('orion:schemas:VitalSignsCredential:v1');
+      expect(vitals, isNotNull);
+      expect(vitals!.name, 'Vital Signs Credential');
+      expect(vitals.attributes, contains('heartRate'));
+    });
+
+    test('resolves composite lab result schema (v2)', () {
+      final labV2 = registry.getSchema('orion:schemas:LabResultCredential:v2');
+      expect(labV2, isNotNull);
+      expect(labV2!.name, 'Lab Result Credential (Composite)');
+      expect(labV2.attributes, contains('specimenType'));
+    });
+
+    test('resolves individual vital sign schemas', () {
+      final hr = registry.getSchema('orion:schemas:HeartRateMeasurement:v1');
+      expect(hr, isNotNull);
+      expect(hr!.attributes, contains('heartRate'));
+      expect(hr.attributes, contains('recordedAt'));
+
+      final bp = registry.getSchema('orion:schemas:BloodPressureReading:v1');
+      expect(bp, isNotNull);
+      expect(bp!.attributes, contains('systolic'));
+      expect(bp.attributes, contains('diastolic'));
+    });
+
+    test('resolves individual lab result schemas', () {
+      final glucose = registry.getSchema('orion:schemas:BloodGlucose:v1');
+      expect(glucose, isNotNull);
+      expect(glucose!.attributes, contains('glucoseValue'));
+
+      final cholesterol = registry.getSchema('orion:schemas:CholesterolPanel:v1');
+      expect(cholesterol, isNotNull);
+      expect(cholesterol!.attributes, contains('ldl'));
+    });
+
+    test('listSchemas returns all registered schemas', () {
+      final all = registry.listSchemas();
+      expect(all.length, greaterThanOrEqualTo(11));
+    });
+
+    test('listSchemasByCategory filters by name', () {
+      final vitals = registry.listSchemasByCategory('vital');
+      expect(vitals, isNotEmpty);
+      expect(vitals.every((s) => s.name.toLowerCase().contains('vital')), true);
+
+      final labs = registry.listSchemasByCategory('lab');
+      expect(labs, isNotEmpty);
+    });
+
+    test('validate returns valid for matching claims', () {
+      final result = registry.validate('orion:schemas:VaccinationCredential:v1', {
+        'vaccineName': 'COVID-19 mRNA',
+        'doseNumber': 2,
+        'dateAdministered': '2026-05-01',
+        'lotNumber': 'LOT-123',
+        'administeringClinic': 'Hospital Central',
+      });
+      expect(result.isValid, true);
+      expect(result.errors, isEmpty);
+    });
+
+    test('validate returns errors for missing attributes', () {
+      final result = registry.validate('orion:schemas:VaccinationCredential:v1', {
+        'vaccineName': 'COVID-19 mRNA',
+      });
+      expect(result.isValid, false);
+      expect(result.errors, isNotEmpty);
+      expect(result.errors.any((e) => e.contains('Missing required')), true);
+    });
+
+    test('validate returns error for unknown schema', () {
+      final result = registry.validate('orion:schemas:Unknown:v1', {});
+      expect(result.isValid, false);
+      expect(result.errors.first, contains('Schema not found'));
+    });
+
+    test('register adds custom schema at runtime', () {
+      registry.register(const CredentialSchema(
+        id: 'orion:schemas:CustomTest:v1',
+        name: 'Custom Test',
+        version: '1.0.0',
+        attributes: ['customField'],
+      ));
+
+      final schema = registry.getSchema('orion:schemas:CustomTest:v1');
+      expect(schema, isNotNull);
+      expect(schema!.name, 'Custom Test');
+    });
+  });
+}

--- a/test/features/ssi/ssi_service_test.dart
+++ b/test/features/ssi/ssi_service_test.dart
@@ -326,6 +326,21 @@ void main() {
       expect(CredentialSchema.prescriptionCredential.attributes, contains('medicationName'));
       expect(CredentialSchema.prescriptionCredential.attributes, contains('dosage'));
     });
+
+    test('vitalSignsCredential composite schema has correct attributes', () {
+      expect(CredentialSchema.vitalSignsCredential.attributes, contains('heartRate'));
+      expect(CredentialSchema.vitalSignsCredential.attributes, contains('systolic'));
+      expect(CredentialSchema.vitalSignsCredential.attributes, contains('diastolic'));
+      expect(CredentialSchema.vitalSignsCredential.attributes, contains('spo2'));
+      expect(CredentialSchema.vitalSignsCredential.attributes, contains('recordedAt'));
+    });
+
+    test('labResultCredentialV2 composite schema has correct attributes', () {
+      expect(CredentialSchema.labResultCredentialV2.attributes, contains('testName'));
+      expect(CredentialSchema.labResultCredentialV2.attributes, contains('resultValue'));
+      expect(CredentialSchema.labResultCredentialV2.attributes, contains('specimenType'));
+      expect(CredentialSchema.labResultCredentialV2.attributes, contains('performingProvider'));
+    });
   });
   });
 }


### PR DESCRIPTION
## Description

Adds composite VitalSigns and LabResult medical credential schemas to the SSI system along with a comprehensive SchemaRegistry.

### Changes

- **credential_schema.dart**: Added \VitalSignsCredential\ composite schema (bundles heart rate, blood pressure, temperature, SpO2, respiratory rate) and \LabResultCredential v2\ composite schema (with specimen type and performing provider)
- **schema_registry.dart**: Registers both new composite schemas alongside existing individual measurement schemas
- **schema_registry_test.dart**: Comprehensive unit tests for schema resolution, validation, listing, and runtime registration
- **ssi_service_test.dart**: Added tests for new composite schema attributes

### Composite Schemas Added

| Schema | ID | Attributes |
|--------|-----|-----------|
| VitalSignsCredential | \orion:schemas:VitalSignsCredential:v1\ | heartRate, systolic, diastolic, bodyTemperature, spo2, respiratoryRate, etc. |
| LabResultCredential v2 | \orion:schemas:LabResultCredential:v2\ | testName, resultValue, specimenType, performingProvider, etc. |

Note that individual Vital Signs and Lab Result measurement schemas (HeartRateMeasurement, BloodPressureReading, BloodGlucose, CholesterolPanel, etc.) were already present in the registry from prior work.

Closes #347

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced Vital Signs and Lab Results v2 composite credential schemas supporting enhanced credential management and validation workflows.

* **Tests**
  * Added comprehensive test coverage for schema resolution, validation with error handling, schema listing/filtering, and runtime schema registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->