### PR TITLE
[test] Add unit tests for HealthRecord BLoC and use cases

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/health_record/application/health_record_cubit_test.dart
+++ b/test/features/health_record/application/health_record_cubit_test.dart
@@ -1,0 +1,281 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_record/application/bloc/health_record_cubit.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+import 'package:orionhealth_health/features/health_record/domain/repositories/health_record_repository.dart';
+import 'package:orionhealth_health/features/health_record/infrastructure/services/file_picker_service.dart';
+import 'package:orionhealth_health/features/health_record/infrastructure/services/image_picker_service.dart';
+import 'package:orionhealth_health/features/health_record/infrastructure/services/ocr_service.dart';
+import 'package:orionhealth_health/features/local_agent/domain/services/vector_store_service.dart';
+
+class MockHealthRecordRepository extends Mock implements HealthRecordRepository {}
+class MockFilePickerService extends Mock implements FilePickerService {}
+class MockImagePickerService extends Mock implements ImagePickerService {}
+class MockOcrService extends Mock implements OcrService {}
+class MockVectorStoreService extends Mock implements VectorStoreService {}
+
+void main() {
+  late HealthRecordCubit cubit;
+  late MockHealthRecordRepository mockRepository;
+  late MockFilePickerService mockFilePicker;
+  late MockImagePickerService mockImagePicker;
+  late MockOcrService mockOcrService;
+  late MockVectorStoreService mockVectorStore;
+
+  setUpAll(() {
+    registerFallbackValue(MedicalRecord(
+      date: DateTime.now(),
+      type: RecordType.other,
+      summary: '',
+      attachments: [],
+    ));
+  });
+
+  setUp(() {
+    mockRepository = MockHealthRecordRepository();
+    mockFilePicker = MockFilePickerService();
+    mockImagePicker = MockImagePickerService();
+    mockOcrService = MockOcrService();
+    mockVectorStore = MockVectorStoreService();
+
+    cubit = HealthRecordCubit(
+      mockRepository,
+      mockFilePicker,
+      mockImagePicker,
+      mockOcrService,
+      mockVectorStore,
+    );
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  test('initial state is HealthRecordInitial', () {
+    expect(cubit.state, isA<HealthRecordInitial>());
+  });
+
+  group('loadRecords', () {
+    test('emits [Loading, Loaded] when repository returns records', () async {
+      final records = [
+        MedicalRecord(type: RecordType.labResult, summary: 'Test record'),
+      ];
+      when(() => mockRepository.getAllRecords()).thenAnswer((_) async => records);
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          HealthRecordLoaded(records),
+        ]),
+      );
+
+      await cubit.loadRecords();
+      await expectation;
+    });
+
+    test('emits [Loading, Error] when repository throws', () async {
+      when(() => mockRepository.getAllRecords()).thenThrow(Exception('DB error'));
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          isA<HealthRecordError>(),
+        ]),
+      );
+
+      await cubit.loadRecords();
+      await expectation;
+
+      final state = cubit.state as HealthRecordError;
+      expect(state.message, contains('DB error'));
+    });
+  });
+
+  group('pickPdf', () {
+    test('emits [Loading, FilePicked] when file is picked and OCR succeeds', () async {
+      when(() => mockFilePicker.pickPdf()).thenAnswer((_) async => 'test.pdf');
+      when(() => mockOcrService.extractText(any())).thenAnswer((_) async => 'Extracted text');
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          const HealthRecordFilePicked(filePath: 'test.pdf', extractedText: 'Extracted text'),
+        ]),
+      );
+
+      await cubit.pickPdf();
+      await expectation;
+    });
+
+    test('emits [Loading, Initial] when file picking is cancelled', () async {
+      when(() => mockFilePicker.pickPdf()).thenAnswer((_) async => null);
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          isA<HealthRecordInitial>(),
+        ]),
+      );
+
+      await cubit.pickPdf();
+      await expectation;
+    });
+
+    test('emits [Loading, Error] when OCR fails', () async {
+      when(() => mockFilePicker.pickPdf()).thenAnswer((_) async => 'test.pdf');
+      when(() => mockOcrService.extractText(any())).thenThrow(Exception('OCR failed'));
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          isA<HealthRecordError>(),
+        ]),
+      );
+
+      await cubit.pickPdf();
+      await expectation;
+    });
+  });
+
+  group('pickImage', () {
+    test('emits [Loading, FilePicked] when image is picked from camera', () async {
+      when(() => mockImagePicker.pickImageFromCamera()).thenAnswer((_) async => 'camera.jpg');
+      when(() => mockOcrService.extractText(any())).thenAnswer((_) async => 'Text from camera');
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          const HealthRecordFilePicked(filePath: 'camera.jpg', extractedText: 'Text from camera'),
+        ]),
+      );
+
+      await cubit.pickImage(true);
+      await expectation;
+    });
+
+    test('emits [Loading, FilePicked] when image is picked from gallery', () async {
+      when(() => mockImagePicker.pickImageFromGallery()).thenAnswer((_) async => 'gallery.jpg');
+      when(() => mockOcrService.extractText(any())).thenAnswer((_) async => 'Text from gallery');
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          const HealthRecordFilePicked(filePath: 'gallery.jpg', extractedText: 'Text from gallery'),
+        ]),
+      );
+
+      await cubit.pickImage(false);
+      await expectation;
+    });
+
+    test('emits [Loading, Initial] when image picking is cancelled', () async {
+      when(() => mockImagePicker.pickImageFromCamera()).thenAnswer((_) async => null);
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          isA<HealthRecordInitial>(),
+        ]),
+      );
+
+      await cubit.pickImage(true);
+      await expectation;
+    });
+  });
+
+  group('saveRecord', () {
+    final testDate = DateTime(2025, 1, 1);
+
+    test('emits [Loading, Saved] when repository succeeds', () async {
+      when(() => mockRepository.saveRecord(any())).thenAnswer((_) async => {});
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          isA<HealthRecordSaved>(),
+        ]),
+      );
+
+      await cubit.saveRecord(
+        filePath: 'test.pdf',
+        extractedText: 'text',
+        summary: 'summary',
+        type: RecordType.labResult,
+        date: testDate,
+      );
+      await expectation;
+
+      verify(() => mockRepository.saveRecord(any())).called(1);
+    });
+
+    test('emits [Loading, Error] when repository fails', () async {
+      when(() => mockRepository.saveRecord(any())).thenThrow(Exception('Save failed'));
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          isA<HealthRecordError>(),
+        ]),
+      );
+
+      await cubit.saveRecord(
+        filePath: 'test.pdf',
+        extractedText: 'text',
+        summary: 'summary',
+        type: RecordType.labResult,
+        date: testDate,
+      );
+      await expectation;
+    });
+  });
+
+  group('Recovery Scenarios', () {
+    test('can load records after a failed save', () async {
+      // 1. Fail a save
+      when(() => mockRepository.saveRecord(any())).thenThrow(Exception('Save failed'));
+      await cubit.saveRecord(
+        filePath: 'test.pdf',
+        extractedText: 'text',
+        summary: 'summary',
+        type: RecordType.labResult,
+        date: DateTime.now(),
+      );
+      expect(cubit.state, isA<HealthRecordError>());
+
+      // 2. Try to load records - should succeed and emit [Loading, Loaded]
+      final records = [MedicalRecord(summary: 'Existing')];
+      when(() => mockRepository.getAllRecords()).thenAnswer((_) async => records);
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<HealthRecordLoading>(),
+          HealthRecordLoaded(records),
+        ]),
+      );
+
+      await cubit.loadRecords();
+      await expectation;
+      expect(cubit.state, isA<HealthRecordLoaded>());
+    });
+
+    test('reset() returns to initial state from error', () async {
+      when(() => mockRepository.getAllRecords()).thenThrow(Exception('Fail'));
+      await cubit.loadRecords();
+      expect(cubit.state, isA<HealthRecordError>());
+
+      cubit.reset();
+      expect(cubit.state, isA<HealthRecordInitial>());
+    });
+  });
+}

