### PR TITLE
Add unit tests for Appointment scheduling logic

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -8,187 +8,189 @@
 // coverage:ignore-file
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
-import 'package:dio/dio.dart' as _i10;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i56;
+import 'package:dio/dio.dart' as _i11;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i57;
 import 'package:get_it/get_it.dart' as _i1;
-import 'package:http/http.dart' as _i7;
+import 'package:http/http.dart' as _i8;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:isar/isar.dart' as _i17;
-import 'package:isar_agent_memory/isar_agent_memory.dart' as _i11;
-import 'package:medical_standards/medical_standards.dart' as _i27;
+import 'package:isar/isar.dart' as _i18;
+import 'package:isar_agent_memory/isar_agent_memory.dart' as _i12;
+import 'package:medical_standards/medical_standards.dart' as _i28;
 
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i65;
-import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
     as _i66;
+import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
+    as _i67;
 import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i69;
-import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
     as _i70;
-import '../../features/auth/application/auth_cubit.dart' as _i99;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i98;
-import '../../features/auth/domain/auth_service.dart' as _i73;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i71;
-import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
-    as _i72;
-import '../../features/auth/infrastructure/services/biometric_service.dart'
+import '../../features/appointments/domain/services/appointment_service.dart'
     as _i3;
+import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
+    as _i71;
+import '../../features/auth/application/auth_cubit.dart' as _i99;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i100;
+import '../../features/auth/domain/auth_service.dart' as _i74;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i72;
+import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
+    as _i73;
+import '../../features/auth/infrastructure/services/biometric_service.dart'
+    as _i4;
 import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
-    as _i74;
-import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i12;
-import '../../features/ble_sharing/domain/ble_sharing_service.dart' as _i4;
-import '../../features/calendar_import/data/calendar_repository.dart' as _i6;
-import '../../features/calendar_import/domain/calendar_import_cubit.dart'
     as _i75;
-import '../../features/eps_connection/data/oauth_repository.dart' as _i42;
-import '../../features/eps_connection/domain/eps_connection_cubit.dart' as _i78;
+import '../../features/auth/infrastructure/services/encryption_service.dart'
+    as _i13;
+import '../../features/ble_sharing/domain/ble_sharing_service.dart' as _i5;
+import '../../features/calendar_import/data/calendar_repository.dart' as _i7;
+import '../../features/calendar_import/domain/calendar_import_cubit.dart'
+    as _i76;
+import '../../features/eps_connection/data/oauth_repository.dart' as _i43;
+import '../../features/eps_connection/domain/eps_connection_cubit.dart' as _i79;
 import '../../features/health_data_import/application/health_import_cubit.dart'
-    as _i82;
-import '../../features/health_data_import/domain/services/health_data_import_service.dart'
-    as _i15;
-import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i100;
-import '../../features/health_record/domain/repositories/health_record_repository.dart'
     as _i83;
-import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i84;
-import '../../features/health_record/infrastructure/services/file_picker_service.dart'
-    as _i14;
-import '../../features/health_record/infrastructure/services/image_picker_service.dart'
+import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i16;
-import '../../features/health_record/infrastructure/services/ocr_service.dart'
-    as _i43;
-import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i95;
-import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
-    as _i28;
-import '../../features/local_agent/domain/services/llm_adapter.dart' as _i20;
-import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i59;
-import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i21;
-import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i85;
-import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i86;
-import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i22;
-import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i88;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i87;
-import '../../features/local_agent/infrastructure/rag_llm_service.dart'
+import '../../features/health_record/application/bloc/health_record_cubit.dart'
     as _i101;
-import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
+import '../../features/health_record/domain/repositories/health_record_repository.dart'
+    as _i84;
+import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+    as _i85;
+import '../../features/health_record/infrastructure/services/file_picker_service.dart'
+    as _i15;
+import '../../features/health_record/infrastructure/services/image_picker_service.dart'
+    as _i17;
+import '../../features/health_record/infrastructure/services/ocr_service.dart'
+    as _i44;
+import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
+    as _i96;
+import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i29;
+import '../../features/local_agent/domain/services/llm_adapter.dart' as _i21;
+import '../../features/local_agent/domain/services/vector_store_service.dart'
+    as _i60;
+import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
+    as _i22;
+import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
+    as _i86;
+import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+    as _i87;
+import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
+    as _i23;
+import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
+    as _i89;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i88;
+import '../../features/local_agent/infrastructure/rag_llm_service.dart'
+    as _i102;
+import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
+    as _i31;
 import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i30;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i60;
-import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
-    as _i25;
-import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i102;
-import '../../features/local_agent/infrastructure/services/model_download_service.dart'
-    as _i41;
-import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i92;
-import '../../features/medical_assistant/application/medical_assistant_cubit.dart'
-    as _i90;
-import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
-    as _i18;
-import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
-    as _i54;
-import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
     as _i61;
-import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
-    as _i76;
-import '../../features/medical_assistant/domain/services/health_context_service.dart'
-    as _i80;
-import '../../features/medical_assistant/domain/services/medical_analysis_service.dart'
+import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i26;
-import '../../features/medical_assistant/infrastructure/analysis/lab_interpreter.dart'
-    as _i19;
-import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
-    as _i48;
-import '../../features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart'
-    as _i62;
-import '../../features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart'
-    as _i31;
-import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
-    as _i77;
-import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
-    as _i81;
-import '../../features/medical_research/domain/services/medical_scraper_service.dart'
-    as _i32;
-import '../../features/medical_research/domain/services/medical_standards_service.dart'
-    as _i34;
-import '../../features/medical_research/domain/services/medical_web_search_service.dart'
-    as _i36;
-import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
-    as _i5;
-import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i91;
-import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
-    as _i33;
-import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
-    as _i35;
-import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
-    as _i37;
-import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i38;
-import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i39;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i44;
-import '../../features/onboarding/application/sync_cubit.dart' as _i96;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i103;
-import '../../features/reports/domain/repositories/report_repository.dart'
-    as _i46;
-import '../../features/reports/domain/services/report_generation_service.dart'
+import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
+    as _i103;
+import '../../features/local_agent/infrastructure/services/model_download_service.dart'
+    as _i42;
+import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
     as _i93;
-import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
-    as _i47;
-import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i94;
-import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
-    as _i40;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i89;
-import '../../features/settings/domain/repositories/llm_settings_repository.dart'
-    as _i23;
-import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i8;
-import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
-    as _i24;
-import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i50;
-import '../../features/ssi/domain/services/anoncreds_service.dart' as _i67;
-import '../../features/ssi/domain/services/ssi_service.dart' as _i52;
-import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
-    as _i51;
-import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
-    as _i68;
-import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
+import '../../features/medical_assistant/application/medical_assistant_cubit.dart'
+    as _i91;
+import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
+    as _i19;
+import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
+    as _i55;
+import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
+    as _i62;
+import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
+    as _i77;
+import '../../features/medical_assistant/domain/services/health_context_service.dart'
+    as _i81;
+import '../../features/medical_assistant/domain/services/medical_analysis_service.dart'
+    as _i27;
+import '../../features/medical_assistant/infrastructure/analysis/lab_interpreter.dart'
+    as _i20;
+import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
     as _i49;
