### PR TITLE
Add unit tests for HealthSharing consent and data transfer

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/health_sharing/application/sharing_cubit_test.dart
+++ b/test/features/health_sharing/application/sharing_cubit_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_sharing/application/sharing_cubit.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/ble_sharing_service.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/nfc_sharing_service.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/wifi_direct_service.dart';
+
+class MockBleSharingService extends Mock implements BleSharingService {}
+class MockNfcSharingService extends Mock implements NfcSharingService {}
+class MockWifiDirectService extends Mock implements WifiDirectService {}
+
+class FakeSharedHealthPackage extends Fake implements SharedHealthPackage {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeSharedHealthPackage());
+  });
+
+  late MockBleSharingService mockBleService;
+  late MockNfcSharingService mockNfcService;
+  late MockWifiDirectService mockWifiService;
+  late SharingCubit cubit;
+
+  final testPackage = SharedHealthPackage(
+    id: 'test-id',
+    senderNodeId: 'sender-1',
+    recipientNodeId: 'recipient-1',
+    createdAt: DateTime.now(),
+    expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+    payload: const EncryptedPayload(
+      encryptedData: 'data',
+      iv: 'iv',
+      ephemeralPublicKey: 'key',
+    ),
+    metadata: const PackageMetadata(
+      packageType: 'full',
+      consentVerified: true,
+      includedCategories: {DataCategory.labResults},
+      appVersion: '1.0.0',
+    ),
+    signature: 'sig',
+  );
+
+  setUp(() {
+    mockBleService = MockBleSharingService();
+    mockNfcService = MockNfcSharingService();
+    mockWifiService = MockWifiDirectService();
+
+    when(() => mockBleService.stateStream).thenAnswer((_) => const Stream.empty());
+    when(() => mockNfcService.stateStream).thenAnswer((_) => const Stream.empty());
+    when(() => mockWifiService.stateStream).thenAnswer((_) => const Stream.empty());
+
+    when(() => mockBleService.initialize()).thenAnswer((_) async {});
+    when(() => mockNfcService.initialize()).thenAnswer((_) async {});
+    when(() => mockWifiService.initialize()).thenAnswer((_) async {});
+
+    when(() => mockBleService.dispose()).thenAnswer((_) => {});
+    when(() => mockNfcService.dispose()).thenAnswer((_) => {});
+    when(() => mockWifiService.dispose()).thenAnswer((_) => {});
+
+    cubit = SharingCubit(
+      bleService: mockBleService,
+      nfcService: mockNfcService,
+      wifiService: mockWifiService,
+    );
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  group('SharingCubit', () {
+    test('initial state is SharingInitial', () {
+      expect(cubit.state, SharingInitial());
+    });
+
+    test('initialize initializes services and emits SharingReady', () async {
+      await cubit.initialize();
+
+      expect(cubit.state, SharingReady());
+      // verify calls
+      verify(() => mockBleService.initialize()).called(1);
+      verify(() => mockNfcService.initialize()).called(1);
+      verify(() => mockWifiService.initialize()).called(1);
+    });
+
+    test('startSharing with NFC calls nfcService.shareData', () async {
+      when(() => mockNfcService.shareData(any())).thenAnswer((_) async => const SharingResult(
+        success: true,
+        bytesTransferred: 100,
+        transferTime: Duration(seconds: 1),
+      ));
+
+      await cubit.startSharing(
+        method: TransferMethod.nfc,
+        package: testPackage,
+      );
+
+      verify(() => mockNfcService.shareData(testPackage)).called(1);
+    });
+
+    test('startSharing with BLE calls bleService.startAdvertising', () async {
+      when(() => mockBleService.startAdvertising(any())).thenAnswer((_) async {});
+
+      await cubit.startSharing(
+        method: TransferMethod.ble,
+        package: testPackage,
+      );
+
+      verify(() => mockBleService.startAdvertising(testPackage.recipientNodeId)).called(1);
+    });
+
+    test('cancelSharing stops all services and emits SharingReady', () async {
+      when(() => mockBleService.disconnect()).thenAnswer((_) async {});
+      when(() => mockBleService.stopAdvertising()).thenAnswer((_) async {});
+      when(() => mockNfcService.stopListening()).thenAnswer((_) async {});
+      when(() => mockWifiService.stop()).thenAnswer((_) async {});
+
+      await cubit.cancelSharing();
+
+      expect(cubit.state, SharingReady());
+      verify(() => mockBleService.disconnect()).called(1);
+      verify(() => mockBleService.stopAdvertising()).called(1);
+      verify(() => mockNfcService.stopListening()).called(1);
+      verify(() => mockWifiService.stop()).called(1);
+    });
+  });
+}

--- a/test/features/health_sharing/domain/entities/shared_health_package_test.dart
+++ b/test/features/health_sharing/domain/entities/shared_health_package_test.dart
@@ -1,0 +1,120 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+
+void main() {
+  group('SharedHealthPackage', () {
+    final now = DateTime.now();
+    final future = now.add(const Duration(minutes: 5));
+    final past = now.subtract(const Duration(minutes: 5));
+
+    final testPackage = SharedHealthPackage(
+      id: 'test-id',
+      senderNodeId: 'sender-1',
+      recipientNodeId: 'recipient-1',
+      createdAt: now,
+      expiresAt: future,
+      payload: const EncryptedPayload(
+        encryptedData: 'encrypted-data',
+        iv: 'iv-vector',
+        ephemeralPublicKey: 'pub-key',
+      ),
+      metadata: const PackageMetadata(
+        packageType: 'selective',
+        consentVerified: true,
+        includedCategories: {DataCategory.labResults, DataCategory.vitalSigns},
+        appVersion: '1.0.0',
+      ),
+      signature: 'test-signature',
+    );
+
+    test('isExpired returns false for future expiration', () {
+      expect(testPackage.isExpired, isFalse);
+    });
+
+    test('isExpired returns true for past expiration', () {
+      final expiredPackage = SharedHealthPackage(
+        id: 'test-id',
+        senderNodeId: 'sender-1',
+        recipientNodeId: 'recipient-1',
+        createdAt: past.subtract(const Duration(minutes: 5)),
+        expiresAt: past,
+        payload: testPackage.payload,
+        metadata: testPackage.metadata,
+        signature: 'test-signature',
+      );
+      expect(expiredPackage.isExpired, isTrue);
+    });
+
+    test('canShare returns true when not expired and consent verified', () {
+      expect(testPackage.canShare, isTrue);
+    });
+
+    test('canShare returns false when expired', () {
+      final expiredPackage = SharedHealthPackage(
+        id: 'test-id',
+        senderNodeId: 'sender-1',
+        recipientNodeId: 'recipient-1',
+        createdAt: past.subtract(const Duration(minutes: 5)),
+        expiresAt: past,
+        payload: testPackage.payload,
+        metadata: testPackage.metadata,
+        signature: 'test-signature',
+      );
+      expect(expiredPackage.canShare, isFalse);
+    });
+
+    test('canShare returns false when consent not verified', () {
+      final noConsentPackage = SharedHealthPackage(
+        id: 'test-id',
+        senderNodeId: 'sender-1',
+        recipientNodeId: 'recipient-1',
+        createdAt: now,
+        expiresAt: future,
+        payload: testPackage.payload,
+        metadata: const PackageMetadata(
+          packageType: 'selective',
+          consentVerified: false,
+          includedCategories: {DataCategory.labResults},
+          appVersion: '1.0.0',
+        ),
+        signature: 'test-signature',
+      );
+      expect(noConsentPackage.canShare, isFalse);
+    });
+
+    test('toJson and fromJson work correctly', () {
+      final json = testPackage.toJson();
+      final fromJson = SharedHealthPackage.fromJson(json);
+
+      expect(fromJson.id, testPackage.id);
+      expect(fromJson.senderNodeId, testPackage.senderNodeId);
+      expect(fromJson.recipientNodeId, testPackage.recipientNodeId);
+      expect(fromJson.payload, testPackage.payload);
+      expect(fromJson.metadata, testPackage.metadata);
+      expect(fromJson.signature, testPackage.signature);
+    });
+
+    test('encode and decode work correctly', () {
+      final encoded = testPackage.encode();
+      final decoded = SharedHealthPackage.decode(encoded);
+
+      expect(decoded.id, testPackage.id);
+      expect(decoded.senderNodeId, testPackage.senderNodeId);
+      expect(decoded.recipientNodeId, testPackage.recipientNodeId);
+      expect(decoded.payload, testPackage.payload);
+      expect(decoded.metadata, testPackage.metadata);
+      expect(decoded.signature, testPackage.signature);
+    });
+  });
+
+  group('DataCategory', () {
+    test('valueOf returns correct category', () {
+      expect(DataCategory.valueOf('labResults'), DataCategory.labResults);
+      expect(DataCategory.valueOf('vitalSigns'), DataCategory.vitalSigns);
+    });
+
+    test('valueOf returns default for unknown name', () {
+      expect(DataCategory.valueOf('unknown'), DataCategory.labResults);
+    });
+  });
+}

--- a/test/features/health_sharing/infrastructure/ble_sharing_service_test.dart
+++ b/test/features/health_sharing/infrastructure/ble_sharing_service_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/ble_sharing_service.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+
+void main() {
+  late BleSharingService service;
+
+  setUp(() {
+    service = BleSharingService();
+  });
+
+  group('BleSharingService', () {
+    test('initial state is not advertising or scanning', () async {
+      expectLater(service.stateStream, emits(predicate((BleSharingState s) => s.status == 'ready')));
+      await service.initialize();
+    });
+
+    test('startAdvertising updates state', () async {
+      await service.initialize();
+
+      expectLater(service.stateStream, emits(predicate((BleSharingState s) =>
+        s.status == 'advertising' && s.deviceId == 'test-node')));
+
+      service.startAdvertising('test-node');
+    });
+
+    test('connect updates state to connecting then connected', () async {
+      await service.initialize();
+
+      expectLater(service.stateStream, emitsThrough(predicate((BleSharingState s) =>
+        s.status == 'connected' && s.deviceId == 'device-123')));
+
+      service.connect('device-123');
+    });
+
+    test('sendData handles not connected state', () async {
+      final package = SharedHealthPackage(
+        id: 'id',
+        senderNodeId: 's',
+        recipientNodeId: 'r',
+        createdAt: DateTime.now(),
+        expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+        payload: const EncryptedPayload(encryptedData: '', iv: '', ephemeralPublicKey: ''),
+        metadata: const PackageMetadata(
+          packageType: 'full',
+          consentVerified: true,
+          includedCategories: {},
+          appVersion: '1.0.0',
+        ),
+        signature: '',
+      );
+
+      final result = await service.sendData(package);
+      expect(result.success, isFalse);
+      expect(result.error, contains('Not connected'));
+    });
+  });
+}

--- a/test/features/health_sharing/infrastructure/nfc_sharing_service_test.dart
+++ b/test/features/health_sharing/infrastructure/nfc_sharing_service_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/nfc_sharing_service.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+import 'package:flutter/services.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late NfcSharingService service;
+  const MethodChannel channel = MethodChannel('orionhealth/nfc');
+
+  setUp(() {
+    service = NfcSharingService();
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      channel,
+      (MethodCall methodCall) async {
+        if (methodCall.method == 'isNfcAvailable') {
+          return true;
+        }
+        if (methodCall.method == 'startNfcSession') {
+          return null;
+        }
+        if (methodCall.method == 'stopNfcSession') {
+          return null;
+        }
+        return null;
+      },
+    );
+  });
+
+  group('NfcSharingService', () {
+    test('initialize checks for NFC availability', () async {
+      await service.initialize();
+      expect(await service.isAvailable(), isTrue);
+    });
+
+    test('handleReceivedData emits received state and package', () async {
+      await service.initialize();
+
+      final package = SharedHealthPackage(
+        id: 'id',
+        senderNodeId: 's',
+        recipientNodeId: 'r',
+        createdAt: DateTime.now(),
+        expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+        payload: const EncryptedPayload(encryptedData: '', iv: '', ephemeralPublicKey: ''),
+        metadata: const PackageMetadata(
+          packageType: 'full',
+          consentVerified: true,
+          includedCategories: {},
+          appVersion: '1.0.0',
+        ),
+        signature: '',
+      );
+
+      final encoded = package.encode();
+
+      expectLater(service.stateStream, emits(predicate((NfcSharingState s) =>
+        s.status == 'received' && s.receivedPackage?.id == 'id')));
+      expectLater(service.incomingData, emits(predicate((SharedHealthPackage p) => p.id == 'id')));
+
+      service.handleReceivedData(encoded);
+    });
+
+    test('handleReceivedData handles expired package', () async {
+      await service.initialize();
+
+      final package = SharedHealthPackage(
+        id: 'id',
+        senderNodeId: 's',
+        recipientNodeId: 'r',
+        createdAt: DateTime.now().subtract(const Duration(minutes: 10)),
+        expiresAt: DateTime.now().subtract(const Duration(minutes: 5)),
+        payload: const EncryptedPayload(encryptedData: '', iv: '', ephemeralPublicKey: ''),
+        metadata: const PackageMetadata(
+          packageType: 'full',
+          consentVerified: true,
+          includedCategories: {},
+          appVersion: '1.0.0',
+        ),
+        signature: '',
+      );
+
+      final encoded = package.encode();
+
+      expectLater(service.stateStream, emits(predicate((NfcSharingState s) =>
+        s.status == 'error' && s.message!.contains('expired'))));
+
+      service.handleReceivedData(encoded);
+    });
+  });
+}

