### PR TITLE
Add unit tests for Allergies domain and management

### DIFF
--- a/lib/features/allergies/domain/entities/allergy.dart
+++ b/lib/features/allergies/domain/entities/allergy.dart
@@ -25,4 +25,6 @@ class Allergy {
     this.severity = AllergySeverity.mild,
     this.notes,
   });
+
+  bool get isValid => allergen != null && allergen!.trim().isNotEmpty;
 }

--- a/lib/features/allergies/domain/services/allergy_service.dart
+++ b/lib/features/allergies/domain/services/allergy_service.dart
@@ -1,0 +1,31 @@
+import 'package:injectable/injectable.dart';
+import '../entities/allergy.dart';
+import '../../../medications/domain/entities/medication.dart';
+
+@lazySingleton
+class AllergyService {
+  /// Checks for interaction between an allergy and a medication.
+  /// Returns true if the medication name or notes contain the allergen name.
+  bool checkInteraction(Allergy allergy, Medication medication) {
+    if (!allergy.isValid) return false;
+
+    final allergen = allergy.allergen!.toLowerCase().trim();
+    final medName = medication.name.toLowerCase();
+    final medNotes = medication.notes?.toLowerCase() ?? '';
+
+    return medName.contains(allergen) || medNotes.contains(allergen);
+  }
+
+  /// Returns a numeric severity level for an allergy.
+  /// 1: Mild, 2: Moderate, 3: Severe
+  int getSeverityLevel(AllergySeverity severity) {
+    switch (severity) {
+      case AllergySeverity.mild:
+        return 1;
+      case AllergySeverity.moderate:
+        return 2;
+      case AllergySeverity.severe:
+        return 3;
+    }
+  }
+}

--- a/test/features/allergies/domain/entities/allergy_test.dart
+++ b/test/features/allergies/domain/entities/allergy_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
+import 'package:isar/isar.dart';
+
+void main() {
+  group('Allergy Entity', () {
+    test('should create an Allergy with default values', () {
+      final allergy = Allergy();
+
+      expect(allergy.id, equals(Isar.autoIncrement));
+      expect(allergy.allergen, isNull);
+      expect(allergy.severity, equals(AllergySeverity.mild));
+      expect(allergy.notes, isNull);
+    });
+
+    test('should create an Allergy with provided values', () {
+      final allergy = Allergy(
+        id: 1,
+        allergen: 'Penicillin',
+        severity: AllergySeverity.severe,
+        notes: 'Anaphylaxis risk',
+      );
+
+      expect(allergy.id, equals(1));
+      expect(allergy.allergen, equals('Penicillin'));
+      expect(allergy.severity, equals(AllergySeverity.severe));
+      expect(allergy.notes, equals('Anaphylaxis risk'));
+    });
+
+    group('isValid', () {
+      test('should return false if allergen is null', () {
+        final allergy = Allergy(allergen: null);
+        expect(allergy.isValid, isFalse);
+      });
+
+      test('should return false if allergen is empty', () {
+        final allergy = Allergy(allergen: '');
+        expect(allergy.isValid, isFalse);
+      });
+
+      test('should return false if allergen is only whitespace', () {
+        final allergy = Allergy(allergen: '   ');
+        expect(allergy.isValid, isFalse);
+      });
+
+      test('should return true if allergen is provided', () {
+        final allergy = Allergy(allergen: 'Peanuts');
+        expect(allergy.isValid, isTrue);
+      });
+    });
+   group('AllergySeverity Enum', () {
+      test('AllergySeverity should have correct values', () {
+        expect(AllergySeverity.values.length, 3);
+        expect(AllergySeverity.mild.index, 0);
+        expect(AllergySeverity.moderate.index, 1);
+        expect(AllergySeverity.severe.index, 2);
+      });
+    });
+  });
+}

--- a/test/features/allergies/domain/services/allergy_service_test.dart
+++ b/test/features/allergies/domain/services/allergy_service_test.dart
@@ -1,0 +1,61 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
+import 'package:orionhealth_health/features/allergies/domain/services/allergy_service.dart';
+import 'package:orionhealth_health/features/medications/domain/entities/medication.dart';
+
+void main() {
+  late AllergyService allergyService;
+
+  setUp(() {
+    allergyService = AllergyService();
+  });
+
+  group('AllergyService', () {
+    group('checkInteraction', () {
+      final medication = Medication(
+        name: 'Amoxicillin Capsule',
+        startDate: DateTime.now(),
+        notes: 'Take with food. Contains penicillin derivatives.',
+      );
+
+      test('should return true when medication name contains allergen', () {
+        final allergy = Allergy(allergen: 'Amoxicillin');
+        expect(allergyService.checkInteraction(allergy, medication), isTrue);
+      });
+
+      test('should return true when medication name contains allergen (case insensitive)', () {
+        final allergy = Allergy(allergen: 'amoxicillin');
+        expect(allergyService.checkInteraction(allergy, medication), isTrue);
+      });
+
+      test('should return true when medication notes contain allergen', () {
+        final allergy = Allergy(allergen: 'penicillin');
+        expect(allergyService.checkInteraction(allergy, medication), isTrue);
+      });
+
+      test('should return false when no interaction is found', () {
+        final allergy = Allergy(allergen: 'Aspirin');
+        expect(allergyService.checkInteraction(allergy, medication), isFalse);
+      });
+
+      test('should return false if allergy is invalid', () {
+        final allergy = Allergy(allergen: '');
+        expect(allergyService.checkInteraction(allergy, medication), isFalse);
+      });
+    });
+
+    group('getSeverityLevel', () {
+      test('should return 1 for mild', () {
+        expect(allergyService.getSeverityLevel(AllergySeverity.mild), equals(1));
+      });
+
+      test('should return 2 for moderate', () {
+        expect(allergyService.getSeverityLevel(AllergySeverity.moderate), equals(2));
+      });
+
+      test('should return 3 for severe', () {
+        expect(allergyService.getSeverityLevel(AllergySeverity.severe), equals(3));
+      });
+    });
+  });
+}

