### PR TITLE
Add comprehensive unit tests for Allergies feature

### DIFF
--- a/test/features/allergies/domain/entities/allergy_test.dart
+++ b/test/features/allergies/domain/entities/allergy_test.dart
@@ -47,14 +47,38 @@ void main() {
         final allergy = Allergy(allergen: 'Peanuts');
         expect(allergy.isValid, isTrue);
       });
+
+      test('should return true for allergen with special characters', () {
+        final allergy = Allergy(allergen: 'Pollen-123!');
+        expect(allergy.isValid, isTrue);
+      });
+
+      test('should return true for very long allergen name', () {
+        final allergy = Allergy(allergen: 'a' * 1000);
+        expect(allergy.isValid, isTrue);
+      });
+
+      test('should return false for allergen with only tabs and newlines', () {
+        final allergy = Allergy(allergen: '\t\n  ');
+        expect(allergy.isValid, isFalse);
+      });
     });
-   group('AllergySeverity Enum', () {
+
+    group('AllergySeverity Enum', () {
       test('AllergySeverity should have correct values', () {
         expect(AllergySeverity.values.length, 3);
         expect(AllergySeverity.mild.index, 0);
         expect(AllergySeverity.moderate.index, 1);
         expect(AllergySeverity.severe.index, 2);
       });
+    });
+
+    test('should support equality by reference (default Isar behavior)', () {
+      final allergy1 = Allergy(id: 1, allergen: 'Dust');
+      final allergy2 = Allergy(id: 1, allergen: 'Dust');
+
+      // Not using Equatable, so they should not be equal by value
+      expect(allergy1, isNot(equals(allergy2)));
     });
   });
 }

--- a/test/features/allergies/domain/services/allergy_service_test.dart
+++ b/test/features/allergies/domain/services/allergy_service_test.dart
@@ -1,46 +1,73 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
 import 'package:orionhealth_health/features/allergies/domain/services/allergy_service.dart';
 import 'package:orionhealth_health/features/medications/domain/entities/medication.dart';
 
