### PR TITLE
Add unit tests for Onboarding step validation

### DIFF
--- a/lib/features/onboarding/application/onboarding_cubit.dart
+++ b/lib/features/onboarding/application/onboarding_cubit.dart
@@ -315,6 +315,39 @@ class OnboardingCubit extends Cubit<OnboardingState> {
     final currentState = state;
     if (currentState is! OnboardingInProgress) return;
 
+    // Validation logic per step
+    final currentStepEnum = OnboardingStep.fromIndex(currentState.currentStep);
+
+    switch (currentStepEnum) {
+      case OnboardingStep.basicInfo:
+        if (currentState.profile.name == null || currentState.profile.name!.isEmpty) {
+          emit(const OnboardingError(message: 'Por favor ingresa tu nombre'));
+          emit(currentState); // Return to progress state
+          return;
+        }
+        if (currentState.profile.birthDate == null) {
+          emit(const OnboardingError(message: 'Por favor selecciona tu fecha de nacimiento'));
+          emit(currentState);
+          return;
+        }
+        if (currentState.profile.sex == null) {
+          emit(const OnboardingError(message: 'Por favor selecciona tu sexo'));
+          emit(currentState);
+          return;
+        }
+        break;
+      case OnboardingStep.privacy:
+        if (!currentState.profile.privacyConsent) {
+          emit(const OnboardingError(message: 'Debes aceptar el consentimiento de privacidad para continuar'));
+          emit(currentState);
+          return;
+        }
+        break;
+      default:
+        // No specific validation for other steps
+        break;
+    }
+
     if (currentState.currentStep < totalSteps - 1) {
       final updatedProfile = currentState.profile.copyWith(
         onboardingStep: currentState.currentStep + 1,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/onboarding/application/onboarding_cubit_test.dart
+++ b/test/features/onboarding/application/onboarding_cubit_test.dart
@@ -1,0 +1,210 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/onboarding/application/onboarding_cubit.dart';
+import 'package:orionhealth_health/features/onboarding/domain/entities/user_profile.dart';
+
+void main() {
+  late OnboardingCubit cubit;
+
+  setUp(() {
+    cubit = OnboardingCubit();
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  group('OnboardingCubit', () {
+    test('initial state is OnboardingInitial', () {
+      expect(cubit.state, isA<OnboardingInitial>());
+    });
+
+    test('startOnboarding emits Loading then InProgress at step 0', () async {
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<OnboardingLoading>(),
+          isA<OnboardingInProgress>().having((s) => s.currentStep, 'currentStep', 0),
+        ]),
+      );
+
+      await cubit.startOnboarding();
+      await expectation;
+    });
+
+    test('resumeOnboarding emits Loading then InProgress at saved step', () async {
+      final savedProfile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        onboardingStep: 2,
+      );
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<OnboardingLoading>(),
+          isA<OnboardingInProgress>().having((s) => s.currentStep, 'currentStep', 2),
+        ]),
+      );
+
+      await cubit.resumeOnboarding(savedProfile);
+      await expectation;
+    });
+
+    test('nextStep from welcome (step 0) to basicInfo (step 1) works without validation', () async {
+      await cubit.startOnboarding();
+
+      final expectation = expectLater(
+        cubit.stream,
+        emits(isA<OnboardingInProgress>().having((s) => s.currentStep, 'currentStep', 1)),
+      );
+
+      await cubit.nextStep();
+      await expectation;
+    });
+
+    group('Validation Logic', () {
+      test('nextStep from basicInfo fails if required fields are missing', () async {
+        await cubit.startOnboarding();
+        await cubit.nextStep(); // Move to basicInfo
+        expect((cubit.state as OnboardingInProgress).currentStep, 1);
+
+        // Name is missing
+        final expectation = expectLater(
+          cubit.stream,
+          emitsInOrder([
+            isA<OnboardingError>().having((e) => e.message, 'message', contains('nombre')),
+            isA<OnboardingInProgress>(), // Emitted back to restore state
+          ]),
+        );
+
+        await cubit.nextStep();
+        await expectation;
+        expect((cubit.state as OnboardingInProgress).currentStep, 1); // Still at step 1
+      });
+
+      test('nextStep from basicInfo succeeds if required fields are present', () async {
+        await cubit.startOnboarding();
+        await cubit.nextStep(); // Move to basicInfo
+
+        await cubit.updateName('John Doe');
+        await cubit.updateBirthDate(DateTime(1990, 1, 1));
+        await cubit.updateSex('M');
+
+        final expectation = expectLater(
+          cubit.stream,
+          emits(isA<OnboardingInProgress>().having((s) => s.currentStep, 'currentStep', 2)),
+        );
+
+        await cubit.nextStep();
+        await expectation;
+      });
+
+      test('nextStep from privacy fails if consent is not given', () async {
+        await cubit.startOnboarding();
+        // Skip to privacy step (5) for testing
+        final savedProfile = (cubit.state as OnboardingInProgress).profile.copyWith(
+          onboardingStep: 5,
+          name: 'John',
+          birthDate: DateTime.now(),
+          sex: 'M',
+        );
+        await cubit.resumeOnboarding(savedProfile);
+
+        final expectation = expectLater(
+          cubit.stream,
+          emitsInOrder([
+            isA<OnboardingError>().having((e) => e.message, 'message', contains('privacidad')),
+            isA<OnboardingInProgress>(),
+          ]),
+        );
+
+        await cubit.nextStep();
+        await expectation;
+        expect((cubit.state as OnboardingInProgress).currentStep, 5);
+      });
+
+      test('nextStep from privacy succeeds if consent is given', () async {
+        await cubit.startOnboarding();
+        final savedProfile = (cubit.state as OnboardingInProgress).profile.copyWith(
+          onboardingStep: 5,
+          name: 'John',
+          birthDate: DateTime.now(),
+          sex: 'M',
+        );
+        await cubit.resumeOnboarding(savedProfile);
+
+        await cubit.acceptPrivacyConsent(consent: true);
+
+        final expectation = expectLater(
+          cubit.stream,
+          emits(isA<OnboardingInProgress>().having((s) => s.currentStep, 'currentStep', 6)),
+        );
+
+        await cubit.nextStep();
+        await expectation;
+      });
+    });
+
+    group('Navigation logic', () {
+      test('previousStep decrements step in OnboardingInProgress', () async {
+        await cubit.startOnboarding();
+        await cubit.nextStep(); // welcome -> basicInfo (step 1)
+
+        final expectation = expectLater(
+          cubit.stream,
+          emits(isA<OnboardingInProgress>().having((s) => s.currentStep, 'currentStep', 0)),
+        );
+
+        await cubit.previousStep();
+        await expectation;
+      });
+
+      test('skipOnboarding emits OnboardingCompleted', () async {
+        await cubit.startOnboarding();
+
+        final expectation = expectLater(
+          cubit.stream,
+          emits(isA<OnboardingCompleted>().having((s) => s.profile.onboardingCompleted, 'completed', true)),
+        );
+
+        await cubit.skipOnboarding();
+        await expectation;
+      });
+    });
+
+    test('updateBasicInfo updates profile and sets step to basicInfo', () async {
+      await cubit.startOnboarding();
+
+      final birthDate = DateTime(1990, 1, 1);
+      await cubit.updateBasicInfo(
+        name: 'John Doe',
+        birthDate: birthDate,
+        sex: 'M',
+        weightKg: 80,
+        heightCm: 180,
+      );
+
+      final state = cubit.state as OnboardingInProgress;
+      expect(state.profile.name, 'John Doe');
+      expect(state.profile.sex, 'M');
+      expect(state.profile.weightKg, 80);
+      expect(state.profile.heightCm, 180);
+      expect(state.currentStep, OnboardingStep.basicInfo.index);
+    });
+
+    test('completeOnboarding emits syncing states then Completed', () async {
+      await cubit.startOnboarding();
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsThrough(isA<OnboardingCompleted>()),
+      );
+
+      await cubit.completeOnboarding();
+      await expectation;
+
+      expect(cubit.state, isA<OnboardingCompleted>());
+      expect((cubit.state as OnboardingCompleted).profile.onboardingCompleted, true);
+    });
+  });
+}

