### PR TITLE
Add unit tests for HealthRecord domain entities

### DIFF
--- a/lib/features/health_record/domain/entities/medical_attachment.dart
+++ b/lib/features/health_record/domain/entities/medical_attachment.dart
@@ -1,9 +1,10 @@
+import 'package:equatable/equatable.dart';
 import 'package:isar/isar.dart';
 
 part 'medical_attachment.g.dart';
 
 @embedded
-class MedicalAttachment {
+class MedicalAttachment with EquatableMixin {
   String? localPath;
   String? mimeType;
   String? extractedText;
@@ -13,4 +14,23 @@ class MedicalAttachment {
     this.mimeType,
     this.extractedText,
   });
+
+  @override
+  List<Object?> get props => [localPath, mimeType, extractedText];
+
+  Map<String, dynamic> toJson() => {
+        'localPath': localPath,
+        'mimeType': mimeType,
+        'extractedText': extractedText,
+      };
+
+  factory MedicalAttachment.fromJson(Map<String, dynamic> json) {
+    return MedicalAttachment(
+      localPath: json['localPath'] as String?,
+      mimeType: json['mimeType'] as String?,
+      extractedText: json['extractedText'] as String?,
+    );
+  }
+
+  bool get isValid => localPath != null && localPath!.isNotEmpty;
 }

--- a/lib/features/health_record/domain/entities/medical_record.dart
+++ b/lib/features/health_record/domain/entities/medical_record.dart
@@ -1,3 +1,4 @@
+import 'package:equatable/equatable.dart';
 import 'package:isar/isar.dart';
 import 'medical_attachment.dart';
 
@@ -11,7 +12,7 @@ enum RecordType {
 }
 
 @collection
-class MedicalRecord {
+class MedicalRecord with EquatableMixin {
   Id id = Isar.autoIncrement;
 
   DateTime? date;
@@ -29,4 +30,29 @@ class MedicalRecord {
     this.summary,
     this.attachments = const [],
   });
+
+  @override
+  List<Object?> get props => [id, date, type, summary, attachments];
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'date': date?.toIso8601String(),
+        'type': type.name,
+        'summary': summary,
+        'attachments': attachments.map((a) => a.toJson()).toList(),
+      };
+
+  factory MedicalRecord.fromJson(Map<String, dynamic> json) {
+    return MedicalRecord(
+      date: json['date'] != null ? DateTime.parse(json['date'] as String) : null,
+      type: RecordType.values.byName(json['type'] as String),
+      summary: json['summary'] as String?,
+      attachments: (json['attachments'] as List<dynamic>?)
+              ?.map((e) => MedicalAttachment.fromJson(e as Map<String, dynamic>))
+              .toList() ??
+          const [],
+    )..id = json['id'] as int? ?? Isar.autoIncrement;
+  }
+
+  bool get isValid => attachments.every((a) => a.isValid);
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/health_record/domain/entities/medical_attachment_test.dart
+++ b/test/features/health_record/domain/entities/medical_attachment_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_attachment.dart';
+
+void main() {
+  group('MedicalAttachment', () {
+    test('should create MedicalAttachment with provided values', () {
+      final attachment = MedicalAttachment(
+        localPath: '/path/to/file.pdf',
+        mimeType: 'application/pdf',
+        extractedText: 'Extracted text content',
+      );
+
+      expect(attachment.localPath, '/path/to/file.pdf');
+      expect(attachment.mimeType, 'application/pdf');
+      expect(attachment.extractedText, 'Extracted text content');
+    });
+
+    test('should allow null fields', () {
+      final attachment = MedicalAttachment();
+
+      expect(attachment.localPath, isNull);
+      expect(attachment.mimeType, isNull);
+      expect(attachment.extractedText, isNull);
+    });
+
+    test('should support value equality', () {
+      final attachment1 = MedicalAttachment(
+        localPath: 'path1',
+        mimeType: 'type1',
+        extractedText: 'text1',
+      );
+      final attachment2 = MedicalAttachment(
+        localPath: 'path1',
+        mimeType: 'type1',
+        extractedText: 'text1',
+      );
+      final attachment3 = MedicalAttachment(
+        localPath: 'path2',
+        mimeType: 'type1',
+        extractedText: 'text1',
+      );
+
+      expect(attachment1, equals(attachment2));
+      expect(attachment1, isNot(equals(attachment3)));
+      expect(attachment1.hashCode, equals(attachment2.hashCode));
+    });
+
+    test('should support serialization', () {
+      final attachment = MedicalAttachment(
+        localPath: '/path/to/file.pdf',
+        mimeType: 'application/pdf',
+        extractedText: 'Extracted text content',
+      );
+
+      final json = attachment.toJson();
+      final fromJson = MedicalAttachment.fromJson(json);
+
+      expect(fromJson, equals(attachment));
+    });
+
+    test('should handle validation', () {
+      final validAttachment = MedicalAttachment(localPath: 'path.pdf');
+      final invalidAttachment1 = MedicalAttachment(localPath: null);
+      final invalidAttachment2 = MedicalAttachment(localPath: '');
+
+      expect(validAttachment.isValid, isTrue);
+      expect(invalidAttachment1.isValid, isFalse);
+      expect(invalidAttachment2.isValid, isFalse);
+    });
+
+    test('should be type safe and handle boundary values', () {
+      final attachment = MedicalAttachment(
+        localPath: '',
+        mimeType: '',
+        extractedText: 'a' * 10000, // Large text
+      );
+
+      expect(attachment.localPath, '');
+      expect(attachment.mimeType, '');
+      expect(attachment.extractedText?.length, 10000);
+    });
+  });
+}