+class MockMedication extends Mock implements Medication {}
+
 void main() {
   late AllergyService allergyService;
+  late MockMedication mockMedication;
 
   setUp(() {
     allergyService = AllergyService();
+    mockMedication = MockMedication();
   });
 
   group('AllergyService', () {
     group('checkInteraction', () {
-      final medication = Medication(
-        name: 'Amoxicillin Capsule',
-        startDate: DateTime.now(),
-        notes: 'Take with food. Contains penicillin derivatives.',
-      );
-
       test('should return true when medication name contains allergen', () {
         final allergy = Allergy(allergen: 'Amoxicillin');
-        expect(allergyService.checkInteraction(allergy, medication), isTrue);
+        when(() => mockMedication.name).thenReturn('Amoxicillin Capsule');
+        when(() => mockMedication.notes).thenReturn(null);
+
+        expect(allergyService.checkInteraction(allergy, mockMedication), isTrue);
       });
 
       test('should return true when medication name contains allergen (case insensitive)', () {
         final allergy = Allergy(allergen: 'amoxicillin');
-        expect(allergyService.checkInteraction(allergy, medication), isTrue);
+        when(() => mockMedication.name).thenReturn('AMOXICILLIN CAPSULE');
+        when(() => mockMedication.notes).thenReturn(null);
+
+        expect(allergyService.checkInteraction(allergy, mockMedication), isTrue);
       });
 
       test('should return true when medication notes contain allergen', () {
         final allergy = Allergy(allergen: 'penicillin');
-        expect(allergyService.checkInteraction(allergy, medication), isTrue);
+        when(() => mockMedication.name).thenReturn('Some Med');
+        when(() => mockMedication.notes).thenReturn('Contains penicillin derivatives.');
+
+        expect(allergyService.checkInteraction(allergy, mockMedication), isTrue);
       });
 
       test('should return false when no interaction is found', () {
         final allergy = Allergy(allergen: 'Aspirin');
-        expect(allergyService.checkInteraction(allergy, medication), isFalse);
+        when(() => mockMedication.name).thenReturn('Amoxicillin');
+        when(() => mockMedication.notes).thenReturn('Take with food');
+
+        expect(allergyService.checkInteraction(allergy, mockMedication), isFalse);
       });
 
       test('should return false if allergy is invalid', () {
         final allergy = Allergy(allergen: '');
-        expect(allergyService.checkInteraction(allergy, medication), isFalse);
+        expect(allergyService.checkInteraction(allergy, mockMedication), isFalse);
+      });
+
+      test('should return true for partial matches within words', () {
+        final allergy = Allergy(allergen: 'Sulfa');
+        when(() => mockMedication.name).thenReturn('Sulfamethoxazole');
+        when(() => mockMedication.notes).thenReturn(null);
+
+        expect(allergyService.checkInteraction(allergy, mockMedication), isTrue);
+      });
+
+      test('should handle allergen with leading/trailing whitespace', () {
+        final allergy = Allergy(allergen: '  penicillin  ');
+        when(() => mockMedication.name).thenReturn('Some Med');
+        when(() => mockMedication.notes).thenReturn('Contains penicillin');
+
+        expect(allergyService.checkInteraction(allergy, mockMedication), isTrue);
       });
     });
 

--- a/test/features/allergies/infrastructure/repositories/isar_allergy_repository_test.dart
+++ b/test/features/allergies/infrastructure/repositories/isar_allergy_repository_test.dart
@@ -11,7 +11,10 @@ void main() {
   late String testDir;
 
   setUpAll(() async {
-    testDir = p.join(Directory.current.path, 'test_db_allergies');
+    testDir = p.join(Directory.current.path, 'test_db_allergies_enhanced');
+    if (await Directory(testDir).exists()) {
+      await Directory(testDir).delete(recursive: true);
+    }
     await Directory(testDir).create(recursive: true);
 
     await Isar.initializeIsarCore(download: true);
@@ -34,6 +37,11 @@ void main() {
   });
 
   group('IsarAllergyRepository', () {
+    test('Should return an empty list when no allergies exist', () async {
+      final allergies = await repository.getAllergies();
+      expect(allergies, isEmpty);
+    });
+
     test('Should save and retrieve an allergy', () async {
       final allergy = Allergy(
         allergen: 'Peanuts',
@@ -50,10 +58,11 @@ void main() {
       expect(allergies.first.notes, 'Strict avoidance');
     });
 
-    test('Should update an existing allergy', () async {
+    test('Should update an existing allergy and persist all fields', () async {
       final allergy = Allergy(
         allergen: 'Pollen',
         severity: AllergySeverity.mild,
+        notes: 'Initial note',
       );
 
       await repository.saveAllergy(allergy);
@@ -61,16 +70,18 @@ void main() {
       final savedAllergies = await repository.getAllergies();
       final savedAllergy = savedAllergies.first;
 
+      savedAllergy.allergen = 'Updated Pollen';
       savedAllergy.severity = AllergySeverity.moderate;
-      savedAllergy.notes = 'Getting worse';
+      savedAllergy.notes = 'Updated note';
 
       await repository.saveAllergy(savedAllergy);
 
       final updatedAllergies = await repository.getAllergies();
       expect(updatedAllergies.length, 1);
       expect(updatedAllergies.first.id, savedAllergy.id);
+      expect(updatedAllergies.first.allergen, 'Updated Pollen');
       expect(updatedAllergies.first.severity, AllergySeverity.moderate);
-      expect(updatedAllergies.first.notes, 'Getting worse');
+      expect(updatedAllergies.first.notes, 'Updated note');
     });
 
     test('Should delete an allergy', () async {
@@ -88,15 +99,26 @@ void main() {
       expect(allergies.isEmpty, true);
     });
 
-    test('Should return multiple allergies', () async {
-      await repository.saveAllergy(Allergy(allergen: 'A1'));
-      await repository.saveAllergy(Allergy(allergen: 'A2'));
-      await repository.saveAllergy(Allergy(allergen: 'A3'));
+    test('Should not fail when deleting a non-existent allergy ID', () async {
+      await expectLater(repository.deleteAllergy(999), completes);
+    });
+
+    test('Should return multiple allergies and maintain their order/data', () async {
+      await repository.saveAllergy(Allergy(allergen: 'A1', severity: AllergySeverity.mild));
+      await repository.saveAllergy(Allergy(allergen: 'A2', severity: AllergySeverity.moderate));
+      await repository.saveAllergy(Allergy(allergen: 'A3', severity: AllergySeverity.severe));
 
       final allergies = await repository.getAllergies();
       expect(allergies.length, 3);
-      final names = allergies.map((a) => a.allergen).toList();
-      expect(names, containsAll(['A1', 'A2', 'A3']));
+
+      final a1 = allergies.firstWhere((a) => a.allergen == 'A1');
+      expect(a1.severity, AllergySeverity.mild);
+
+      final a2 = allergies.firstWhere((a) => a.allergen == 'A2');
+      expect(a2.severity, AllergySeverity.moderate);
+
+      final a3 = allergies.firstWhere((a) => a.allergen == 'A3');
+      expect(a3.severity, AllergySeverity.severe);
     });
   });
 }


### PR DESCRIPTION
I have enhanced the unit testing suite for the Allergies feature to ensure comprehensive coverage of domain logic and infrastructure operations.

### Changes:
- **Domain Entities**: In `allergy_test.dart`, I added test cases for validating the `allergen` name, including handling of special characters, very long strings, and various whitespace configurations. I also verified the default values and enum indices for `AllergySeverity`.
- **Domain Services**: In `allergy_service_test.dart`, I migrated the tests to use `mocktail` for mocking `Medication` dependencies. I expanded the interaction check tests to include case-insensitive matches, partial matches within words, and matches within medication notes.
- **Infrastructure Repositories**: In `isar_allergy_repository_test.dart`, I strengthened the CRUD tests by verifying behavior with empty databases, ensuring that all fields (allergen, severity, notes) are correctly persisted during updates, and confirming that deleting non-existent IDs does not cause errors. I also ensured strict test isolation by clearing the Isar collection in the `setUp` block.

All 27 tests in the `test/features/allergies/` directory pass successfully.

Fixes #406

---
*PR created automatically by Jules for task [12416240268930721864](https://jules.google.com/task/12416240268930721864) started by @iberi22*