### PR TITLE
Add unit tests and robust parsing for HealthDataImport

### DIFF
--- a/lib/features/health_data_import/domain/services/health_data_import_service.dart
+++ b/lib/features/health_data_import/domain/services/health_data_import_service.dart
@@ -127,6 +127,26 @@ class HealthDataImportService {
     return vitalSigns;
   }
 
+  /// Identifies duplicates in the imported data by comparing them with existing records.
+  /// Two records are considered duplicates if they have the same type, value, unit, and timestamp.
+  /// Optimized for performance using a Set of keys.
+  List<VitalSign> findDuplicates(
+    List<VitalSign> importedData,
+    List<VitalSign> existingData,
+  ) {
+    if (importedData.isEmpty || existingData.isEmpty) return [];
+
+    final existingKeys = existingData.map(_getVitalSignKey).toSet();
+    return importedData.where((imported) => existingKeys.contains(_getVitalSignKey(imported))).toList();
+  }
+
+  /// Generates a unique key for a [VitalSign] to facilitate duplicate detection.
+  String _getVitalSignKey(VitalSign vital) {
+    // Round value to 3 decimal places to handle floating point precision
+    final roundedValue = (vital.value * 1000).round() / 1000;
+    return '${vital.type.name}_${roundedValue}_${vital.unit ?? ''}_${vital.dateTime.millisecondsSinceEpoch}';
+  }
+
   VitalSign? _mapHealthDataToVitalSign(
     HealthDataPoint data,
     HealthDataSource source,

--- a/lib/features/health_data_import/domain/services/health_data_parser.dart
+++ b/lib/features/health_data_import/domain/services/health_data_parser.dart
@@ -1,0 +1,268 @@
+import 'dart:convert';
+import '../../../vitals/domain/entities/vital_sign.dart';
+
+class HealthDataParser {
+  /// Parses a CSV string into a list of [VitalSign] entities.
+  /// Expected format: type,value,unit,dateTime
+  List<VitalSign> parseCsv(String csvData) {
+    final List<VitalSign> results = [];
+    final lines = csvData.trim().split('\n');
+
+    if (lines.isEmpty) return [];
+
+    // Skip header if it exists
+    int startIndex = 0;
+    if (lines[0].toLowerCase().contains('type') && lines[0].contains('value')) {
+      startIndex = 1;
+    }
+
+    for (int i = startIndex; i < lines.length; i++) {
+      final line = lines[i].trim();
+      if (line.isEmpty) continue;
+
+      final parts = _splitCsvLine(line);
+      if (parts.length < 4) continue;
+
+      try {
+        final typeStr = parts[0];
+        final valueStr = parts[1];
+        final unitStr = parts[2];
+        final dateStr = parts[3];
+
+        final type = _mapStringToVitalSignType(typeStr);
+        final value = double.tryParse(valueStr);
+        final dateTime = DateTime.tryParse(dateStr);
+
+        if (type != null && value != null && dateTime != null) {
+          results.add(VitalSign(
+            type: type,
+            value: value,
+            unit: _sanitizeString(unitStr),
+            dateTime: dateTime,
+            source: 'CSV_IMPORT',
+          ));
+        }
+      } catch (_) {
+        // Skip malformed rows
+      }
+    }
+    return results;
+  }
+
+  /// Splits a CSV line robustly, handling quoted values and escaped quotes.
+  List<String> _splitCsvLine(String line) {
+    final List<String> result = [];
+    bool inQuotes = false;
+    StringBuffer buffer = StringBuffer();
+
+    for (int i = 0; i < line.length; i++) {
+      final char = line[i];
+      if (char == '"') {
+        if (inQuotes && i + 1 < line.length && line[i + 1] == '"') {
+          // Escaped quote
+          buffer.write('"');
+          i++;
+        } else {
+          inQuotes = !inQuotes;
+        }
+      } else if (char == ',' && !inQuotes) {
+        result.add(buffer.toString().trim());
+        buffer.clear();
+      } else {
+        buffer.write(char);
+      }
+    }
+    result.add(buffer.toString().trim());
+    return result;
+  }
+
+  /// Parses a JSON string into a list of [VitalSign] entities.
+  List<VitalSign> parseJson(String jsonData) {
+    try {
+      final decoded = jsonDecode(jsonData);
+      if (decoded is! List) return [];
+
+      final List<VitalSign> results = [];
+      for (final item in decoded) {
+        if (item is! Map<String, dynamic>) continue;
+
+        final typeStr = item['type'] as String?;
+        final value = (item['value'] as num?)?.toDouble();
+        final unit = item['unit'] as String?;
+        final dateStr = item['dateTime'] as String?;
+
+        if (typeStr != null && value != null && dateStr != null) {
+          final type = _mapStringToVitalSignType(typeStr);
+          final dateTime = DateTime.tryParse(dateStr);
+
+          if (type != null && dateTime != null) {
+            results.add(VitalSign(
+              type: type,
+              value: value,
+              unit: _sanitizeString(unit ?? ''),
+              dateTime: dateTime,
+              source: 'JSON_IMPORT',
+            ));
+          }
+        }
+      }
+      return results;
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Parses FHIR Observation resources from a JSON string into [VitalSign] entities.
+  List<VitalSign> parseFhir(String fhirData) {
+    try {
+      final decoded = jsonDecode(fhirData);
+      if (decoded is! Map<String, dynamic>) return [];
+
+      if (decoded['resourceType'] == 'Bundle') {
+        final entries = decoded['entry'] as List?;
+        if (entries == null) return [];
+
+        final List<VitalSign> results = [];
+        for (final entry in entries) {
+          final resource = entry['resource'] as Map<String, dynamic>?;
+          if (resource != null && resource['resourceType'] == 'Observation') {
+            results.addAll(_mapFhirObservation(resource));
+          }
+        }
+        return results;
+      } else if (decoded['resourceType'] == 'Observation') {
+        return _mapFhirObservation(decoded);
+      }
+      return [];
+    } catch (_) {
+      return [];
+    }
+  }
+
+  /// Internal FHIR mapping logic to avoid dependency on Data layer.
+  List<VitalSign> _mapFhirObservation(Map<String, dynamic> json) {
+    final code = json['code'];
+    final codings = code?['coding'] as List?;
+    if (codings == null) return [];
+
+    final effectiveDateTimeStr = json['effectiveDateTime'] as String?;
+    final dateTime = effectiveDateTimeStr != null ? DateTime.tryParse(effectiveDateTimeStr) : DateTime.now();
+    if (dateTime == null) return [];
+
+    final List<VitalSign> vitals = [];
+
+    if (json['valueQuantity'] != null) {
+      final type = _mapLoincToVitalType(codings);
+      if (type != null) {
+        vitals.add(VitalSign(
+          type: type,
+          value: (json['valueQuantity']['value'] as num).toDouble(),
+          dateTime: dateTime,
+          unit: json['valueQuantity']['unit'] as String?,
+          source: 'FHIR_IMPORT',
+        ));
+      }
+    }
+
+    final components = json['component'] as List?;
+    if (components != null) {
+      for (final comp in components) {
+        final compCodings = comp['code']?['coding'] as List?;
+        if (compCodings != null && comp['valueQuantity'] != null) {
+          final type = _mapLoincToVitalType(compCodings);
+          if (type != null) {
+            vitals.add(VitalSign(
+              type: type,
+              value: (comp['valueQuantity']['value'] as num).toDouble(),
+              dateTime: dateTime,
+              unit: comp['valueQuantity']['unit'] as String?,
+              source: 'FHIR_IMPORT',
+            ));
+          }
+        }
+      }
+    }
+
+    return vitals;
+  }
+
+  VitalSignType? _mapLoincToVitalType(List codings) {
+    for (final coding in codings) {
+      if (coding['system'] == 'http://loinc.org') {
+        final code = coding['code'] as String?;
+        switch (code) {
+          case '8867-4': return VitalSignType.heartRate;
+          case '8310-5': return VitalSignType.temperature;
+          case '8480-6': return VitalSignType.bloodPressureSystolic;
+          case '8462-4': return VitalSignType.bloodPressureDiastolic;
+          case '2708-6': return VitalSignType.spO2;
+          case '59408-5': return VitalSignType.oxygenSaturation;
+          case '15074-8': return VitalSignType.bloodGlucose;
+        }
+      }
+    }
+    return null;
+  }
+
+  /// Sanitizes input strings by trimming and removing potentially harmful characters.
+  String _sanitizeString(String input) {
+    return input.trim().replaceAll(RegExp(r'[<>{}\[\]\\"]'), '');
+  }
+
+  /// Maps a string to a [VitalSignType].
+  VitalSignType? _mapStringToVitalSignType(String typeStr) {
+    final normalized = typeStr.toLowerCase().replaceAll(' ', '');
+    switch (normalized) {
+      case 'heartrate':
+      case 'bpm':
+        return VitalSignType.heartRate;
+      case 'temperature':
+      case 'temp':
+        return VitalSignType.temperature;
+      case 'bloodpressuresystolic':
+      case 'systolic':
+        return VitalSignType.bloodPressureSystolic;
+      case 'bloodpressurediastolic':
+      case 'diastolic':
+        return VitalSignType.bloodPressureDiastolic;
+      case 'spo2':
+        return VitalSignType.spO2;
+      case 'steps':
+        return VitalSignType.steps;
+      case 'sleep':
+        return VitalSignType.sleep;
+      case 'bloodglucose':
+      case 'glucose':
+        return VitalSignType.bloodGlucose;
+      case 'oxygensaturation':
+        return VitalSignType.oxygenSaturation;
+      default:
+        return null;
+    }
+  }
+
+  /// Validates if a [VitalSign] has reasonable values, considering units.
+  bool isValid(VitalSign vital) {
+    final value = vital.value;
+    final unit = vital.unit?.toLowerCase();
+
+    switch (vital.type) {
+      case VitalSignType.heartRate:
+        return value > 0 && value < 300;
+      case VitalSignType.temperature:
+        if (unit == 'f') {
+          return value > 68 && value < 122; // Fahrenheit equivalent of 20-50 C
+        }
+        return value > 20 && value < 50; // Celsius
+      case VitalSignType.bloodPressureSystolic:
+        return value > 40 && value < 300;
+      case VitalSignType.bloodPressureDiastolic:
+        return value > 20 && value < 200;
+      case VitalSignType.spO2:
+      case VitalSignType.oxygenSaturation:
+        return value >= 0 && value <= 100;
+      default:
+        return value >= 0;
+    }
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/health_data_import/domain/services/health_data_import_service_test.dart
+++ b/test/features/health_data_import/domain/services/health_data_import_service_test.dart
@@ -1,0 +1,171 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/services/health_data_import_service.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/services/health_data_parser.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+
+void main() {
+  late HealthDataImportService service;
+
+  setUp(() {
+    service = HealthDataImportService();
+  });
+
+  group('HealthDataImportService - findDuplicates', () {
+    test('should identify exact duplicates', () {
+      final now = DateTime(2023, 10, 27, 10);
+      final imported = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 72,
+          unit: 'bpm',
+          dateTime: now,
+        ),
+        VitalSign(
+          type: VitalSignType.temperature,
+          value: 36.6,
+          unit: 'C',
+          dateTime: now,
+        ),
+      ];
+
+      final existing = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 72,
+          unit: 'bpm',
+          dateTime: now,
+        ),
+      ];
+
+      final duplicates = service.findDuplicates(imported, existing);
+
+      expect(duplicates.length, 1);
+      expect(duplicates[0].type, VitalSignType.heartRate);
+    });
+
+    test('should handle small differences in floating point values', () {
+      final now = DateTime(2023, 10, 27, 10);
+      final imported = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 72.00001,
+          unit: 'bpm',
+          dateTime: now,
+        ),
+      ];
+
+      final existing = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 72.0,
+          unit: 'bpm',
+          dateTime: now,
+        ),
+      ];
+
+      final duplicates = service.findDuplicates(imported, existing);
+      expect(duplicates.length, 1);
+    });
+
+    test('should not mark records with different timestamps as duplicates', () {
+      final now = DateTime(2023, 10, 27, 10);
+      final later = now.add(const Duration(seconds: 1));
+
+      final imported = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 72,
+          unit: 'bpm',
+          dateTime: later,
+        ),
+      ];
+
+      final existing = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 72,
+          unit: 'bpm',
+          dateTime: now,
+        ),
+      ];
+
+      final duplicates = service.findDuplicates(imported, existing);
+      expect(duplicates.length, 0);
+    });
+
+    test('should return empty list when no duplicates found', () {
+      final now = DateTime(2023, 10, 27, 10);
+      final imported = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 80,
+          unit: 'bpm',
+          dateTime: now,
+        ),
+      ];
+
+      final existing = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 72,
+          unit: 'bpm',
+          dateTime: now,
+        ),
+      ];
+
+      final duplicates = service.findDuplicates(imported, existing);
+      expect(duplicates.isEmpty, isTrue);
+    });
+
+    test('should handle large datasets efficiently', () {
+      final now = DateTime(2023, 10, 27, 10);
+      final imported = List.generate(
+        1000,
+        (i) => VitalSign(
+          type: VitalSignType.heartRate,
+          value: 70.0 + (i % 10),
+          unit: 'bpm',
+          dateTime: now.add(Duration(minutes: i)),
+        ),
+      );
+
+      final existing = List.generate(
+        1000,
+        (i) => VitalSign(
+          type: VitalSignType.heartRate,
+          value: 70.0 + (i % 10),
+          unit: 'bpm',
+          dateTime: now.add(Duration(minutes: i)),
+        ),
+      );
+
+      final stopwatch = Stopwatch()..start();
+      final duplicates = service.findDuplicates(imported, existing);
+      stopwatch.stop();
+
+      expect(duplicates.length, 1000);
+      // O(N+M) should be very fast, much less than 100ms for 2000 items
+      expect(stopwatch.elapsedMilliseconds, lessThan(100));
+    });
+  });
+
+  group('HealthDataParser - Robust CSV', () {
+    late HealthDataParser parser;
+
+    setUp(() {
+      parser = HealthDataParser();
+    });
+
+    test('should handle commas inside quoted fields', () {
+      const csv = 'type,value,unit,dateTime\nheartRate,72,"bpm, with comma",2023-10-27T10:00:00Z';
+      final results = parser.parseCsv(csv);
+      expect(results[0].unit, 'bpm, with comma');
+    });
+
+    test('should handle escaped quotes inside quoted fields', () {
+      const csv = 'type,value,unit,dateTime\nheartRate,72,"bpm ""quoted""",2023-10-27T10:00:00Z';
+      final results = parser.parseCsv(csv);
+      expect(results[0].unit, 'bpm quoted');
+    });
+  });
+}

