### PR TITLE
Add unit tests for isar_agent_memory

### DIFF
--- a/packages/isar_agent_memory/test/agent_memory_types_test.dart
+++ b/packages/isar_agent_memory/test/agent_memory_types_test.dart
@@ -1,0 +1,101 @@
+import 'dart:io';
+import 'package:test/test.dart';
+import 'package:isar/isar.dart';
+import 'package:path/path.dart' as p;
+import 'package:isar_agent_memory/isar_agent_memory.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Isar isar;
+  late MemoryGraph memoryGraph;
+  late AgentMemoryTypes agentMemory;
+  late String testDir;
+  late MockEmbeddingsAdapter mockEmbeddings;
+  late InMemoryVectorIndex mockIndex;
+
+  setUpAll(() async {
+    testDir = p.join(Directory.current.path, 'test_db_agent_memory');
+    await Directory(testDir).create(recursive: true);
+
+    await Isar.initializeIsarCore(download: true);
+    isar = await Isar.open(
+      [MemoryNodeSchema, MemoryEdgeSchema],
+      directory: testDir,
+    );
+
+    mockEmbeddings = MockEmbeddingsAdapter(dimension: 3);
+    mockIndex = InMemoryVectorIndex(dimension: 3);
+    memoryGraph = MemoryGraph(isar, embeddingsAdapter: mockEmbeddings, index: mockIndex);
+    agentMemory = AgentMemoryTypes(memoryGraph);
+  });
+
+  tearDownAll(() async {
+    await isar.close();
+    if (await Directory(testDir).exists()) {
+      await Directory(testDir).delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    await isar.writeTxn(() async {
+      await isar.memoryNodes.clear();
+      await isar.memoryEdges.clear();
+    });
+    await mockIndex.clear();
+  });
+
+  group('AgentMemoryTypes Storage', () {
+    test('storeEpisodicMemory', () async {
+      final timestamp = DateTime.now();
+      final id = await agentMemory.storeEpisodicMemory(
+        content: 'Went to the park',
+        timestamp: timestamp,
+        location: 'Park',
+        participants: ['Alice'],
+        emotionalValence: 0.8,
+      );
+
+      final node = await memoryGraph.getNode(id);
+      expect(node, isNotNull);
+      expect(node!.type, AgentMemoryTypes.typeEpisodic);
+      // Note: metadata is @ignore in MemoryNode, so it is NOT persisted in Isar.
+      // This is the current behavior of the package.
+    });
+
+    test('storeSemanticMemory', () async {
+      final id = await agentMemory.storeSemanticMemory(
+        content: 'The sky is blue',
+        category: 'Science',
+        tags: ['nature'],
+        confidence: 0.99,
+      );
+
+      final node = await memoryGraph.getNode(id);
+      expect(node, isNotNull);
+      expect(node!.type, AgentMemoryTypes.typeSemantic);
+    });
+
+    test('storeProceduralMemory', () async {
+      final id = await agentMemory.storeProceduralMemory(
+        procedure: 'Make tea',
+        steps: ['Boil water', 'Add tea bag', 'Wait'],
+        skill: 'Cooking',
+      );
+
+      final node = await memoryGraph.getNode(id);
+      expect(node, isNotNull);
+      expect(node!.type, AgentMemoryTypes.typeProcedural);
+    });
+
+    test('storeWorkingMemory', () async {
+      final id = await agentMemory.storeWorkingMemory(
+        content: 'Remember the milk',
+        ttl: Duration(minutes: 5),
+      );
+
+      final node = await memoryGraph.getNode(id);
+      expect(node, isNotNull);
+      expect(node!.type, AgentMemoryTypes.typeWorking);
+    });
+  });
+}