-import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
-    as _i53;
-import '../../features/sync/data/fhir_client.dart' as _i13;
-import '../../features/sync/data/sync_repository.dart' as _i55;
-import '../../features/sync/domain/sync_cubit.dart' as _i79;
-import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i97;
-import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i57;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
-    as _i58;
-import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+import '../../features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart'
     as _i63;
-import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+import '../../features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart'
+    as _i32;
+import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
+    as _i78;
+import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
+    as _i82;
+import '../../features/medical_research/domain/services/medical_scraper_service.dart'
+    as _i33;
+import '../../features/medical_research/domain/services/medical_standards_service.dart'
+    as _i35;
+import '../../features/medical_research/domain/services/medical_web_search_service.dart'
+    as _i37;
+import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
+    as _i6;
+import '../../features/medical_research/infrastructure/medical_research_service.dart'
+    as _i92;
+import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
+    as _i34;
+import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
+    as _i36;
+import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
+    as _i38;
+import '../../features/medications/domain/repositories/medication_repository.dart'
+    as _i39;
+import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+    as _i40;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i45;
+import '../../features/onboarding/application/sync_cubit.dart' as _i97;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i104;
+import '../../features/reports/domain/repositories/report_repository.dart'
+    as _i47;
+import '../../features/reports/domain/services/report_generation_service.dart'
+    as _i94;
+import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
+    as _i48;
+import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+    as _i95;
+import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
+    as _i41;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i90;
+import '../../features/settings/domain/repositories/llm_settings_repository.dart'
+    as _i24;
+import '../../features/settings/domain/services/device_capability_service.dart'
+    as _i10;
+import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
+    as _i25;
+import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i51;
+import '../../features/ssi/domain/services/anoncreds_service.dart' as _i68;
+import '../../features/ssi/domain/services/ssi_service.dart' as _i53;
+import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
+    as _i52;
+import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
+    as _i69;
+import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
+    as _i50;
+import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
+    as _i54;
+import '../../features/sync/data/fhir_client.dart' as _i14;
+import '../../features/sync/data/sync_repository.dart' as _i56;
+import '../../features/sync/domain/sync_cubit.dart' as _i80;
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i98;
+import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
+    as _i58;
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+    as _i59;
+import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
     as _i64;
+import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+    as _i65;
 import '../services/device_capability_service.dart' as _i9;
-import '../services/privacy_anonymizer.dart' as _i45;
-import 'database_module.dart' as _i107;
-import 'fhir_module.dart' as _i104;
-import 'memory_module.dart' as _i106;
-import 'network_module.dart' as _i105;
+import '../services/privacy_anonymizer.dart' as _i46;
+import 'database_module.dart' as _i108;
+import 'fhir_module.dart' as _i105;
+import 'memory_module.dart' as _i107;
+import 'network_module.dart' as _i106;
 
 const String _mobile = 'mobile';
 const String _desktop = 'desktop';