--- a/test/features/health_data_import/domain/services/health_data_parser_test.dart
+++ b/test/features/health_data_import/domain/services/health_data_parser_test.dart
@@ -1,0 +1,184 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/services/health_data_parser.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+
+void main() {
+  late HealthDataParser parser;
+
+  setUp(() {
+    parser = HealthDataParser();
+  });
+
+  group('HealthDataParser - CSV', () {
+    test('should parse valid CSV data with header', () {
+      const csv = 'type,value,unit,dateTime\nheartRate,72,bpm,2023-10-27T10:00:00Z\ntemperature,36.6,C,2023-10-27T10:05:00Z';
+      final results = parser.parseCsv(csv);
+
+      expect(results.length, 2);
+      expect(results[0].type, VitalSignType.heartRate);
+      expect(results[0].value, 72.0);
+      expect(results[0].unit, 'bpm');
+      expect(results[1].type, VitalSignType.temperature);
+      expect(results[1].value, 36.6);
+    });
+
+    test('should parse valid CSV data without header', () {
+      const csv = 'bpm,75,bpm,2023-10-27T11:00:00Z';
+      final results = parser.parseCsv(csv);
+
+      expect(results.length, 1);
+      expect(results[0].type, VitalSignType.heartRate);
+      expect(results[0].value, 75.0);
+    });
+
+    test('should handle malformed CSV rows', () {
+      const csv = 'type,value,unit,dateTime\ninvalid,not_a_number,unit,date\nheartRate,80,bpm,2023-10-27T12:00:00Z';
+      final results = parser.parseCsv(csv);
+
+      expect(results.length, 1);
+      expect(results[0].type, VitalSignType.heartRate);
+    });
+
+    test('should handle empty CSV', () {
+      expect(parser.parseCsv('').length, 0);
+      expect(parser.parseCsv('   ').length, 0);
+    });
+  });
+
+  group('HealthDataParser - JSON', () {
+    test('should parse valid JSON array', () {
+      final jsonStr = jsonEncode([
+        {
+          'type': 'heartRate',
+          'value': 70.5,
+          'unit': 'bpm',
+          'dateTime': '2023-10-27T13:00:00Z'
+        },
+        {
+          'type': 'glucose',
+          'value': 110,
+          'unit': 'mg/dL',
+          'dateTime': '2023-10-27T13:30:00Z'
+        }
+      ]);
+
+      final results = parser.parseJson(jsonStr);
+
+      expect(results.length, 2);
+      expect(results[0].type, VitalSignType.heartRate);
+      expect(results[0].value, 70.5);
+      expect(results[1].type, VitalSignType.bloodGlucose);
+    });
+
+    test('should handle missing fields in JSON', () {
+      final jsonStr = jsonEncode([
+        {'type': 'heartRate', 'value': 70}, // missing dateTime
+        {'type': 'heartRate', 'dateTime': '2023-10-27T14:00:00Z'} // missing value
+      ]);
+
+      final results = parser.parseJson(jsonStr);
+      expect(results.length, 0);
+    });
+
+    test('should handle invalid JSON', () {
+      expect(parser.parseJson('invalid json').length, 0);
+      expect(parser.parseJson('{}').length, 0);
+    });
+  });
+
+  group('HealthDataParser - FHIR', () {
+    test('should parse FHIR Observation resource', () {
+      final fhirData = jsonEncode({
+        'resourceType': 'Observation',
+        'status': 'final',
+        'code': {
+          'coding': [
+            {'system': 'http://loinc.org', 'code': '8867-4', 'display': 'Heart rate'}
+          ]
+        },
+        'effectiveDateTime': '2023-10-27T15:00:00Z',
+        'valueQuantity': {'value': 78, 'unit': 'bpm'}
+      });
+
+      final results = parser.parseFhir(fhirData);
+
+      expect(results.length, 1);
+      expect(results[0].type, VitalSignType.heartRate);
+      expect(results[0].value, 78.0);
+    });
+
+    test('should parse FHIR Bundle with Observations', () {
+      final fhirBundle = jsonEncode({
+        'resourceType': 'Bundle',
+        'entry': [
+          {
+            'resource': {
+              'resourceType': 'Observation',
+              'code': {
+                'coding': [
+                  {'system': 'http://loinc.org', 'code': '8310-5'}
+                ]
+              },
+              'effectiveDateTime': '2023-10-27T15:30:00Z',
+              'valueQuantity': {'value': 37.2}
+            }
+          }
+        ]
+      });
+
+      final results = parser.parseFhir(fhirBundle);
+
+      expect(results.length, 1);
+      expect(results[0].type, VitalSignType.temperature);
+      expect(results[0].value, 37.2);
+    });
+  });
+
+  group('HealthDataParser - Sanitization & Validation', () {
+    test('should sanitize unit strings', () {
+      const csv = 'heartRate,72,"bpm <script>",2023-10-27T10:00:00Z';
+      final results = parser.parseCsv(csv);
+
+      expect(results[0].unit, 'bpm script');
+    });
+
+    test('should validate heart rate range', () {
+      final valid = VitalSign(
+        type: VitalSignType.heartRate,
+        value: 70,
+        dateTime: DateTime.now(),
+      );
+      final invalidLow = VitalSign(
+        type: VitalSignType.heartRate,
+        value: -5,
+        dateTime: DateTime.now(),
+      );
+      final invalidHigh = VitalSign(
+        type: VitalSignType.heartRate,
+        value: 350,
+        dateTime: DateTime.now(),
+      );
+
+      expect(parser.isValid(valid), isTrue);
+      expect(parser.isValid(invalidLow), isFalse);
+      expect(parser.isValid(invalidHigh), isFalse);
+    });
+
+    test('should validate temperature range', () {
+      final valid = VitalSign(
+        type: VitalSignType.temperature,
+        value: 36.5,
+        dateTime: DateTime.now(),
+      );
+      final invalid = VitalSign(
+        type: VitalSignType.temperature,
+        value: 15,
+        dateTime: DateTime.now(),
+      );
+
+      expect(parser.isValid(valid), isTrue);
+      expect(parser.isValid(invalid), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
I have implemented a comprehensive unit test suite and the underlying parsing logic for health data imports. 

Key changes:
1. **New `HealthDataParser`**: Handles CSV, JSON, and FHIR formats. It includes robust CSV logic for quoted fields and handles complex FHIR structures like multi-component observations (e.g., blood pressure) and Bundles.
2. **Optimized Duplicate Detection**: Added a `findDuplicates` method to `HealthDataImportService` that uses a `Set` of composite keys for $O(N+M)$ performance, ensuring efficiency even with large files.
3. **Validation & Sanitization**: Implemented medical range checks (supporting multiple units) and string sanitization to ensure data integrity.
4. **Comprehensive Tests**: Created 19 unit tests across two files to verify all success and edge cases, including a performance test for large datasets.

All tests passed successfully.

Fixes #361

---
*PR created automatically by Jules for task [16665350129726778588](https://jules.google.com/task/16665350129726778588) started by @iberi22*