### PR TITLE
Add unit tests for Vitals data model and calculations

### DIFF
--- a/lib/features/vitals/domain/services/vitals_calculator.dart
+++ b/lib/features/vitals/domain/services/vitals_calculator.dart
@@ -1,0 +1,61 @@
+enum BmiCategory { underweight, normal, overweight, obese }
+
+enum HeartRateZone { none, zone1, zone2, zone3, zone4, zone5 }
+
+enum BloodPressureCategory { normal, elevated, stage1, stage2, crisis }
+
+class VitalsCalculator {
+  /// Calculates BMI using weight in kg and height in cm.
+  static double calculateBMI(double weightKg, double heightCm) {
+    if (heightCm <= 0 || weightKg <= 0) return 0;
+    final heightMeters = heightCm / 100;
+    return weightKg / (heightMeters * heightMeters);
+  }
+
+  /// Classifies BMI according to WHO standards.
+  static BmiCategory classifyBMI(double bmi) {
+    if (bmi < 18.5) return BmiCategory.underweight;
+    if (bmi < 25.0) return BmiCategory.normal;
+    if (bmi < 30.0) return BmiCategory.overweight;
+    return BmiCategory.obese;
+  }
+
+  /// Calculates Heart Rate Zone based on percentage of Max HR (220 - age).
+  ///
+  /// Zone 1: 50–60% of MHR
+  /// Zone 2: 60–70% of MHR
+  /// Zone 3: 70–80% of MHR
+  /// Zone 4: 80–90% of MHR
+  /// Zone 5: 90–100% of MHR
+  static HeartRateZone calculateHeartRateZone(int hr, int age) {
+    if (age <= 0 || age > 120) return HeartRateZone.none;
+    final maxHr = 220 - age;
+    if (maxHr <= 0) return HeartRateZone.none;
+    final percentage = (hr / maxHr) * 100;
+
+    if (percentage < 50) return HeartRateZone.none;
+    if (percentage < 60) return HeartRateZone.zone1;
+    if (percentage < 70) return HeartRateZone.zone2;
+    if (percentage < 80) return HeartRateZone.zone3;
+    if (percentage < 90) return HeartRateZone.zone4;
+    return HeartRateZone.zone5;
+  }
+
+  /// Classifies Blood Pressure according to AHA 2017 guidelines.
+  static BloodPressureCategory classifyBloodPressure(double systolic, double diastolic) {
+    if (systolic >= 180 || diastolic >= 120) return BloodPressureCategory.crisis;
+    if (systolic >= 140 || diastolic >= 90) return BloodPressureCategory.stage2;
+    if (systolic >= 130 || diastolic >= 80) return BloodPressureCategory.stage1;
+    if (systolic >= 120 && diastolic < 80) return BloodPressureCategory.elevated;
+    return BloodPressureCategory.normal;
+  }
+
+  /// Converts temperature between Celsius and Fahrenheit.
+  static double convertTemperature(double value, {required bool toFahrenheit}) {
+    if (toFahrenheit) {
+      return (value * 9 / 5) + 32;
+    } else {
+      return (value - 32) * 5 / 9;
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/vitals/domain/entities/vital_sign_test.dart
+++ b/test/features/vitals/domain/entities/vital_sign_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+
+void main() {
+  group('VitalSign', () {
+    final now = DateTime.now();
+
+    test('formattedValue returns correct string for heartRate', () {
+      final vital = VitalSign(
+        type: VitalSignType.heartRate,
+        value: 72,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '72 bpm');
+    });
+
+    test('formattedValue returns correct string for temperature', () {
+      final vital = VitalSign(
+        type: VitalSignType.temperature,
+        value: 36.6,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '36.6°C');
+    });
+
+    test('formattedValue returns correct string for systolic BP', () {
+      final vital = VitalSign(
+        type: VitalSignType.bloodPressureSystolic,
+        value: 120,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '120 mmHg');
+    });
+
+    test('formattedValue returns correct string for diastolic BP', () {
+      final vital = VitalSign(
+        type: VitalSignType.bloodPressureDiastolic,
+        value: 80,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '80 mmHg');
+    });
+
+    test('formattedValue returns correct string for spO2', () {
+      final vital = VitalSign(
+        type: VitalSignType.spO2,
+        value: 98,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '98%');
+    });
+
+    test('formattedValue returns correct string for oxygenSaturation', () {
+      final vital = VitalSign(
+        type: VitalSignType.oxygenSaturation,
+        value: 97,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '97%');
+    });
+
+    test('formattedValue returns correct string for steps', () {
+      final vital = VitalSign(
+        type: VitalSignType.steps,
+        value: 10000,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '10000 steps');
+    });
+
+    test('formattedValue returns correct string for sleep', () {
+      final vital = VitalSign(
+        type: VitalSignType.sleep,
+        value: 480,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '480 min');
+    });
+
+    test('formattedValue returns correct string for bloodGlucose', () {
+      final vital = VitalSign(
+        type: VitalSignType.bloodGlucose,
+        value: 90,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '90 mg/dL');
+    });
+  });
+}

--- a/test/features/vitals/domain/services/vitals_calculator_test.dart
+++ b/test/features/vitals/domain/services/vitals_calculator_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/vitals/domain/services/vitals_calculator.dart';
+
+void main() {
+  group('VitalsCalculator', () {
+    group('BMI', () {
+      test('calculateBMI returns correct value', () {
+        // 70kg / (1.75m * 1.75m) = 22.857...
+        expect(VitalsCalculator.calculateBMI(70, 175), closeTo(22.86, 0.01));
+      });
+
+      test('calculateBMI handles zero height', () {
+        expect(VitalsCalculator.calculateBMI(70, 0), 0);
+      });
+
+      test('calculateBMI handles zero weight', () {
+        expect(VitalsCalculator.calculateBMI(0, 175), 0);
+      });
+
+      test('classifyBMI returns correct categories', () {
+        expect(VitalsCalculator.classifyBMI(16.0), BmiCategory.underweight);
+        expect(VitalsCalculator.classifyBMI(18.4), BmiCategory.underweight);
+        expect(VitalsCalculator.classifyBMI(18.5), BmiCategory.normal);
+        expect(VitalsCalculator.classifyBMI(24.9), BmiCategory.normal);
+        expect(VitalsCalculator.classifyBMI(25.0), BmiCategory.overweight);
+        expect(VitalsCalculator.classifyBMI(29.9), BmiCategory.overweight);
+        expect(VitalsCalculator.classifyBMI(30.0), BmiCategory.obese);
+        expect(VitalsCalculator.classifyBMI(40.0), BmiCategory.obese);
+      });
+    });
+
+    group('Heart Rate Zone', () {
+      test('calculateHeartRateZone returns correct zones for 30 year old', () {
+        // Max HR = 220 - 30 = 190
+        // Zone 1: 50-60% (95-114)
+        // Zone 2: 60-70% (114-133)
+        // Zone 3: 70-80% (133-152)
+        // Zone 4: 80-90% (152-171)
+        // Zone 5: 90-100% (171-190)
+
+        expect(VitalsCalculator.calculateHeartRateZone(90, 30), HeartRateZone.none);
+        expect(VitalsCalculator.calculateHeartRateZone(100, 30), HeartRateZone.zone1);
+        expect(VitalsCalculator.calculateHeartRateZone(120, 30), HeartRateZone.zone2);
+        expect(VitalsCalculator.calculateHeartRateZone(140, 30), HeartRateZone.zone3);
+        expect(VitalsCalculator.calculateHeartRateZone(160, 30), HeartRateZone.zone4);
+        expect(VitalsCalculator.calculateHeartRateZone(180, 30), HeartRateZone.zone5);
+      });
+
+      test('calculateHeartRateZone handles invalid age', () {
+        expect(VitalsCalculator.calculateHeartRateZone(100, 0), HeartRateZone.none);
+        expect(VitalsCalculator.calculateHeartRateZone(100, -1), HeartRateZone.none);
+        expect(VitalsCalculator.calculateHeartRateZone(100, 221), HeartRateZone.none);
+      });
+    });
+
+    group('Blood Pressure', () {
+      test('classifyBloodPressure returns correct categories', () {
+        expect(VitalsCalculator.classifyBloodPressure(110, 70), BloodPressureCategory.normal);
+        expect(VitalsCalculator.classifyBloodPressure(120, 75), BloodPressureCategory.elevated);
+        expect(VitalsCalculator.classifyBloodPressure(130, 80), BloodPressureCategory.stage1);
+        expect(VitalsCalculator.classifyBloodPressure(135, 85), BloodPressureCategory.stage1);
+        expect(VitalsCalculator.classifyBloodPressure(140, 90), BloodPressureCategory.stage2);
+        expect(VitalsCalculator.classifyBloodPressure(150, 95), BloodPressureCategory.stage2);
+        expect(VitalsCalculator.classifyBloodPressure(180, 110), BloodPressureCategory.crisis);
+        expect(VitalsCalculator.classifyBloodPressure(170, 120), BloodPressureCategory.crisis);
+      });
+    });
+
+    group('Temperature Conversion', () {
+      test('convertTemperature to Fahrenheit', () {
+        expect(VitalsCalculator.convertTemperature(0, toFahrenheit: true), 32);
+        expect(VitalsCalculator.convertTemperature(100, toFahrenheit: true), 212);
+        expect(VitalsCalculator.convertTemperature(37, toFahrenheit: true), 98.6);
+      });
+
+      test('convertTemperature to Celsius', () {
+        expect(VitalsCalculator.convertTemperature(32, toFahrenheit: false), 0);
+        expect(VitalsCalculator.convertTemperature(212, toFahrenheit: false), 100);
+        expect(VitalsCalculator.convertTemperature(98.6, toFahrenheit: false), closeTo(37, 0.1));
+      });
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces a central `VitalsCalculator` service to handle medical calculations and classifications for health vitals. It also adds comprehensive unit tests for both the new service and the `VitalSign` domain entity, ensuring accuracy in BMI, BP, and heart rate zone interpretations.

Fixes #360

---
*PR created automatically by Jules for task [474718118249808159](https://jules.google.com/task/474718118249808159) started by @iberi22*