### PR TITLE
Extend Medical Research tests for drug interactions and analysis

### DIFF
--- a/test/features/medical_research/adapters_test.dart
+++ b/test/features/medical_research/adapters_test.dart
@@ -61,7 +61,34 @@ void main() {
 
       expect(results, isEmpty);
     });
-   group('FdaAdapter', () {
+
+    test('search handles malformed JSON response', () async {
+      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+          .thenAnswer((_) async => Response(
+                data: 'Not JSON',
+                statusCode: 200,
+                requestOptions: RequestOptions(path: ''),
+              ));
+
+      final results = await pubMedAdapter.search('diabetes');
+      expect(results, isEmpty);
+    });
+
+    test('search handles empty ID list', () async {
+      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+          .thenAnswer((_) async => Response(
+                data: {
+                  'esearchresult': {'idlist': []}
+                },
+                statusCode: 200,
+                requestOptions: RequestOptions(path: ''),
+              ));
+
+      final results = await pubMedAdapter.search('diabetes');
+      expect(results, isEmpty);
+    });
+
+    group('FdaAdapter', () {
     test('search returns results on success', () async {
       when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
           .thenAnswer((_) async => Response(
@@ -82,6 +109,36 @@ void main() {
       expect(results.length, 1);
       expect(results[0].title, 'Tylenol');
       expect(results[0].source, 'FDA (openFDA)');
+    });
+
+    test('search returns empty list on failure', () async {
+      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+          .thenThrow(DioException(requestOptions: RequestOptions(path: '')));
+
+      final results = await fdaAdapter.search('aspirin');
+
+      expect(results, isEmpty);
+    });
+
+    test('search handles missing results field', () async {
+      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+          .thenAnswer((_) async => Response(
+                data: {'error': 'not found'},
+                statusCode: 404,
+                requestOptions: RequestOptions(path: ''),
+              ));
+
+      final results = await fdaAdapter.search('unknown');
+      expect(results, isEmpty);
+    });
+  });
+
+  group('WhoAdapter', () {
+    test('search returns placeholder results', () async {
+      final whoAdapter = WhoAdapter(mockDio);
+      final results = await whoAdapter.search('covid');
+      expect(results, isNotEmpty);
+      expect(results.first.source, 'WHO');
     });
   });
 });

--- a/test/features/medical_research/drug_interaction_service_test.dart
+++ b/test/features/medical_research/drug_interaction_service_test.dart
@@ -1,0 +1,137 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:medical_standards/medical_standards.dart';
+import 'package:orionhealth_health/features/medical_research/infrastructure/medical_standards_service_impl.dart';
+
+class MockMedicalContextProvider extends Mock implements MedicalContextProvider {}
+
+void main() {
+  late MockMedicalContextProvider mockProvider;
+  late MedicalStandardsServiceImpl standardsService;
+
+  setUp(() {
+    mockProvider = MockMedicalContextProvider();
+    standardsService = MedicalStandardsServiceImpl(mockProvider);
+
+    when(() => mockProvider.isInitialized).thenReturn(true);
+    when(() => mockProvider.initialize()).thenAnswer((_) async => {});
+  });
+
+  group('MedicalStandardsService - Drug Interaction Analysis', () {
+    test('handles empty drug list', () async {
+      final interactions = await standardsService.checkDrugInteractions([]);
+      expect(interactions, isEmpty);
+    });
+
+    test('handles single drug (no interaction possible)', () async {
+      final warfarin = LocalRxnormEntry(code: '855332', displayName: 'Warfarin', drugClass: 'Anticoagulant');
+      when(() => mockProvider.getRxnormForCode('855332')).thenReturn(warfarin);
+
+      final interactions = await standardsService.checkDrugInteractions(['855332']);
+      expect(interactions, isEmpty);
+    });
+
+    test('handles unknown drug codes', () async {
+      when(() => mockProvider.getRxnormForCode('unknown')).thenReturn(null);
+
+      final interactions = await standardsService.checkDrugInteractions(['unknown', '855332']);
+      expect(interactions, isEmpty);
+    });
+
+    test('detects Major interaction: Warfarin + Aspirin', () async {
+      final warfarin = LocalRxnormEntry(code: '855332', displayName: 'Warfarin', drugClass: 'Anticoagulant');
+      final aspirin = LocalRxnormEntry(code: '1191', displayName: 'Aspirin', drugClass: 'NSAID');
+
+      when(() => mockProvider.getRxnormForCode('855332')).thenReturn(warfarin);
+      when(() => mockProvider.getRxnormForCode('1191')).thenReturn(aspirin);
+
+      final interactions = await standardsService.checkDrugInteractions(['855332', '1191']);
+
+      expect(interactions, hasLength(1));
+      expect(interactions.first, contains('Major Interaction'));
+      expect(interactions.first, contains('Warfarin + Aspirin'));
+    });
+
+    test('detects Moderate interaction: Lisinopril + Spironolactone', () async {
+      final lisinopril = LocalRxnormEntry(code: '1', displayName: 'Lisinopril', drugClass: 'ACE Inhibitor');
+      final spiro = LocalRxnormEntry(code: '2', displayName: 'Spironolactone', drugClass: 'Diuretic');
+
+      when(() => mockProvider.getRxnormForCode('1')).thenReturn(lisinopril);
+      when(() => mockProvider.getRxnormForCode('2')).thenReturn(spiro);
+
+      final interactions = await standardsService.checkDrugInteractions(['1', '2']);
+
+      expect(interactions, hasLength(1));
+      expect(interactions.first, contains('Moderate Interaction'));
+      expect(interactions.first, contains('ACE Inhibitor + Spironolactone'));
+    });
+
+    test('detects Moderate interaction: Metformin + Contrast Medium', () async {
+      final metformin = LocalRxnormEntry(code: 'M', displayName: 'Metformin', drugClass: 'Biguanide');
+      final contrast = LocalRxnormEntry(code: 'C', displayName: 'Contrast Medium', drugClass: 'Diagnostic');
+
+      when(() => mockProvider.getRxnormForCode('M')).thenReturn(metformin);
+      when(() => mockProvider.getRxnormForCode('C')).thenReturn(contrast);
+
+      final interactions = await standardsService.checkDrugInteractions(['M', 'C']);
+
+      expect(interactions, hasLength(1));
+      expect(interactions.first, contains('Moderate Interaction'));
+      expect(interactions.first, contains('Metformin + Contrast'));
+    });
+
+    test('detects Contraindicated: SSRI + MAOI classes', () async {
+      final fluoxetine = LocalRxnormEntry(code: '3', displayName: 'Fluoxetine', drugClass: 'SSRI');
+      final phenelzine = LocalRxnormEntry(code: '4', displayName: 'Phenelzine', drugClass: 'MAOI');
+
+      when(() => mockProvider.getRxnormForCode('3')).thenReturn(fluoxetine);
+      when(() => mockProvider.getRxnormForCode('4')).thenReturn(phenelzine);
+
+      final interactions = await standardsService.checkDrugInteractions(['3', '4']);
+
+      expect(interactions, hasLength(1));
+      expect(interactions.first, contains('Contraindicated'));
+      expect(interactions.first, contains('SSRI + MAOI'));
+    });
+
+    test('handles multi-drug scenarios (3+ medications)', () async {
+      // Warfarin (Anticoagulant), Aspirin (NSAID), and Ibuprofen (NSAID)
+      // Interactions:
+      // 1. Warfarin + Aspirin (Major)
+      // 2. Warfarin + Ibuprofen (Moderate, via class NSAID + Anticoagulant)
+
+      final warfarin = LocalRxnormEntry(code: 'W', displayName: 'Warfarin', drugClass: 'Anticoagulant');
+      final aspirin = LocalRxnormEntry(code: 'A', displayName: 'Aspirin', drugClass: 'NSAID');
+      final ibuprofen = LocalRxnormEntry(code: 'I', displayName: 'Ibuprofen', drugClass: 'NSAID');
+
+      when(() => mockProvider.getRxnormForCode('W')).thenReturn(warfarin);
+      when(() => mockProvider.getRxnormForCode('A')).thenReturn(aspirin);
+      when(() => mockProvider.getRxnormForCode('I')).thenReturn(ibuprofen);
+
+      final interactions = await standardsService.checkDrugInteractions(['W', 'A', 'I']);
+
+      // Interactions: Warfarin+Aspirin (Major) AND Warfarin+Ibuprofen (Moderate)
+      expect(interactions.length, equals(2));
+      expect(interactions.any((i) => i.contains('Major Interaction: Warfarin + Aspirin')), isTrue);
+      expect(interactions.any((i) => i.contains('Moderate Interaction: NSAID + Anticoagulant')), isTrue);
+    });
+
+    test('detects multiple distinct interactions in one list', () async {
+      final warfarin = LocalRxnormEntry(code: 'W', displayName: 'Warfarin', drugClass: 'Anticoagulant');
+      final aspirin = LocalRxnormEntry(code: 'A', displayName: 'Aspirin', drugClass: 'NSAID');
+      final fluoxetine = LocalRxnormEntry(code: 'F', displayName: 'Fluoxetine', drugClass: 'SSRI');
+      final phenelzine = LocalRxnormEntry(code: 'P', displayName: 'Phenelzine', drugClass: 'MAOI');
+
+      when(() => mockProvider.getRxnormForCode('W')).thenReturn(warfarin);
+      when(() => mockProvider.getRxnormForCode('A')).thenReturn(aspirin);
+      when(() => mockProvider.getRxnormForCode('F')).thenReturn(fluoxetine);
+      when(() => mockProvider.getRxnormForCode('P')).thenReturn(phenelzine);
+
+      final interactions = await standardsService.checkDrugInteractions(['W', 'A', 'F', 'P']);
+
+      // Should find Warfarin+Aspirin AND SSRI+MAOI
+      expect(interactions.any((i) => i.contains('Warfarin + Aspirin')), isTrue);
+      expect(interactions.any((i) => i.contains('SSRI + MAOI')), isTrue);
+    });
+  });
+}

--- a/test/features/medical_research/research_analysis_service_test.dart
+++ b/test/features/medical_research/research_analysis_service_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/medical_research/domain/models/research_result.dart';
+import 'package:orionhealth_health/features/medical_research/domain/services/medical_web_search_service.dart';
+import 'package:orionhealth_health/features/medical_research/domain/services/medical_scraper_service.dart';
+import 'package:orionhealth_health/features/medical_research/infrastructure/medical_research_service.dart';
+
+class MockMedicalWebSearchService extends Mock implements MedicalWebSearchService {}
+class MockMedicalScraperService extends Mock implements MedicalScraperService {}
+
+void main() {
+  late MockMedicalWebSearchService mockSearch;
+  late MockMedicalScraperService mockScraper;
+  late MedicalResearchService researchService;
+
+  setUp(() {
+    mockSearch = MockMedicalWebSearchService();
+    mockScraper = MockMedicalScraperService();
+    researchService = MedicalResearchService(mockSearch, mockScraper);
+
+    // Default: scraping returns null
+    when(() => mockScraper.scrape(any())).thenAnswer((_) async => null);
+  });
+
+  group('MedicalResearchService - Research Analysis', () {
+    test('performResearch returns results from search service', () async {
+      final searchResults = [
+        const ResearchResult(
+          title: 'Diabetes Overview',
+          content: 'Diabetes is a chronic condition...',
+          source: 'PubMed',
+          url: 'https://example.com/diabetes',
+        ),
+      ];
+
+      when(() => mockSearch.search('diabetes')).thenAnswer((_) async => searchResults);
+
+      final results = await researchService.performResearch('diabetes');
+
+      expect(results, equals(searchResults));
+      verify(() => mockSearch.search('diabetes')).called(1);
+    });
+
+    test('performResearch scrapes top result if it is a valid URL', () async {
+      final searchResults = [
+        const ResearchResult(
+          title: 'Top Result',
+          content: 'Initial content',
+          source: 'PubMed',
+          url: 'https://example.com/top',
+        ),
+        const ResearchResult(
+          title: 'Second Result',
+          content: 'Other content',
+          source: 'FDA',
+          url: 'https://example.com/second',
+        ),
+      ];
+
+      final detailedResult = const ResearchResult(
+        title: 'Top Result Detailed',
+        content: 'Much more detailed content from scraping',
+        source: 'example.com',
+        url: 'https://example.com/top',
+      );
+
+      when(() => mockSearch.search('fever')).thenAnswer((_) async => List.from(searchResults));
+      when(() => mockScraper.scrape('https://example.com/top')).thenAnswer((_) async => detailedResult);
+
+      final results = await researchService.performResearch('fever');
+
+      expect(results.length, 2);
+      expect(results[0].content, contains('detailed content'));
+      expect(results[0].title, 'Top Result Detailed');
+      expect(results[1].content, 'Other content');
+
+      verify(() => mockScraper.scrape('https://example.com/top')).called(1);
+    });
+
+    test('performResearch does not scrape if search results are empty', () async {
+      when(() => mockSearch.search('unknown')).thenAnswer((_) async => []);
+
+      final results = await researchService.performResearch('unknown');
+
+      expect(results, isEmpty);
+      verifyNever(() => mockScraper.scrape(any()));
+    });
+
+    test('performResearch returns original results if scraping fails', () async {
+      final searchResults = [
+        const ResearchResult(
+          title: 'Top Result',
+          content: 'Initial content',
+          source: 'PubMed',
+          url: 'https://example.com/top',
+        ),
+      ];
+
+      when(() => mockSearch.search('fever')).thenAnswer((_) async => List.from(searchResults));
+      when(() => mockScraper.scrape('https://example.com/top')).thenAnswer((_) async => null);
+
+      final results = await researchService.performResearch('fever');
+
+      expect(results.first.content, 'Initial content');
+    });
+
+    test('performResearch handles non-http URLs for scraping', () async {
+       final searchResults = [
+        const ResearchResult(
+          title: 'Local Info',
+          content: 'Some local info',
+          source: 'Internal',
+          url: 'internal://info',
+        ),
+      ];
+
+      when(() => mockSearch.search('info')).thenAnswer((_) async => searchResults);
+
+      final results = await researchService.performResearch('info');
+
+      expect(results, equals(searchResults));
+      verifyNever(() => mockScraper.scrape(any()));
+    });
+  });
+}


### PR DESCRIPTION
Extended the test suite for the medical research feature to cover drug interactions, research analysis orchestration, and API adapter edge cases.

Key changes:
- Created `drug_interaction_service_test.dart`: Validates the rule-based interaction engine in `MedicalStandardsService`. Tests include pairwise checks for multiple medications, unknown medication handling, and specific clinical severity levels (Major, Moderate, Contraindicated).
- Created `research_analysis_service_test.dart`: Tests `MedicalResearchService` for its ability to aggregate search results and conditionally scrape the top result for detailed content, while handling various failure modes.
- Updated `adapters_test.dart`: Added robust edge case testing for `PubMedAdapter` and `FdaAdapter`, including handling of malformed JSON, empty result sets from APIs, and network exceptions. Added a test for `WhoAdapter`.
- Verified that all 28 tests in the `medical_research` feature pass.

Fixes #389

---
*PR created automatically by Jules for task [17851572369541834085](https://jules.google.com/task/17851572369541834085) started by @iberi22*