--- a/test/features/health_record/infrastructure/health_record_repository_test.dart
+++ b/test/features/health_record/infrastructure/health_record_repository_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_attachment.dart';
+import 'package:orionhealth_health/features/health_record/infrastructure/repositories/health_record_repository_impl.dart';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Isar isar;
+  late HealthRecordRepositoryImpl repository;
+  late String testDir;
+
+  setUpAll(() async {
+    testDir = p.join(Directory.current.path, 'test_db_health_records');
+    await Directory(testDir).create(recursive: true);
+
+    await Isar.initializeIsarCore(download: true);
+    isar = await Isar.open(
+      [MedicalRecordSchema],
+      directory: testDir,
+    );
+    repository = HealthRecordRepositoryImpl(isar);
+  });
+
+  tearDownAll(() async {
+    await isar.close();
+    if (await Directory(testDir).exists()) {
+      await Directory(testDir).delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    await isar.writeTxn(() => isar.medicalRecords.clear());
+  });
+
+  test('Should save and retrieve a health record', () async {
+    final attachment = MedicalAttachment(
+      localPath: 'test.pdf',
+      mimeType: 'application/pdf',
+      extractedText: 'Extracted text content',
+    );
+
+    final record = MedicalRecord(
+      date: DateTime.now(),
+      type: RecordType.labResult,
+      summary: 'Test summary',
+      attachments: [attachment],
+    );
+
+    await repository.saveRecord(record);
+
+    final records = await repository.getAllRecords();
+    expect(records.length, 1);
+    expect(records.first.summary, 'Test summary');
+    expect(records.first.type, RecordType.labResult);
+    expect(records.first.attachments.length, 1);
+    expect(records.first.attachments.first.extractedText, 'Extracted text content');
+  });
+
+  test('Should return multiple records sorted by Isar (default)', () async {
+    final record1 = MedicalRecord(summary: 'Record 1');
+    final record2 = MedicalRecord(summary: 'Record 2');
+
+    await repository.saveRecord(record1);
+    await repository.saveRecord(record2);
+
+    final records = await repository.getAllRecords();
+    expect(records.length, 2);
+    final summaries = records.map((r) => r.summary).toList();
+    expect(summaries, containsAll(['Record 1', 'Record 2']));
+  });
+
+  test('Should handle empty records', () async {
+    final records = await repository.getAllRecords();
+    expect(records, isEmpty);
+  });
+}


### PR DESCRIPTION
Added comprehensive unit tests for HealthRecordCubit and HealthRecordRepositoryImpl. Tests cover state management, CRUD operations, error handling, and recovery scenarios. Verified that all 16 new tests pass.

Fixes #355

---
*PR created automatically by Jules for task [4312296527688038263](https://jules.google.com/task/4312296527688038263) started by @iberi22*