--- a/test/features/health_sharing/infrastructure/wifi_direct_service_test.dart
+++ b/test/features/health_sharing/infrastructure/wifi_direct_service_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/wifi_direct_service.dart';
+
+void main() {
+  late WifiDirectService service;
+
+  setUp(() {
+    service = WifiDirectService();
+  });
+
+  group('WifiDirectService', () {
+    test('initial state is ready', () async {
+      expectLater(service.stateStream, emits(predicate((WifiSharingState s) => s.status == 'ready')));
+      await service.initialize();
+    });
+
+    test('discoverDevices updates state', () async {
+      await service.initialize();
+
+      expectLater(service.stateStream, emits(predicate((WifiSharingState s) => s.status == 'discovering')));
+
+      service.discoverDevices(timeout: const Duration(milliseconds: 100));
+    });
+
+    test('startServer updates state to hosting', () async {
+      await service.initialize();
+
+      expectLater(service.stateStream, emitsThrough(predicate((WifiSharingState s) =>
+        s.status == 'hosting' && s.address != null)));
+
+      // Using a random high port to avoid conflicts
+      await service.startServer(port: 0);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the HealthSharing feature.

Key changes:
- Created `test/features/health_sharing/` directory structure.
- Added `shared_health_package_test.dart` to verify domain logic including consent checks and expiration.
- Added `sharing_cubit_test.dart` to test the application state machine for data sharing.
- Added infrastructure tests for BLE, NFC, and WiFi Direct services to verify protocol state management and simulated data transfers.
- All 24 new tests pass.

Fixes #356

---
*PR created automatically by Jules for task [17089737786861279135](https://jules.google.com/task/17089737786861279135) started by @iberi22*