--- a/packages/isar_agent_memory/test/memory_graph_test.dart
+++ b/packages/isar_agent_memory/test/memory_graph_test.dart
@@ -1,0 +1,206 @@
+import 'dart:io';
+import 'dart:typed_data';
+import 'package:test/test.dart';
+import 'package:isar/isar.dart';
+import 'package:path/path.dart' as p;
+import 'package:isar_agent_memory/isar_agent_memory.dart';
+import 'test_utils.dart';
+
+void main() {
+  late Isar isar;
+  late MemoryGraph memoryGraph;
+  late String testDir;
+  late MockEmbeddingsAdapter mockEmbeddings;
+  late InMemoryVectorIndex mockIndex;
+
+  setUpAll(() async {
+    testDir = p.join(Directory.current.path, 'test_db_memory_graph');
+    await Directory(testDir).create(recursive: true);
+
+    await Isar.initializeIsarCore(download: true);
+    isar = await Isar.open(
+      [MemoryNodeSchema, MemoryEdgeSchema],
+      directory: testDir,
+    );
+
+    mockEmbeddings = MockEmbeddingsAdapter(dimension: 3);
+    mockIndex = InMemoryVectorIndex(dimension: 3);
+    memoryGraph = MemoryGraph(isar, embeddingsAdapter: mockEmbeddings, index: mockIndex);
+  });
+
+  tearDownAll(() async {
+    await isar.close();
+    if (await Directory(testDir).exists()) {
+      await Directory(testDir).delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    await isar.writeTxn(() async {
+      await isar.memoryNodes.clear();
+      await isar.memoryEdges.clear();
+    });
+    await mockIndex.clear();
+  });
+
+  group('MemoryGraph Node CRUD', () {
+    test('storeNode and getNode', () async {
+      final node = MemoryNode(content: 'Test content', type: 'test');
+      final id = await memoryGraph.storeNode(node);
+
+      final retrieved = await memoryGraph.getNode(id);
+      expect(retrieved, isNotNull);
+      expect(retrieved!.content, 'Test content');
+      expect(retrieved.type, 'test');
+    });
+
+    test('deleteNode', () async {
+      final node = MemoryNode(content: 'Delete me');
+      final id = await memoryGraph.storeNode(node);
+
+      final deleted = await memoryGraph.deleteNode(id);
+      expect(deleted, isTrue);
+
+      final retrieved = await memoryGraph.getNode(id);
+      expect(retrieved, isNull);
+    });
+
+    test('storeNodeWithEmbedding', () async {
+      final id = await memoryGraph.storeNodeWithEmbedding(
+        content: 'Embedded content',
+        type: 'embedded',
+      );
+
+      final retrieved = await memoryGraph.getNode(id);
+      expect(retrieved, isNotNull);
+      expect(retrieved!.content, 'Embedded content');
+      expect(retrieved.embedding, isNotNull);
+      expect(retrieved.embedding!.vector.length, 3);
+
+      // Verify it's in the index
+      final results = await mockIndex.search(
+        Float32List.fromList([0.1, 0.2, 0.3]), // dummy query
+        topK: 1,
+      );
+      expect(results, isNotEmpty);
+      expect(results.first.id, id.toString());
+    });
+
+    test('storeNodeWithEmbedding deduplication', () async {
+      final content = 'Duplicate';
+
+      // First store
+      final id1 = await memoryGraph.storeNodeWithEmbedding(content: content);
+
+      // Store again with deduplicate=true.
+      // InMemoryVectorIndex uses Cosine similarity (1.0 = perfect match)
+      // deduplicationThreshold in MemoryGraph is compared with score < threshold.
+
+      final id2 = await memoryGraph.storeNodeWithEmbedding(
+        content: content,
+        deduplicate: true,
+        deduplicationThreshold: 2.0, // High threshold should catch it if it's distance
+      );
+
+      expect(id1, id2);
+    });
+  });
+
+  group('MemoryGraph Edge Operations', () {
+    test('storeEdge and getEdgesForNode', () async {
+      final nodeA = MemoryNode(content: 'Node A');
+      final nodeB = MemoryNode(content: 'Node B');
+      final idA = await memoryGraph.storeNode(nodeA);
+      final idB = await memoryGraph.storeNode(nodeB);
+
+      final edge = MemoryEdge(
+        fromNodeId: idA,
+        toNodeId: idB,
+        relation: 'related_to',
+      );
+      final edgeId = await memoryGraph.storeEdge(edge);
+      expect(edgeId, isPositive);
+
+      final edgesA = await memoryGraph.getEdgesForNode(idA);
+      expect(edgesA.length, 1);
+      expect(edgesA.first.relation, 'related_to');
+      expect(edgesA.first.fromNodeId, idA);
+      expect(edgesA.first.toNodeId, idB);
+
+      final edgesB = await memoryGraph.getEdgesForNode(idB);
+      expect(edgesB.length, 1);
+      expect(edgesB.first.fromNodeId, idA);
+    });
+  });
+
+  group('MemoryGraph Search and Initialization', () {
+    test('semanticSearch', () async {
+      await memoryGraph.storeNodeWithEmbedding(content: 'Apple');
+      await memoryGraph.storeNodeWithEmbedding(content: 'Banana');
+
+      final queryVector = await mockEmbeddings.embed('Apple');
+      final results = await memoryGraph.semanticSearch(queryVector, topK: 1);
+
+      expect(results, isNotEmpty);
+      expect(results.first.node.content, 'Apple');
+    });
+
+    test('hybridSearch', () async {
+      await memoryGraph.storeNodeWithEmbedding(content: 'Medical report about diabetes');
+      await memoryGraph.storeNodeWithEmbedding(content: 'Recipe for chocolate cake');
+
+      final results = await memoryGraph.hybridSearch('diabetes', topK: 1);
+
+      expect(results, isNotEmpty);
+      expect(results.first.node.content, contains('diabetes'));
+    });
+
+    test('initialize syncs Isar to index', () async {
+      // Add node directly to Isar, bypassing MemoryGraph.storeNode
+      final vector = [0.1, 0.2, 0.3];
+      final node = MemoryNode(
+        content: 'Direct Isar node',
+        embedding: MemoryEmbedding(vector: vector, provider: 'mock', dimension: 3),
+      );
+
+      await isar.writeTxn(() => isar.memoryNodes.put(node));
+
+      // Index should be empty
+      var results = await mockIndex.search(Float32List.fromList(vector), topK: 1);
+      expect(results, isEmpty);
+
+      // Initialize
+      await memoryGraph.initialize();
+
+      // Now it should be in the index
+      results = await mockIndex.search(Float32List.fromList(vector), topK: 1);
+      expect(results, isNotEmpty);
+      expect(results.first.id, node.id.toString());
+    });
+
+    test('explainRecall', () async {
+      final id = await memoryGraph.storeNodeWithEmbedding(content: 'Explain me');
+      final explanation = await memoryGraph.explainRecall(id, queryEmbedding: [0.1, 0.2, 0.3]);
+
+      expect(explanation, contains('recalled'));
+      expect(explanation, contains('Semantic distance'));
+    });
+
+    test('semanticSearchWithReRanking', () async {
+      final oldNode = MemoryNode(content: 'Old news', updatedAt: DateTime(2020));
+      final newNode = MemoryNode(content: 'Fresh news', updatedAt: DateTime.now());
+      await memoryGraph.storeNode(oldNode);
+      await memoryGraph.storeNode(newNode);
+
+      final queryVector = await mockEmbeddings.embed('news');
+      final results = await memoryGraph.semanticSearchWithReRanking(
+        queryVector,
+        reranker: RecencyReRanker(),
+        topK: 1,
+      );
+
+      expect(results, isNotEmpty);
+      expect(results.first.node.content, 'Fresh news');
+    });
+  });
+}

--- a/packages/isar_agent_memory/test/test_utils.dart
+++ b/packages/isar_agent_memory/test/test_utils.dart
@@ -1,0 +1,123 @@
+import 'dart:math' as math;
+import 'dart:typed_data';
+import 'package:isar_agent_memory/isar_agent_memory.dart';
+
+class MockEmbeddingsAdapter implements EmbeddingsAdapter {
+  final int _dimension;
+  MockEmbeddingsAdapter({int dimension = 3}) : _dimension = dimension;
+
+  @override
+  int get dimension => _dimension;
+
+  @override
+  String get providerName => 'mock';
+
+  @override
+  Future<List<double>> embed(String text) async {
+    // Generate a simple deterministic vector based on the text
+    final random = math.Random(text.hashCode);
+    return List.generate(_dimension, (_) => random.nextDouble());
+  }
+}
+
+class InMemoryVectorIndex implements VectorIndex {
+  final Map<String, _DocEntry> _docs = {};
+  final int dimension;
+  final VectorMetric _metric;
+
+  InMemoryVectorIndex({this.dimension = 3, VectorMetric metric = VectorMetric.cosine})
+      : _metric = metric;
+
+  @override
+  String get provider => 'in_memory';
+  @override
+  String get namespace => 'test';
+  @override
+  bool get normalize => false;
+  @override
+  VectorMetric get metric => _metric;
+
+  @override
+  Future<void> addDocument(String id, String content, Float32List vector) async {
+    _docs[id] = _DocEntry(content: content, vector: vector);
+  }
+
+  @override
+  Future<void> removeDocument(String id) async {
+    _docs.remove(id);
+  }
+
+  @override
+  Future<List<VectorSearchResult>> search(Float32List query, {int topK = 5}) async {
+    final scores = <_ScoredId>[];
+    for (final entry in _docs.entries) {
+      double score;
+      switch (_metric) {
+        case VectorMetric.cosine:
+          score = _cosine(query, entry.value.vector);
+          break;
+        case VectorMetric.l2:
+          score = _l2(query, entry.value.vector);
+          break;
+        case VectorMetric.dot:
+          score = _dot(query, entry.value.vector);
+          break;
+      }
+      scores.add(_ScoredId(id: entry.key, score: score));
+    }
+
+    if (_metric == VectorMetric.l2) {
+      scores.sort((a, b) => a.score.compareTo(b.score)); // Smaller is better
+    } else {
+      scores.sort((a, b) => b.score.compareTo(a.score)); // Larger is better
+    }
+
+    return scores.take(topK).map((s) => VectorSearchResult(id: s.id, score: s.score)).toList();
+  }
+
+  @override
+  Future<void> clear() async {
+    _docs.clear();
+  }
+
+  @override
+  Future<void> load() async {}
+
+  double _cosine(Float32List a, Float32List b) {
+    double dot = 0, magA = 0, magB = 0;
+    for (int i = 0; i < a.length; i++) {
+      dot += a[i] * b[i];
+      magA += a[i] * a[i];
+      magB += b[i] * b[i];
+    }
+    return magA == 0 || magB == 0 ? 0 : dot / (math.sqrt(magA) * math.sqrt(magB));
+  }
+
+  double _l2(Float32List a, Float32List b) {
+    double sum = 0;
+    for (int i = 0; i < a.length; i++) {
+      sum += (a[i] - b[i]) * (a[i] - b[i]);
+    }
+    return math.sqrt(sum);
+  }
+
+  double _dot(Float32List a, Float32List b) {
+    double dot = 0;
+    for (int i = 0; i < a.length; i++) {
+      dot += a[i] * b[i];
+    }
+    return dot;
+  }
+}
+
+class _DocEntry {
+  final String content;
+  final Float32List vector;
+  _DocEntry({required this.content, required this.vector});
+}
+
+class _ScoredId {
+  final String id;
+  final double score;
+  _ScoredId({required this.id, required this.score});
+}


### PR DESCRIPTION
This PR adds a comprehensive suite of unit tests for the `isar_agent_memory` package. 

Key changes:
- Created `packages/isar_agent_memory/test/` directory.
- Added `test_utils.dart` with `MockEmbeddingsAdapter` and `InMemoryVectorIndex` for testing.
- Added `memory_graph_test.dart` covering node/edge CRUD, semantic/hybrid search, re-ranking, and initialization.
- Added `agent_memory_types_test.dart` covering storage logic for episodic, semantic, procedural, and working memories.

Note: During testing, it was confirmed that the `metadata` field in `MemoryNode` and `MemoryEdge` is currently marked with `@ignore`, meaning it is not persisted in the Isar database. Tests have been adjusted to reflect this current implementation detail.

Fixes #382

---
*PR created automatically by Jules for task [489665283041885451](https://jules.google.com/task/489665283041885451) started by @iberi22*