@@ -209,263 +211,264 @@ extension GetItInjectableX on _i1.GetIt {
     final networkModule = _$NetworkModule();
     final memoryModule = _$MemoryModule();
     final databaseModule = _$DatabaseModule();
-    gh.lazySingleton<_i3.BiometricService>(() => _i3.BiometricService());
-    gh.lazySingleton<_i4.BleSharingService>(() => _i4.BleSharingService());
-    gh.lazySingleton<_i5.BotBypassHandler>(() => _i5.BotBypassHandler());
-    gh.lazySingleton<_i6.CalendarRepository>(() => _i6.CalendarRepository());
-    gh.lazySingleton<_i7.Client>(() => fhirModule.httpClient);
-    gh.lazySingleton<_i8.DeviceCapabilityService>(
-        () => _i8.DeviceCapabilityService());
+    gh.lazySingleton<_i3.AppointmentService>(() => _i3.AppointmentService());
+    gh.lazySingleton<_i4.BiometricService>(() => _i4.BiometricService());
+    gh.lazySingleton<_i5.BleSharingService>(() => _i5.BleSharingService());
+    gh.lazySingleton<_i6.BotBypassHandler>(() => _i6.BotBypassHandler());
+    gh.lazySingleton<_i7.CalendarRepository>(() => _i7.CalendarRepository());
+    gh.lazySingleton<_i8.Client>(() => fhirModule.httpClient);
     gh.lazySingleton<_i9.DeviceCapabilityService>(
         () => _i9.DeviceCapabilityService());
-    gh.lazySingleton<_i10.Dio>(() => networkModule.dio);
-    gh.lazySingleton<_i11.EmbeddingsAdapter>(
+    gh.lazySingleton<_i10.DeviceCapabilityService>(
+        () => _i10.DeviceCapabilityService());
+    gh.lazySingleton<_i11.Dio>(() => networkModule.dio);
+    gh.lazySingleton<_i12.EmbeddingsAdapter>(
         () => memoryModule.embeddingsAdapter);
-    gh.lazySingleton<_i12.EncryptionService>(() => _i12.EncryptionService());
-    gh.lazySingleton<_i13.FhirClient>(() => fhirModule.fhirClient);
-    gh.lazySingleton<_i14.FilePickerService>(
-        () => _i14.FilePickerServiceImpl());
-    gh.lazySingleton<_i15.HealthDataImportService>(
-        () => _i15.HealthDataImportService());
-    gh.lazySingleton<_i16.ImagePickerService>(
-        () => _i16.ImagePickerServiceImpl());
-    await gh.factoryAsync<_i17.Isar>(
+    gh.lazySingleton<_i13.EncryptionService>(() => _i13.EncryptionService());
+    gh.lazySingleton<_i14.FhirClient>(() => fhirModule.fhirClient);
+    gh.lazySingleton<_i15.FilePickerService>(
+        () => _i15.FilePickerServiceImpl());
+    gh.lazySingleton<_i16.HealthDataImportService>(
+        () => _i16.HealthDataImportService());
+    gh.lazySingleton<_i17.ImagePickerService>(
+        () => _i17.ImagePickerServiceImpl());
+    await gh.factoryAsync<_i18.Isar>(
       () => databaseModule.isar,
       preResolve: true,
     );
-    gh.factory<_i18.LabAnalysisStrategy>(() => _i18.LabAnalysisStrategy());
-    gh.factory<_i19.LabInterpreter>(() => _i19.LabInterpreter());
-    gh.lazySingleton<_i20.LlmAdapter>(
-      () => _i21.FlutterGemmaAdapter(),
+    gh.factory<_i19.LabAnalysisStrategy>(() => _i19.LabAnalysisStrategy());
+    gh.factory<_i20.LabInterpreter>(() => _i20.LabInterpreter());
+    gh.lazySingleton<_i21.LlmAdapter>(
+      () => _i22.FlutterGemmaAdapter(),
       instanceName: 'gemma',
     );
-    gh.lazySingleton<_i20.LlmAdapter>(
-      () => _i22.OpenaiCompatibleAdapter(),
+    gh.lazySingleton<_i21.LlmAdapter>(
+      () => _i23.OpenaiCompatibleAdapter(),
       instanceName: 'openai',
     );
-    gh.lazySingleton<_i23.LlmSettingsRepository>(
-        () => _i24.LlmSettingsRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i25.LocalLlmService>(() => _i25.LocalLlmService());
-    gh.factory<_i26.MedicalAnalysisService>(
-        () => _i26.MedicalAnalysisService());
-    gh.lazySingleton<_i27.MedicalContextProvider>(
+    gh.lazySingleton<_i24.LlmSettingsRepository>(
+        () => _i25.LlmSettingsRepositoryImpl(gh<_i18.Isar>()));
+    gh.lazySingleton<_i26.LocalLlmService>(() => _i26.LocalLlmService());
+    gh.factory<_i27.MedicalAnalysisService>(
+        () => _i27.MedicalAnalysisService());
+    gh.lazySingleton<_i28.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
-    gh.factory<_i28.MedicalKnowledgeRepository>(
-      () => _i29.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
-    );
-    gh.factory<_i28.MedicalKnowledgeRepository>(
+    gh.factory<_i29.MedicalKnowledgeRepository>(
       () => _i30.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
     );
-    gh.factory<_i31.MedicalLlmAdapter>(() => _i31.MedicalLlmAdapter());
-    gh.lazySingleton<_i32.MedicalScraperService>(
-        () => _i33.MedicalScraperServiceImpl(
-              gh<_i10.Dio>(),
-              gh<_i5.BotBypassHandler>(),
+    gh.factory<_i29.MedicalKnowledgeRepository>(
+      () => _i31.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
+    );
+    gh.factory<_i32.MedicalLlmAdapter>(() => _i32.MedicalLlmAdapter());
+    gh.lazySingleton<_i33.MedicalScraperService>(
+        () => _i34.MedicalScraperServiceImpl(
+              gh<_i11.Dio>(),
+              gh<_i6.BotBypassHandler>(),
             ));
-    gh.lazySingleton<_i34.MedicalStandardsService>(() =>
-        _i35.MedicalStandardsServiceImpl(gh<_i27.MedicalContextProvider>()));
-    gh.lazySingleton<_i36.MedicalWebSearchService>(
-        () => _i37.MedicalWebSearchServiceImpl(gh<_i10.Dio>()));
-    gh.lazySingleton<_i38.MedicationRepository>(
-        () => _i39.IsarMedicationRepository(gh<_i17.Isar>()));
-    await gh.lazySingletonAsync<_i11.MemoryGraph>(
+    gh.lazySingleton<_i35.MedicalStandardsService>(() =>
+        _i36.MedicalStandardsServiceImpl(gh<_i28.MedicalContextProvider>()));
+    gh.lazySingleton<_i37.MedicalWebSearchService>(
+        () => _i38.MedicalWebSearchServiceImpl(gh<_i11.Dio>()));
+    gh.lazySingleton<_i39.MedicationRepository>(
+        () => _i40.IsarMedicationRepository(gh<_i18.Isar>()));
+    await gh.lazySingletonAsync<_i12.MemoryGraph>(
       () => memoryModule.memoryGraph(
-        gh<_i17.Isar>(),
-        gh<_i11.EmbeddingsAdapter>(),
+        gh<_i18.Isar>(),
+        gh<_i12.EmbeddingsAdapter>(),
       ),
       preResolve: true,
     );
-    gh.lazySingleton<_i40.MockReportGenerationService>(
-      () => _i40.MockReportGenerationService(),
+    gh.lazySingleton<_i41.MockReportGenerationService>(
+      () => _i41.MockReportGenerationService(),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i41.ModelDownloadService>(
-        () => _i41.ModelDownloadService());
-    gh.lazySingleton<_i42.OAuthRepository>(() => _i42.OAuthRepositoryImpl());
-    gh.lazySingleton<_i43.OcrService>(() => _i43.MlKitOcrService());
-    gh.factory<_i44.OnboardingCubit>(() => _i44.OnboardingCubit());
-    gh.lazySingleton<_i45.PromptScrubber>(
-        () => _i45.PromptScrubber(gh<_i17.Isar>()));
-    gh.lazySingleton<_i46.ReportRepository>(
-        () => _i47.IsarReportRepository(gh<_i17.Isar>()));
-    gh.factory<_i48.RiskCalculator>(() => _i48.RiskCalculator());
-    gh.lazySingleton<_i49.SidetreeAnchorClient>(
-        () => _i49.SidetreeAnchorClient.create());
-    gh.lazySingleton<_i50.SsiRepository>(
-        () => _i51.IsarSsiRepository(gh<_i17.Isar>()));
-    gh.lazySingleton<_i52.SsiService>(() => _i53.SsiServiceImpl(
-          gh<_i50.SsiRepository>(),
-          gh<_i49.SidetreeAnchorClient>(),
+    gh.lazySingleton<_i42.ModelDownloadService>(
+        () => _i42.ModelDownloadService());
+    gh.lazySingleton<_i43.OAuthRepository>(() => _i43.OAuthRepositoryImpl());
+    gh.lazySingleton<_i44.OcrService>(() => _i44.MlKitOcrService());
+    gh.factory<_i45.OnboardingCubit>(() => _i45.OnboardingCubit());
+    gh.lazySingleton<_i46.PromptScrubber>(
+        () => _i46.PromptScrubber(gh<_i18.Isar>()));
+    gh.lazySingleton<_i47.ReportRepository>(
+        () => _i48.IsarReportRepository(gh<_i18.Isar>()));
+    gh.factory<_i49.RiskCalculator>(() => _i49.RiskCalculator());
+    gh.lazySingleton<_i50.SidetreeAnchorClient>(
+        () => _i50.SidetreeAnchorClient.create());
+    gh.lazySingleton<_i51.SsiRepository>(
+        () => _i52.IsarSsiRepository(gh<_i18.Isar>()));
+    gh.lazySingleton<_i53.SsiService>(() => _i54.SsiServiceImpl(
+          gh<_i51.SsiRepository>(),
+          gh<_i50.SidetreeAnchorClient>(),
         ));
-    gh.factory<_i54.SymptomAnalysisStrategy>(
-        () => _i54.SymptomAnalysisStrategy());
-    gh.lazySingleton<_i55.SyncRepository>(() => _i55.SyncRepository(
-          gh<_i13.FhirClient>(),
-          gh<_i17.Isar>(),
-          gh<_i56.FlutterSecureStorage>(),
+    gh.factory<_i55.SymptomAnalysisStrategy>(
+        () => _i55.SymptomAnalysisStrategy());
+    gh.lazySingleton<_i56.SyncRepository>(() => _i56.SyncRepository(
+          gh<_i14.FhirClient>(),
+          gh<_i18.Isar>(),
+          gh<_i57.FlutterSecureStorage>(),
         ));
-    gh.lazySingleton<_i27.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i57.UserProfileRepository>(
-        () => _i58.UserProfileRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i59.VectorStoreService>(() => _i60.IsarVectorStoreService(
-          gh<_i11.MemoryGraph>(),
-          gh<_i28.MedicalKnowledgeRepository>(),
+    gh.lazySingleton<_i28.SyncService>(() => networkModule.syncService);
+    gh.lazySingleton<_i58.UserProfileRepository>(
+        () => _i59.UserProfileRepositoryImpl(gh<_i18.Isar>()));
+    gh.lazySingleton<_i60.VectorStoreService>(() => _i61.IsarVectorStoreService(
+          gh<_i12.MemoryGraph>(),
+          gh<_i29.MedicalKnowledgeRepository>(),
         ));
-    gh.factory<_i61.VitalAnalysisStrategy>(() => _i61.VitalAnalysisStrategy());
-    gh.factory<_i62.VitalSignAnalyzer>(() => _i62.VitalSignAnalyzer());
-    gh.lazySingleton<_i63.VitalSignRepository>(
-        () => _i64.VitalSignRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i65.AllergyRepository>(
-        () => _i66.IsarAllergyRepository(gh<_i17.Isar>()));
-    gh.lazySingleton<_i67.AnonCredsService>(
-        () => _i68.AnonCredsServiceImpl(gh<_i50.SsiRepository>()));
-    gh.lazySingleton<_i69.AppointmentRepository>(
-        () => _i70.IsarAppointmentRepository(gh<_i17.Isar>()));
-    gh.lazySingleton<_i71.AuthRepository>(
-        () => _i72.AuthRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i73.AuthService>(
-        () => _i73.AuthServiceImpl(gh<_i12.EncryptionService>()));
-    gh.lazySingleton<_i74.BleMedicalSharingService>(
-        () => _i74.BleMedicalSharingService(
-              gh<_i4.BleSharingService>(),
-              gh<_i12.EncryptionService>(),
-              gh<_i52.SsiService>(),
+    gh.factory<_i62.VitalAnalysisStrategy>(() => _i62.VitalAnalysisStrategy());
+    gh.factory<_i63.VitalSignAnalyzer>(() => _i63.VitalSignAnalyzer());
+    gh.lazySingleton<_i64.VitalSignRepository>(
+        () => _i65.VitalSignRepositoryImpl(gh<_i18.Isar>()));
+    gh.lazySingleton<_i66.AllergyRepository>(
+        () => _i67.IsarAllergyRepository(gh<_i18.Isar>()));
+    gh.lazySingleton<_i68.AnonCredsService>(
+        () => _i69.AnonCredsServiceImpl(gh<_i51.SsiRepository>()));
+    gh.lazySingleton<_i70.AppointmentRepository>(
+        () => _i71.IsarAppointmentRepository(gh<_i18.Isar>()));
+    gh.lazySingleton<_i72.AuthRepository>(
+        () => _i73.AuthRepositoryImpl(gh<_i18.Isar>()));
+    gh.lazySingleton<_i74.AuthService>(
+        () => _i74.AuthServiceImpl(gh<_i13.EncryptionService>()));
+    gh.lazySingleton<_i75.BleMedicalSharingService>(
+        () => _i75.BleMedicalSharingService(
+              gh<_i5.BleSharingService>(),
+              gh<_i13.EncryptionService>(),
+              gh<_i53.SsiService>(),
             ));
-    gh.factory<_i75.CalendarImportCubit>(() => _i75.CalendarImportCubit(
-          gh<_i6.CalendarRepository>(),
-          gh<_i69.AppointmentRepository>(),
-          gh<_i57.UserProfileRepository>(),
+    gh.factory<_i76.CalendarImportCubit>(() => _i76.CalendarImportCubit(
+          gh<_i7.CalendarRepository>(),
+          gh<_i70.AppointmentRepository>(),
+          gh<_i58.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i76.ClinicalReasonerService>(
-        () => _i77.SymphonyClinicalReasonerService(
-              gh<_i28.MedicalKnowledgeRepository>(),
-              gh<_i45.PromptScrubber>(),
+    gh.lazySingleton<_i77.ClinicalReasonerService>(
+        () => _i78.SymphonyClinicalReasonerService(
+              gh<_i29.MedicalKnowledgeRepository>(),
+              gh<_i46.PromptScrubber>(),
             ));
-    gh.factory<_i78.EpsConnectionCubit>(() => _i78.EpsConnectionCubit(
-          gh<_i42.OAuthRepository>(),
-          gh<_i57.UserProfileRepository>(),
+    gh.factory<_i79.EpsConnectionCubit>(() => _i79.EpsConnectionCubit(
+          gh<_i43.OAuthRepository>(),
+          gh<_i58.UserProfileRepository>(),
         ));
-    gh.factory<_i79.FhirSyncCubit>(
-        () => _i79.FhirSyncCubit(gh<_i55.SyncRepository>()));
-    gh.lazySingleton<_i80.HealthContextService>(
-        () => _i81.IsarHealthContextService(
-              gh<_i63.VitalSignRepository>(),
-              gh<_i38.MedicationRepository>(),
-              gh<_i57.UserProfileRepository>(),
-              gh<_i11.MemoryGraph>(),
+    gh.factory<_i80.FhirSyncCubit>(
+        () => _i80.FhirSyncCubit(gh<_i56.SyncRepository>()));
+    gh.lazySingleton<_i81.HealthContextService>(
+        () => _i82.IsarHealthContextService(
+              gh<_i64.VitalSignRepository>(),
+              gh<_i39.MedicationRepository>(),
+              gh<_i58.UserProfileRepository>(),
+              gh<_i12.MemoryGraph>(),
             ));
-    gh.factory<_i82.HealthImportCubit>(() => _i82.HealthImportCubit(
-          gh<_i15.HealthDataImportService>(),
-          gh<_i63.VitalSignRepository>(),
+    gh.factory<_i83.HealthImportCubit>(() => _i83.HealthImportCubit(
+          gh<_i16.HealthDataImportService>(),
+          gh<_i64.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i83.HealthRecordRepository>(
-        () => _i84.HealthRecordRepositoryImpl(gh<_i17.Isar>()));
-    gh.lazySingleton<_i20.LlmAdapter>(
-      () => _i85.GeminiLlmAdapter(
-        scrubber: gh<_i45.PromptScrubber>(),
-        userProfileRepository: gh<_i57.UserProfileRepository>(),
+    gh.lazySingleton<_i84.HealthRecordRepository>(
+        () => _i85.HealthRecordRepositoryImpl(gh<_i18.Isar>()));
+    gh.lazySingleton<_i21.LlmAdapter>(
+      () => _i86.GeminiLlmAdapter(
+        scrubber: gh<_i46.PromptScrubber>(),
+        userProfileRepository: gh<_i58.UserProfileRepository>(),
       ),
       instanceName: 'gemini',
     );
-    gh.factory<_i20.LlmAdapter>(
-      () => _i86.MockLlmAdapter(gh<_i45.PromptScrubber>()),
+    gh.factory<_i21.LlmAdapter>(
+      () => _i87.MockLlmAdapter(gh<_i46.PromptScrubber>()),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i87.LlmService>(() => _i88.GemmaLlmService(
-          gh<_i59.VectorStoreService>(),
-          gh<_i57.UserProfileRepository>(),
-          gh<_i20.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i88.LlmService>(() => _i89.GemmaLlmService(
+          gh<_i60.VectorStoreService>(),
+          gh<_i58.UserProfileRepository>(),
+          gh<_i21.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i89.LlmSettingsCubit>(() => _i89.LlmSettingsCubit(
-          gh<_i23.LlmSettingsRepository>(),
-          gh<_i8.DeviceCapabilityService>(),
-          gh<_i20.LlmAdapter>(instanceName: 'gemma'),
+    gh.factory<_i90.LlmSettingsCubit>(() => _i90.LlmSettingsCubit(
+          gh<_i24.LlmSettingsRepository>(),
+          gh<_i10.DeviceCapabilityService>(),
+          gh<_i21.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i90.MedicalAssistantCubit>(() => _i90.MedicalAssistantCubit(
-          llmAdapter: gh<_i31.MedicalLlmAdapter>(),
-          analysisService: gh<_i26.MedicalAnalysisService>(),
-          healthContextService: gh<_i80.HealthContextService>(),
-          labInterpreter: gh<_i19.LabInterpreter>(),
-          vitalAnalyzer: gh<_i62.VitalSignAnalyzer>(),
-          riskCalculator: gh<_i48.RiskCalculator>(),
+    gh.factory<_i91.MedicalAssistantCubit>(() => _i91.MedicalAssistantCubit(
+          llmAdapter: gh<_i32.MedicalLlmAdapter>(),
+          analysisService: gh<_i27.MedicalAnalysisService>(),
+          healthContextService: gh<_i81.HealthContextService>(),
+          labInterpreter: gh<_i20.LabInterpreter>(),
+          vitalAnalyzer: gh<_i63.VitalSignAnalyzer>(),
+          riskCalculator: gh<_i49.RiskCalculator>(),
         ));
-    gh.lazySingleton<_i91.MedicalResearchService>(
-        () => _i91.MedicalResearchService(
-              gh<_i36.MedicalWebSearchService>(),
-              gh<_i32.MedicalScraperService>(),
+    gh.lazySingleton<_i92.MedicalResearchService>(
+        () => _i92.MedicalResearchService(
+              gh<_i37.MedicalWebSearchService>(),
+              gh<_i33.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i92.PatientContextIndexer>(
-      () => _i92.PatientContextIndexer(
-        gh<_i17.Isar>(),
-        gh<_i59.VectorStoreService>(),
-        gh<_i83.HealthRecordRepository>(),
-        gh<_i38.MedicationRepository>(),
-        gh<_i65.AllergyRepository>(),
-        gh<_i63.VitalSignRepository>(),
-        gh<_i69.AppointmentRepository>(),
+    gh.lazySingleton<_i93.PatientContextIndexer>(
+      () => _i93.PatientContextIndexer(
+        gh<_i18.Isar>(),
+        gh<_i60.VectorStoreService>(),
+        gh<_i84.HealthRecordRepository>(),
+        gh<_i39.MedicationRepository>(),
+        gh<_i66.AllergyRepository>(),
+        gh<_i64.VitalSignRepository>(),
+        gh<_i70.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i93.ReportGenerationService>(
-        () => _i94.GemmaReportGenerationService(
-              gh<_i20.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i59.VectorStoreService>(),
-              gh<_i57.UserProfileRepository>(),
-              gh<_i45.PromptScrubber>(),
+    gh.lazySingleton<_i94.ReportGenerationService>(
+        () => _i95.GemmaReportGenerationService(
+              gh<_i21.LlmAdapter>(instanceName: 'gemma'),
+              gh<_i60.VectorStoreService>(),
+              gh<_i58.UserProfileRepository>(),
+              gh<_i46.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i95.SmartSearchUseCase>(
-        () => _i95.SmartSearchUseCase(gh<_i59.VectorStoreService>()));
-    gh.factory<_i96.SyncCubit>(() => _i96.SyncCubit(
-          gh<_i27.SyncService>(),
-          gh<_i59.VectorStoreService>(),
+    gh.lazySingleton<_i96.SmartSearchUseCase>(
+        () => _i96.SmartSearchUseCase(gh<_i60.VectorStoreService>()));
+    gh.factory<_i97.SyncCubit>(() => _i97.SyncCubit(
+          gh<_i28.SyncService>(),
+          gh<_i60.VectorStoreService>(),
         ));
-    gh.factory<_i97.UserProfileCubit>(
-        () => _i97.UserProfileCubit(gh<_i57.UserProfileRepository>()));
-    gh.factory<_i98.AuthCubit>(() => _i98.AuthCubit(
-          gh<_i71.AuthRepository>(),
-          gh<_i12.EncryptionService>(),
-          gh<_i3.BiometricService>(),
+    gh.factory<_i98.UserProfileCubit>(
+        () => _i98.UserProfileCubit(gh<_i58.UserProfileRepository>()));
+    gh.factory<_i99.AuthCubit>(() => _i99.AuthCubit(gh<_i74.AuthService>()));
+    gh.factory<_i100.AuthCubit>(() => _i100.AuthCubit(
+          gh<_i72.AuthRepository>(),
+          gh<_i13.EncryptionService>(),
+          gh<_i4.BiometricService>(),
         ));
-    gh.factory<_i99.AuthCubit>(() => _i99.AuthCubit(gh<_i73.AuthService>()));
-    gh.factory<_i100.HealthRecordCubit>(() => _i100.HealthRecordCubit(
-          gh<_i83.HealthRecordRepository>(),
-          gh<_i14.FilePickerService>(),
-          gh<_i16.ImagePickerService>(),
-          gh<_i43.OcrService>(),
-          gh<_i59.VectorStoreService>(),
+    gh.factory<_i101.HealthRecordCubit>(() => _i101.HealthRecordCubit(
+          gh<_i84.HealthRecordRepository>(),
+          gh<_i15.FilePickerService>(),
+          gh<_i17.ImagePickerService>(),
+          gh<_i44.OcrService>(),
+          gh<_i60.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i87.LlmService>(
-      () => _i101.RagLlmService(
-        gh<_i59.VectorStoreService>(),
-        gh<_i91.MedicalResearchService>(),
-        gh<_i57.UserProfileRepository>(),
-        gh<_i20.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i88.LlmService>(
+      () => _i102.RagLlmService(
+        gh<_i60.VectorStoreService>(),
+        gh<_i92.MedicalResearchService>(),
+        gh<_i58.UserProfileRepository>(),
+        gh<_i21.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
-    gh.lazySingleton<_i102.MedicalIndexingService>(
-        () => _i102.MedicalIndexingService(
-              gh<_i28.MedicalKnowledgeRepository>(),
-              gh<_i59.VectorStoreService>(),
-              gh<_i92.PatientContextIndexer>(),
+    gh.lazySingleton<_i103.MedicalIndexingService>(
+        () => _i103.MedicalIndexingService(
+              gh<_i29.MedicalKnowledgeRepository>(),
+              gh<_i60.VectorStoreService>(),
+              gh<_i93.PatientContextIndexer>(),
             ));
-    gh.factory<_i103.ReportBloc>(() => _i103.ReportBloc(
-          gh<_i46.ReportRepository>(),
-          gh<_i93.ReportGenerationService>(),
+    gh.factory<_i104.ReportBloc>(() => _i104.ReportBloc(
+          gh<_i47.ReportRepository>(),
+          gh<_i94.ReportGenerationService>(),
         ));
     return this;
   }
 }
 
-class _$FhirModule extends _i104.FhirModule {}
+class _$FhirModule extends _i105.FhirModule {}
 
-class _$NetworkModule extends _i105.NetworkModule {}
+class _$NetworkModule extends _i106.NetworkModule {}
 
-class _$MemoryModule extends _i106.MemoryModule {}
+class _$MemoryModule extends _i107.MemoryModule {}
 
-class _$DatabaseModule extends _i107.DatabaseModule {}
+class _$DatabaseModule extends _i108.DatabaseModule {}

--- a/lib/features/appointments/domain/entities/appointment.dart
+++ b/lib/features/appointments/domain/entities/appointment.dart
@@ -15,6 +15,8 @@ class Appointment {
   late String doctorName;
   late String specialty;
   late DateTime dateTime;
+  int durationInMinutes = 30;
+  String? recurrenceRule; // e.g., "FREQ=DAILY", "FREQ=WEEKLY"
   String? notes;
   String? source;
 
@@ -26,8 +28,19 @@ class Appointment {
     required this.doctorName,
     required this.specialty,
     required this.dateTime,
+    this.durationInMinutes = 30,
+    this.recurrenceRule,
     this.notes,
     this.source,
     required this.status,
   });
+
+  bool validate() {
+    if (doctorName.trim().isEmpty) return false;
+    if (specialty.trim().isEmpty) return false;
+    if (durationInMinutes <= 0) return false;
+    return true;
+  }
+
+  bool get isPast => dateTime.isBefore(DateTime.now());
 }

--- a/lib/features/appointments/domain/entities/appointment.g.dart
+++ b/lib/features/appointments/domain/entities/appointment.g.dart
@@ -27,23 +27,38 @@ const AppointmentSchema = CollectionSchema(
       name: r'doctorName',
       type: IsarType.string,
     ),
-    r'notes': PropertySchema(
+    r'durationInMinutes': PropertySchema(
       id: 2,
+      name: r'durationInMinutes',
+      type: IsarType.long,
+    ),
+    r'isPast': PropertySchema(
+      id: 3,
+      name: r'isPast',
+      type: IsarType.bool,
+    ),
+    r'notes': PropertySchema(
+      id: 4,
       name: r'notes',
       type: IsarType.string,
     ),
+    r'recurrenceRule': PropertySchema(
+      id: 5,
+      name: r'recurrenceRule',
+      type: IsarType.string,
+    ),
     r'source': PropertySchema(
-      id: 3,
+      id: 6,
       name: r'source',
       type: IsarType.string,
     ),
     r'specialty': PropertySchema(
-      id: 4,
+      id: 7,
       name: r'specialty',
       type: IsarType.string,
     ),
     r'status': PropertySchema(
-      id: 5,
+      id: 8,
       name: r'status',
       type: IsarType.string,
       enumMap: _AppointmentstatusEnumValueMap,
@@ -77,6 +92,12 @@ int _appointmentEstimateSize(
     }
   }
   {
+    final value = object.recurrenceRule;
+    if (value != null) {
+      bytesCount += 3 + value.length * 3;
+    }
+  }
+  {
     final value = object.source;
     if (value != null) {
       bytesCount += 3 + value.length * 3;
@@ -95,10 +116,13 @@ void _appointmentSerialize(
 ) {
   writer.writeDateTime(offsets[0], object.dateTime);
   writer.writeString(offsets[1], object.doctorName);
-  writer.writeString(offsets[2], object.notes);
-  writer.writeString(offsets[3], object.source);
-  writer.writeString(offsets[4], object.specialty);
-  writer.writeString(offsets[5], object.status.name);
+  writer.writeLong(offsets[2], object.durationInMinutes);
+  writer.writeBool(offsets[3], object.isPast);
+  writer.writeString(offsets[4], object.notes);
+  writer.writeString(offsets[5], object.recurrenceRule);
+  writer.writeString(offsets[6], object.source);
+  writer.writeString(offsets[7], object.specialty);
+  writer.writeString(offsets[8], object.status.name);
 }
 
 Appointment _appointmentDeserialize(
@@ -110,12 +134,14 @@ Appointment _appointmentDeserialize(
   final object = Appointment(
     dateTime: reader.readDateTime(offsets[0]),
     doctorName: reader.readString(offsets[1]),
+    durationInMinutes: reader.readLongOrNull(offsets[2]) ?? 30,
     id: id,
-    notes: reader.readStringOrNull(offsets[2]),
-    source: reader.readStringOrNull(offsets[3]),
-    specialty: reader.readString(offsets[4]),
+    notes: reader.readStringOrNull(offsets[4]),
+    recurrenceRule: reader.readStringOrNull(offsets[5]),
+    source: reader.readStringOrNull(offsets[6]),
+    specialty: reader.readString(offsets[7]),
     status:
-        _AppointmentstatusValueEnumMap[reader.readStringOrNull(offsets[5])] ??
+        _AppointmentstatusValueEnumMap[reader.readStringOrNull(offsets[8])] ??
             AppointmentStatus.upcoming,
   );
   return object;
@@ -133,12 +159,18 @@ P _appointmentDeserializeProp<P>(
     case 1:
       return (reader.readString(offset)) as P;
     case 2:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readLongOrNull(offset) ?? 30) as P;
     case 3:
-      return (reader.readStringOrNull(offset)) as P;
+      return (reader.readBool(offset)) as P;
     case 4:
-      return (reader.readString(offset)) as P;
+      return (reader.readStringOrNull(offset)) as P;
     case 5:
+      return (reader.readStringOrNull(offset)) as P;
+    case 6:
+      return (reader.readStringOrNull(offset)) as P;
+    case 7:
+      return (reader.readString(offset)) as P;
+    case 8:
       return (_AppointmentstatusValueEnumMap[reader.readStringOrNull(offset)] ??
           AppointmentStatus.upcoming) as P;
     default:
@@ -441,6 +473,62 @@ extension AppointmentQueryFilter
     });
   }
 
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      durationInMinutesEqualTo(int value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'durationInMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      durationInMinutesGreaterThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'durationInMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      durationInMinutesLessThan(
+    int value, {
+    bool include = false,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'durationInMinutes',
+        value: value,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      durationInMinutesBetween(
+    int lower,
+    int upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'durationInMinutes',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+      ));
+    });
+  }
+
   QueryBuilder<Appointment, Appointment, QAfterFilterCondition> idEqualTo(
       Id value) {
     return QueryBuilder.apply(this, (query) {
@@ -490,6 +578,16 @@ extension AppointmentQueryFilter
         includeLower: includeLower,
         upper: upper,
         includeUpper: includeUpper,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition> isPastEqualTo(
+      bool value) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'isPast',
+        value: value,
       ));
     });
   }
@@ -638,6 +736,160 @@ extension AppointmentQueryFilter
     return QueryBuilder.apply(this, (query) {
       return query.addFilterCondition(FilterCondition.greaterThan(
         property: r'notes',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleIsNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNull(
+        property: r'recurrenceRule',
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleIsNotNull() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(const FilterCondition.isNotNull(
+        property: r'recurrenceRule',
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleEqualTo(
+    String? value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'recurrenceRule',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleGreaterThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        include: include,
+        property: r'recurrenceRule',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleLessThan(
+    String? value, {
+    bool include = false,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.lessThan(
+        include: include,
+        property: r'recurrenceRule',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleBetween(
+    String? lower,
+    String? upper, {
+    bool includeLower = true,
+    bool includeUpper = true,
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.between(
+        property: r'recurrenceRule',
+        lower: lower,
+        includeLower: includeLower,
+        upper: upper,
+        includeUpper: includeUpper,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleStartsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.startsWith(
+        property: r'recurrenceRule',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleEndsWith(
+    String value, {
+    bool caseSensitive = true,
+  }) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.endsWith(
+        property: r'recurrenceRule',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleContains(String value, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.contains(
+        property: r'recurrenceRule',
+        value: value,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleMatches(String pattern, {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.matches(
+        property: r'recurrenceRule',
+        wildcard: pattern,
+        caseSensitive: caseSensitive,
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleIsEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.equalTo(
+        property: r'recurrenceRule',
+        value: '',
+      ));
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterFilterCondition>
+      recurrenceRuleIsNotEmpty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addFilterCondition(FilterCondition.greaterThan(
+        property: r'recurrenceRule',
         value: '',
       ));
     });
@@ -1097,6 +1349,32 @@ extension AppointmentQuerySortBy
     });
   }
 
+  QueryBuilder<Appointment, Appointment, QAfterSortBy>
+      sortByDurationInMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationInMinutes', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy>
+      sortByDurationInMinutesDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationInMinutes', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy> sortByIsPast() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isPast', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy> sortByIsPastDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isPast', Sort.desc);
+    });
+  }
+
   QueryBuilder<Appointment, Appointment, QAfterSortBy> sortByNotes() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'notes', Sort.asc);
@@ -1106,6 +1384,19 @@ extension AppointmentQuerySortBy
   QueryBuilder<Appointment, Appointment, QAfterSortBy> sortByNotesDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'notes', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy> sortByRecurrenceRule() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'recurrenceRule', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy>
+      sortByRecurrenceRuleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'recurrenceRule', Sort.desc);
     });
   }
 
@@ -1172,6 +1463,20 @@ extension AppointmentQuerySortThenBy
     });
   }
 
+  QueryBuilder<Appointment, Appointment, QAfterSortBy>
+      thenByDurationInMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationInMinutes', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy>
+      thenByDurationInMinutesDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'durationInMinutes', Sort.desc);
+    });
+  }
+
   QueryBuilder<Appointment, Appointment, QAfterSortBy> thenById() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'id', Sort.asc);
@@ -1184,6 +1489,18 @@ extension AppointmentQuerySortThenBy
     });
   }
 
+  QueryBuilder<Appointment, Appointment, QAfterSortBy> thenByIsPast() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isPast', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy> thenByIsPastDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'isPast', Sort.desc);
+    });
+  }
+
   QueryBuilder<Appointment, Appointment, QAfterSortBy> thenByNotes() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'notes', Sort.asc);
@@ -1193,6 +1510,19 @@ extension AppointmentQuerySortThenBy
   QueryBuilder<Appointment, Appointment, QAfterSortBy> thenByNotesDesc() {
     return QueryBuilder.apply(this, (query) {
       return query.addSortBy(r'notes', Sort.desc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy> thenByRecurrenceRule() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'recurrenceRule', Sort.asc);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QAfterSortBy>
+      thenByRecurrenceRuleDesc() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addSortBy(r'recurrenceRule', Sort.desc);
     });
   }
 
@@ -1248,10 +1578,31 @@ extension AppointmentQueryWhereDistinct
     });
   }
 
+  QueryBuilder<Appointment, Appointment, QDistinct>
+      distinctByDurationInMinutes() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'durationInMinutes');
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QDistinct> distinctByIsPast() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'isPast');
+    });
+  }
+
   QueryBuilder<Appointment, Appointment, QDistinct> distinctByNotes(
       {bool caseSensitive = true}) {
     return QueryBuilder.apply(this, (query) {
       return query.addDistinctBy(r'notes', caseSensitive: caseSensitive);
+    });
+  }
+
+  QueryBuilder<Appointment, Appointment, QDistinct> distinctByRecurrenceRule(
+      {bool caseSensitive = true}) {
+    return QueryBuilder.apply(this, (query) {
+      return query.addDistinctBy(r'recurrenceRule',
+          caseSensitive: caseSensitive);
     });
   }
 
@@ -1297,9 +1648,28 @@ extension AppointmentQueryProperty
     });
   }
 
+  QueryBuilder<Appointment, int, QQueryOperations> durationInMinutesProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'durationInMinutes');
+    });
+  }
+
+  QueryBuilder<Appointment, bool, QQueryOperations> isPastProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'isPast');
+    });
+  }
+
   QueryBuilder<Appointment, String?, QQueryOperations> notesProperty() {
     return QueryBuilder.apply(this, (query) {
       return query.addPropertyName(r'notes');
+    });
+  }
+
+  QueryBuilder<Appointment, String?, QQueryOperations>
+      recurrenceRuleProperty() {
+    return QueryBuilder.apply(this, (query) {
+      return query.addPropertyName(r'recurrenceRule');
     });
   }
 

--- a/lib/features/appointments/domain/services/appointment_service.dart
+++ b/lib/features/appointments/domain/services/appointment_service.dart
@@ -1,0 +1,68 @@
+import 'package:injectable/injectable.dart';
+import 'package:isar/isar.dart';
+import '../entities/appointment.dart';
+
+@lazySingleton
+class AppointmentService {
+  /// Checks if [newApp] conflicts with any of the [existingApps].
+  /// A conflict is defined as an overlap in time for the same doctor or same patient.
+  /// (In this context, we assume all existingApps belong to the same patient).
+  /// Cancelled appointments are ignored.
+  bool hasConflict(Appointment newApp, List<Appointment> existingApps) {
+    if (newApp.status == AppointmentStatus.cancelled) return false;
+
+    final newStart = newApp.dateTime;
+    final newEnd = newStart.add(Duration(minutes: newApp.durationInMinutes));
+
+    for (final existing in existingApps) {
+      if (existing.id == newApp.id) continue;
+      if (existing.status == AppointmentStatus.cancelled) continue;
+
+      final existingStart = existing.dateTime;
+      final existingEnd = existingStart.add(Duration(minutes: existing.durationInMinutes));
+
+      // Overlap detection logic: (StartA < EndB) and (EndA > StartB)
+      if (newStart.isBefore(existingEnd) && newEnd.isAfter(existingStart)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /// Generates recurring instances of an appointment based on its [recurrenceRule].
+  /// Supported rules: "FREQ=DAILY", "FREQ=WEEKLY".
+  /// [count] specifies the number of instances to generate (default 10).
+  List<Appointment> generateInstances(Appointment app, {int count = 10}) {
+    if (app.recurrenceRule == null || app.recurrenceRule!.isEmpty) {
+      return [app];
+    }
+
+    final List<Appointment> instances = [];
+    final rule = app.recurrenceRule!.toUpperCase();
+
+    Duration step;
+    if (rule.contains("FREQ=DAILY")) {
+      step = const Duration(days: 1);
+    } else if (rule.contains("FREQ=WEEKLY")) {
+      step = const Duration(days: 7);
+    } else {
+      return [app];
+    }
+
+    for (int i = 0; i < count; i++) {
+      instances.add(Appointment(
+        id: i == 0 ? app.id : Isar.autoIncrement,
+        doctorName: app.doctorName,
+        specialty: app.specialty,
+        dateTime: app.dateTime.add(step * i),
+        durationInMinutes: app.durationInMinutes,
+        notes: app.notes,
+        source: app.source,
+        status: app.status,
+        recurrenceRule: app.recurrenceRule,
+      ));
+    }
+
+    return instances;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/appointments/domain/appointment_service_test.dart
+++ b/test/features/appointments/domain/appointment_service_test.dart
@@ -1,0 +1,203 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+import 'package:orionhealth_health/features/appointments/domain/services/appointment_service.dart';
+
+void main() {
+  late AppointmentService service;
+
+  setUp(() {
+    service = AppointmentService();
+  });
+
+  group('AppointmentService - Conflict Detection', () {
+    final baseTime = DateTime(2025, 5, 20, 10, 0); // 10:00 AM
+
+    test('should detect conflict when appointments overlap perfectly', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'GP',
+          dateTime: baseTime,
+          durationInMinutes: 30,
+          status: AppointmentStatus.upcoming,
+        ),
+      ];
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Cardio',
+        dateTime: baseTime,
+        durationInMinutes: 30,
+        status: AppointmentStatus.upcoming,
+      );
+
+      final conflict = service.hasConflict(newApp, existing);
+      expect(conflict, isTrue);
+    });
+
+    test('should detect conflict when new appointment starts during existing one', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'GP',
+          dateTime: baseTime,
+          durationInMinutes: 60,
+          status: AppointmentStatus.upcoming,
+        ),
+      ];
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Cardio',
+        dateTime: baseTime.add(const Duration(minutes: 30)),
+        durationInMinutes: 30,
+        status: AppointmentStatus.upcoming,
+      );
+
+      expect(service.hasConflict(newApp, existing), isTrue);
+    });
+
+    test('should detect conflict when new appointment ends during existing one', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'GP',
+          dateTime: baseTime,
+          durationInMinutes: 60,
+          status: AppointmentStatus.upcoming,
+        ),
+      ];
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Cardio',
+        dateTime: baseTime.subtract(const Duration(minutes: 30)),
+        durationInMinutes: 45,
+        status: AppointmentStatus.upcoming,
+      );
+
+      expect(service.hasConflict(newApp, existing), isTrue);
+    });
+
+    test('should NOT detect conflict when appointments are back-to-back', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'GP',
+          dateTime: baseTime,
+          durationInMinutes: 30,
+          status: AppointmentStatus.upcoming,
+        ),
+      ];
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Cardio',
+        dateTime: baseTime.add(const Duration(minutes: 30)),
+        durationInMinutes: 30,
+        status: AppointmentStatus.upcoming,
+      );
+
+      expect(service.hasConflict(newApp, existing), isFalse);
+    });
+
+    test('should ignore cancelled appointments for conflict detection', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'GP',
+          dateTime: baseTime,
+          durationInMinutes: 30,
+          status: AppointmentStatus.cancelled,
+        ),
+      ];
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Cardio',
+        dateTime: baseTime,
+        durationInMinutes: 30,
+        status: AppointmentStatus.upcoming,
+      );
+
+      expect(service.hasConflict(newApp, existing), isFalse);
+    });
+
+    test('should NOT detect conflict if new appointment is cancelled', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'GP',
+          dateTime: baseTime,
+          durationInMinutes: 30,
+          status: AppointmentStatus.upcoming,
+        ),
+      ];
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Cardio',
+        dateTime: baseTime,
+        durationInMinutes: 30,
+        status: AppointmentStatus.cancelled,
+      );
+
+      expect(service.hasConflict(newApp, existing), isFalse);
+    });
+  });
+
+  group('AppointmentService - Recurrence Logic', () {
+    final baseTime = DateTime(2025, 5, 20, 10, 0);
+
+    test('should return only one instance if no recurrence rule', () {
+      final app = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'GP',
+        dateTime: baseTime,
+        status: AppointmentStatus.upcoming,
+      );
+
+      final instances = service.generateInstances(app);
+      expect(instances.length, 1);
+      expect(instances.first.dateTime, baseTime);
+    });
+
+    test('should generate daily instances', () {
+      final app = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'GP',
+        dateTime: baseTime,
+        status: AppointmentStatus.upcoming,
+        recurrenceRule: 'FREQ=DAILY',
+      );
+
+      final instances = service.generateInstances(app, count: 5);
+      expect(instances.length, 5);
+      expect(instances[0].dateTime, baseTime);
+      expect(instances[1].dateTime, baseTime.add(const Duration(days: 1)));
+      expect(instances[4].dateTime, baseTime.add(const Duration(days: 4)));
+    });
+
+    test('should generate weekly instances', () {
+      final app = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'GP',
+        dateTime: baseTime,
+        status: AppointmentStatus.upcoming,
+        recurrenceRule: 'FREQ=WEEKLY',
+      );
+
+      final instances = service.generateInstances(app, count: 3);
+      expect(instances.length, 3);
+      expect(instances[0].dateTime, baseTime);
+      expect(instances[1].dateTime, baseTime.add(const Duration(days: 7)));
+      expect(instances[2].dateTime, baseTime.add(const Duration(days: 14)));
+    });
+  });
+}

--- a/test/features/appointments/domain/appointment_test.dart
+++ b/test/features/appointments/domain/appointment_test.dart
@@ -1,0 +1,80 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+
+void main() {
+  group('Appointment Model Validation', () {
+    test('valid appointment should pass validation', () {
+      final appointment = Appointment(
+        doctorName: 'Dr. House',
+        specialty: 'Diagnostics',
+        dateTime: DateTime.now(),
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.validate(), isTrue);
+    });
+
+    test('appointment with empty doctor name should fail validation', () {
+      final appointment = Appointment(
+        doctorName: '',
+        specialty: 'Diagnostics',
+        dateTime: DateTime.now(),
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.validate(), isFalse);
+    });
+
+    test('appointment with empty specialty should fail validation', () {
+      final appointment = Appointment(
+        doctorName: 'Dr. House',
+        specialty: ' ',
+        dateTime: DateTime.now(),
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.validate(), isFalse);
+    });
+
+    test('appointment with zero duration should fail validation', () {
+      final appointment = Appointment(
+        doctorName: 'Dr. House',
+        specialty: 'Diagnostics',
+        dateTime: DateTime.now(),
+        durationInMinutes: 0,
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.validate(), isFalse);
+    });
+
+    test('appointment with negative duration should fail validation', () {
+      final appointment = Appointment(
+        doctorName: 'Dr. House',
+        specialty: 'Diagnostics',
+        dateTime: DateTime.now(),
+        durationInMinutes: -15,
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.validate(), isFalse);
+    });
+
+    test('isPast should return true for dates in the past', () {
+      final pastDate = DateTime.now().subtract(const Duration(days: 1));
+      final appointment = Appointment(
+        doctorName: 'Dr. House',
+        specialty: 'Diagnostics',
+        dateTime: pastDate,
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.isPast, isTrue);
+    });
+
+    test('isPast should return false for future dates', () {
+      final futureDate = DateTime.now().add(const Duration(days: 1));
+      final appointment = Appointment(
+        doctorName: 'Dr. House',
+        specialty: 'Diagnostics',
+        dateTime: futureDate,
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.isPast, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Added unit tests and domain logic for appointment scheduling.

Key changes:
- Enhanced `Appointment` model with `durationInMinutes`, `recurrenceRule`, and `validate()` method.
- Created `AppointmentService` to handle overlapping slot detection and generation of recurring instances (DAILY/WEEKLY).
- Added unit tests in `test/features/appointments/domain/` covering:
    - Model validation (empty fields, invalid durations).
    - Conflict detection (overlapping times, back-to-back appointments, cancelled status handling).
    - Recurrence expansion logic.
    - Edge cases like past dates.
- Registered `AppointmentService` as a lazy singleton in the DI container.
- Ensured unique IDs for recurring instances to prevent Isar collisions.

Fixes #357

---
*PR created automatically by Jules for task [15894512160929617679](https://jules.google.com/task/15894512160929617679) started by @iberi22*