### PR TITLE
Replace deprecated RadioListTile properties with RadioGroup

### DIFF
--- a/integration_test/health_sharing_e2e_test.dart
+++ b/integration_test/health_sharing_e2e_test.dart
@@ -325,12 +325,16 @@ class _MockSharePage extends StatelessWidget {
             ),
             const SizedBox(height: 16),
             Card(
-              child: Column(
-                children: [
-                  RadioListTile(title: Text('NFC'), subtitle: Text('Tap phones to share'), value: 0, groupValue: -1, onChanged: (_) {}),
-                  RadioListTile(title: Text('Bluetooth'), subtitle: Text('Nearby device'), value: 1, groupValue: -1, onChanged: (_) {}),
-                  RadioListTile(title: Text('WiFi Direct'), subtitle: Text('Same network'), value: 2, groupValue: -1, onChanged: (_) {}),
-                ],
+              child: RadioGroup<int>(
+                groupValue: -1,
+                onChanged: (_) {},
+                child: Column(
+                  children: const [
+                    RadioListTile(title: Text('NFC'), subtitle: Text('Tap phones to share'), value: 0),
+                    RadioListTile(title: Text('Bluetooth'), subtitle: Text('Nearby device'), value: 1),
+                    RadioListTile(title: Text('WiFi Direct'), subtitle: Text('Same network'), value: 2),
+                  ],
+                ),
               ),
             ),
           ],
@@ -393,30 +397,28 @@ class _MockSharePageWithStateState extends State<_MockSharePageWithState> {
             ),
             const SizedBox(height: 16),
             Card(
-              child: Column(
-                children: [
-                  RadioListTile(
-                    title: Text('NFC'),
-                    subtitle: Text('Tap phones to share'),
-                    value: 0,
-                    groupValue: _selectedMethod,
-                    onChanged: (v) => setState(() => _selectedMethod = v ?? 0),
-                  ),
-                  RadioListTile(
-                    title: Text('Bluetooth'),
-                    subtitle: Text('Nearby device'),
-                    value: 1,
-                    groupValue: _selectedMethod,
-                    onChanged: (v) => setState(() => _selectedMethod = v ?? 0),
-                  ),
-                  RadioListTile(
-                    title: Text('WiFi Direct'),
-                    subtitle: Text('Same network'),
-                    value: 2,
-                    groupValue: _selectedMethod,
-                    onChanged: (v) => setState(() => _selectedMethod = v ?? 0),
-                  ),
-                ],
+              child: RadioGroup<int>(
+                groupValue: _selectedMethod,
+                onChanged: (v) => setState(() => _selectedMethod = v ?? 0),
+                child: Column(
+                  children: const [
+                    RadioListTile(
+                      title: Text('NFC'),
+                      subtitle: Text('Tap phones to share'),
+                      value: 0,
+                    ),
+                    RadioListTile(
+                      title: Text('Bluetooth'),
+                      subtitle: Text('Nearby device'),
+                      value: 1,
+                    ),
+                    RadioListTile(
+                      title: Text('WiFi Direct'),
+                      subtitle: Text('Same network'),
+                      value: 2,
+                    ),
+                  ],
+                ),
               ),
             ),
             const SizedBox(height: 16),

--- a/lib/features/health_sharing/presentation/pages/share_page.dart
+++ b/lib/features/health_sharing/presentation/pages/share_page.dart
@@ -127,19 +127,23 @@ class _SharePageContentState extends State<_SharePageContent> {
               style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold),
             ),
             const SizedBox(height: 12),
-            ...TransferMethod.values.map((method) {
-              return RadioListTile<TransferMethod>(
-                title: Text(method.displayName),
-                subtitle: Text(method.description),
-                value: method,
-                groupValue: _selectedMethod,
-                onChanged: (value) {
-                  if (value != null) {
-                    setState(() => _selectedMethod = value);
-                  }
-                },
-              );
-            }),
+            RadioGroup<TransferMethod>(
+              groupValue: _selectedMethod,
+              onChanged: (value) {
+                if (value != null) {
+                  setState(() => _selectedMethod = value);
+                }
+              },
+              child: Column(
+                children: TransferMethod.values.map((method) {
+                  return RadioListTile<TransferMethod>(
+                    title: Text(method.displayName),
+                    subtitle: Text(method.description),
+                    value: method,
+                  );
+                }).toList(),
+              ),
+            ),
           ],
         ),
       ),

--- a/lib/features/local_agent/presentation/pages/llm_settings_page.dart
+++ b/lib/features/local_agent/presentation/pages/llm_settings_page.dart
@@ -106,13 +106,17 @@ class _LlmSettingsPageState extends State<LlmSettingsPage> {
       children: [
         const Text('LLM Provider', style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: CyberTheme.primary)),
         const SizedBox(height: 16),
-        ...LlmProvider.values.map((provider) => RadioListTile<LlmProvider>(
-          title: Text(provider.name.toUpperCase()),
-          value: provider,
+        RadioGroup<LlmProvider>(
           groupValue: _selectedProvider,
           onChanged: (val) => val != null ? _saveProvider(val) : null,
-          activeColor: CyberTheme.primary,
-        )),
+          child: Column(
+            children: LlmProvider.values.map((provider) => RadioListTile<LlmProvider>(
+              title: Text(provider.name.toUpperCase()),
+              value: provider,
+              activeColor: CyberTheme.primary,
+            )).toList(),
+          ),
+        ),
       ],
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
This change addresses the deprecation of `RadioListTile.groupValue` and `RadioListTile.onChanged` in Flutter 3.32+. It introduces the `RadioGroup` ancestor widget to manage the group value and change events, as recommended by the Flutter framework.

Modified files:
- `integration_test/health_sharing_e2e_test.dart`: Updated mock components `_MockSharePage` and `_MockSharePageWithState`.
- `lib/features/health_sharing/presentation/pages/share_page.dart`: Refactored the method selector to use `RadioGroup`.
- `lib/features/local_agent/presentation/pages/llm_settings_page.dart`: Refactored the provider selection to use `RadioGroup`.

Verification:
- Static analysis performed using `flutter analyze` on the affected files.
- Confirmed no remaining `deprecated_member_use` warnings for `RadioListTile.groupValue` or `RadioListTile.onChanged`.

Fixes #378

---
*PR created automatically by Jules for task [2993258282925491325](https://jules.google.com/task/2993258282925491325) started by @iberi22*