### PR TITLE
Rename _ConditionChip to lowerCamelCase in app_test.dart

### DIFF
--- a/integration_test/app_test.dart
+++ b/integration_test/app_test.dart
@@ -392,9 +392,9 @@ class _RealisticProfilePage extends StatelessWidget {
                       ],
                     ),
                     const SizedBox(height: 12),
-                    _ConditionChip(theme, 'Diabetes Tipo 2', Icons.warning_amber, Colors.orange),
-                    _ConditionChip(theme, 'Hipertensión Controlada', Icons.favorite, Colors.red),
-                    _ConditionChip(theme, 'Hipotiroidismo', Icons.biotech, Colors.purple),
+                    _conditionChip(theme, 'Diabetes Tipo 2', Icons.warning_amber, Colors.orange),
+                    _conditionChip(theme, 'Hipertensión Controlada', Icons.favorite, Colors.red),
+                    _conditionChip(theme, 'Hipotiroidismo', Icons.biotech, Colors.purple),
                   ],
                 ),
               ),
@@ -487,7 +487,7 @@ class _QuickStatCard extends StatelessWidget {
   }
 }
 
-Widget _ConditionChip(ThemeData theme, String name, IconData icon, Color color) {
+Widget _conditionChip(ThemeData theme, String name, IconData icon, Color color) {
   return Padding(
     padding: const EdgeInsets.only(bottom: 8),
     child: Row(


### PR DESCRIPTION
Renamed the private helper function `_ConditionChip` to `_conditionChip` in `integration_test/app_test.dart` to adhere to Dart's `lowerCamelCase` naming convention. This change affects only the internal testing utility and improves code style consistency.

Fixes #381

---
*PR created automatically by Jules for task [6652999649563957248](https://jules.google.com/task/6652999649563957248) started by @iberi22*