--- a/test/features/allergies/infrastructure/repositories/isar_allergy_repository_test.dart
+++ b/test/features/allergies/infrastructure/repositories/isar_allergy_repository_test.dart
@@ -1,0 +1,102 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
+import 'package:orionhealth_health/features/allergies/infrastructure/repositories/isar_allergy_repository.dart';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Isar isar;
+  late IsarAllergyRepository repository;
+  late String testDir;
+
+  setUpAll(() async {
+    testDir = p.join(Directory.current.path, 'test_db_allergies');
+    await Directory(testDir).create(recursive: true);
+
+    await Isar.initializeIsarCore(download: true);
+    isar = await Isar.open(
+      [AllergySchema],
+      directory: testDir,
+    );
+    repository = IsarAllergyRepository(isar);
+  });
+
+  tearDownAll(() async {
+    await isar.close();
+    if (await Directory(testDir).exists()) {
+      await Directory(testDir).delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    await isar.writeTxn(() => isar.allergys.clear());
+  });
+
+  group('IsarAllergyRepository', () {
+    test('Should save and retrieve an allergy', () async {
+      final allergy = Allergy(
+        allergen: 'Peanuts',
+        severity: AllergySeverity.severe,
+        notes: 'Strict avoidance',
+      );
+
+      await repository.saveAllergy(allergy);
+
+      final allergies = await repository.getAllergies();
+      expect(allergies.length, 1);
+      expect(allergies.first.allergen, 'Peanuts');
+      expect(allergies.first.severity, AllergySeverity.severe);
+      expect(allergies.first.notes, 'Strict avoidance');
+    });
+
+    test('Should update an existing allergy', () async {
+      final allergy = Allergy(
+        allergen: 'Pollen',
+        severity: AllergySeverity.mild,
+      );
+
+      await repository.saveAllergy(allergy);
+
+      final savedAllergies = await repository.getAllergies();
+      final savedAllergy = savedAllergies.first;
+
+      savedAllergy.severity = AllergySeverity.moderate;
+      savedAllergy.notes = 'Getting worse';
+
+      await repository.saveAllergy(savedAllergy);
+
+      final updatedAllergies = await repository.getAllergies();
+      expect(updatedAllergies.length, 1);
+      expect(updatedAllergies.first.id, savedAllergy.id);
+      expect(updatedAllergies.first.severity, AllergySeverity.moderate);
+      expect(updatedAllergies.first.notes, 'Getting worse');
+    });
+
+    test('Should delete an allergy', () async {
+      final allergy = Allergy(
+        allergen: 'Dust',
+        severity: AllergySeverity.mild,
+      );
+
+      await repository.saveAllergy(allergy);
+      var allergies = await repository.getAllergies();
+      expect(allergies.length, 1);
+
+      await repository.deleteAllergy(allergies.first.id);
+      allergies = await repository.getAllergies();
+      expect(allergies.isEmpty, true);
+    });
+
+    test('Should return multiple allergies', () async {
+      await repository.saveAllergy(Allergy(allergen: 'A1'));
+      await repository.saveAllergy(Allergy(allergen: 'A2'));
+      await repository.saveAllergy(Allergy(allergen: 'A3'));
+
+      final allergies = await repository.getAllergies();
+      expect(allergies.length, 3);
+      final names = allergies.map((a) => a.allergen).toList();
+      expect(names, containsAll(['A1', 'A2', 'A3']));
+    });
+  });
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the Allergies feature, as well as necessary domain logic for validation and medication interaction checks.

Key changes:
- Added `isValid` getter to `Allergy` entity to ensure allergen name is present.
- Implemented `AllergyService` with `checkInteraction` (case-insensitive keyword matching between allergens and medications) and `getSeverityLevel`.
- Added unit tests for:
  - `Allergy` entity: validation and default values.
  - `IsarAllergyRepository`: saving, updating, deleting, and listing allergies in a real Isar environment.
  - `AllergyService`: interaction logic and severity mapping.

Verified by running `flutter test test/features/allergies/` with all tests passing.

Fixes #392

---
*PR created automatically by Jules for task [7791875261012709955](https://jules.google.com/task/7791875261012709955) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced allergy validation to ensure complete allergen information
  * Added drug-allergy interaction detection to identify potential medication conflicts
  * Implemented severity level classification (mild, moderate, severe) for allergies

* **Tests**
  * Comprehensive test coverage added for allergy entities, interaction checking, and data persistence

<!-- end of auto-generated comment: release notes by coderabbit.ai -->