--- a/test/features/onboarding/domain/services/profile_analysis_service_test.dart
+++ b/test/features/onboarding/domain/services/profile_analysis_service_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/onboarding/domain/entities/user_profile.dart';
+import 'package:orionhealth_health/features/onboarding/domain/services/profile_analysis_service.dart';
+
+void main() {
+  late ProfileAnalysisService service;
+
+  setUp(() {
+    service = ProfileAnalysisService();
+  });
+
+  group('ProfileAnalysisService', () {
+    test('analyzeProfile returns correct standards for diabetes', () {
+      final profile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        conditions: const ['Diabetes Type 2'],
+      );
+
+      final standards = service.analyzeProfile(profile);
+
+      expect(standards.icd10Codes, contains('E11'));
+      expect(standards.loincCodes, contains('2345-7')); // Glucose
+      expect(standards.guidelineIds, contains('ADA-2024'));
+      expect(standards.medicationClasses, contains('metformin'));
+    });
+
+    test('analyzeProfile returns correct standards for hypertension', () {
+      final profile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        conditions: const ['Hypertension'],
+      );
+
+      final standards = service.analyzeProfile(profile);
+
+      expect(standards.icd10Codes, contains('I10'));
+      expect(standards.loincCodes, contains('8480-6')); // Systolic BP
+      expect(standards.guidelineIds, contains('JNC-8'));
+    });
+
+    test('analyzeProfile returns correct standards for medications', () {
+      final profile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        medications: const ['Lisinopril 10mg'],
+      );
+
+      final standards = service.analyzeProfile(profile);
+
+      expect(standards.medicationClasses, contains('ace_inhibitors'));
+    });
+
+    test('estimateStorageSizeMb returns non-zero for medical profile', () {
+      final profile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        conditions: const ['Diabetes'],
+      );
+
+      final size = service.estimateStorageSizeMb(profile);
+      expect(size, greaterThan(0));
+    });
+
+    test('analyzeProfile returns empty for healthy profile', () {
+      final profile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+      );
+
+      final standards = service.analyzeProfile(profile);
+
+      expect(standards.icd10Codes, isEmpty);
+      expect(standards.loincCodes, isEmpty);
+      expect(standards.guidelineIds, isEmpty);
+      expect(standards.medicationClasses, isEmpty);
+      expect(standards.estimatedSizeMB, 0);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds unit tests for the onboarding flow validation and implements the necessary validation logic in the `OnboardingCubit`.

Key changes:
- Modified `OnboardingCubit.nextStep()` to include validation for `basicInfo` (name, birthDate, sex) and `privacy` (consent) steps.
- Created `test/features/onboarding/application/onboarding_cubit_test.dart` with tests for:
    - Initial state and starting onboarding.
    - Resuming onboarding from a saved profile.
    - Step progression with and without validation.
    - Navigation (backwards and skipping).
    - Profile updates.
    - Completion flow with syncing states.
- Created `test/features/onboarding/domain/services/profile_analysis_service_test.dart` to verify that profiles are correctly analyzed for medical standards (ICD-10, LOINC, etc.).

All tests in `test/features/onboarding/` were run and passed successfully.

Fixes #359

---
*PR created automatically by Jules for task [2401629150390732201](https://jules.google.com/task/2401629150390732201) started by @iberi22*