--- a/test/features/health_record/domain/entities/medical_record_test.dart
+++ b/test/features/health_record/domain/entities/medical_record_test.dart
@@ -1,0 +1,119 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_attachment.dart';
+
+void main() {
+  group('MedicalRecord', () {
+    test('should create MedicalRecord with default values', () {
+      final record = MedicalRecord();
+
+      expect(record.type, RecordType.other);
+      expect(record.attachments, isEmpty);
+      expect(record.date, isNull);
+      expect(record.summary, isNull);
+    });
+
+    test('should create MedicalRecord with provided values', () {
+      final date = DateTime(2023, 10, 27);
+      final attachment = MedicalAttachment(localPath: 'test.pdf');
+      final record = MedicalRecord(
+        date: date,
+        type: RecordType.labResult,
+        summary: 'Blood test',
+        attachments: [attachment],
+      );
+
+      expect(record.date, date);
+      expect(record.type, RecordType.labResult);
+      expect(record.summary, 'Blood test');
+      expect(record.attachments, contains(attachment));
+    });
+
+    test('should support value equality', () {
+      final date = DateTime(2023, 10, 27);
+      final attachment1 = MedicalAttachment(localPath: 'test.pdf');
+      final attachment2 = MedicalAttachment(localPath: 'test.pdf');
+
+      final record1 = MedicalRecord(
+        date: date,
+        type: RecordType.prescription,
+        summary: 'Aspirin',
+        attachments: [attachment1],
+      )..id = 1;
+
+      final record2 = MedicalRecord(
+        date: date,
+        type: RecordType.prescription,
+        summary: 'Aspirin',
+        attachments: [attachment2],
+      )..id = 1;
+
+      final record3 = MedicalRecord(
+        date: date,
+        type: RecordType.prescription,
+        summary: 'Aspirin',
+        attachments: [attachment1],
+      )..id = 2;
+
+      expect(record1, equals(record2));
+      expect(record1, isNot(equals(record3)));
+      expect(record1.hashCode, equals(record2.hashCode));
+    });
+
+    test('should support serialization', () {
+      final date = DateTime(2023, 10, 27).toUtc();
+      final attachment = MedicalAttachment(localPath: 'test.pdf');
+      final record = MedicalRecord(
+        date: date,
+        type: RecordType.labResult,
+        summary: 'Blood test',
+        attachments: [attachment],
+      )..id = 10;
+
+      final json = record.toJson();
+      final fromJson = MedicalRecord.fromJson(json);
+
+      expect(fromJson, equals(record));
+      expect(fromJson.id, record.id);
+      expect(fromJson.attachments.first, equals(attachment));
+    });
+
+    test('should handle validation', () {
+      final validAttachment = MedicalAttachment(localPath: 'path.pdf');
+      final invalidAttachment = MedicalAttachment(localPath: '');
+
+      final validRecord = MedicalRecord(attachments: [validAttachment]);
+      final invalidRecord = MedicalRecord(attachments: [invalidAttachment]);
+      final emptyRecord = MedicalRecord(attachments: []);
+
+      expect(validRecord.isValid, isTrue);
+      expect(invalidRecord.isValid, isFalse);
+      expect(emptyRecord.isValid, isTrue); // Empty is technically valid if no attachments
+    });
+
+    test('should handle empty records and null fields', () {
+      final record = MedicalRecord(
+        date: null,
+        summary: null,
+        attachments: [],
+      );
+
+      expect(record.date, isNull);
+      expect(record.summary, isNull);
+      expect(record.attachments, isEmpty);
+    });
+
+    test('should handle nested equality with attachments', () {
+      final attachment1 = MedicalAttachment(localPath: 'path1');
+      final attachment2 = MedicalAttachment(localPath: 'path1');
+      final attachment3 = MedicalAttachment(localPath: 'path2');
+
+      final record1 = MedicalRecord(attachments: [attachment1]);
+      final record2 = MedicalRecord(attachments: [attachment2]);
+      final record3 = MedicalRecord(attachments: [attachment3]);
+
+      expect(record1, equals(record2));
+      expect(record1, isNot(equals(record3)));
+    });
+  });
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the health record domain entities (`MedicalRecord` and `MedicalAttachment`). 

To support robust testing as requested, the domain entities were updated with:
- `EquatableMixin` for value-based equality.
- `toJson` and `fromJson` for serialization.
- `isValid` property for domain validation.

The new tests cover:
- Object creation with default and provided values.
- Null field handling.
- Value equality (including nested lists).
- Serialization round-trip verification.
- Validation logic.
- Boundary values for text fields.

All tests passed successfully.

Fixes #354

---
*PR created automatically by Jules for task [4737011368533896964](https://jules.google.com/task/4737011368533896964) started by @iberi22*