### PR TITLE
Port OpenMed EntitySpan to Dart: pii_entity.dart

### DIFF
--- a/lib/core/medical/pii_entity.dart
+++ b/lib/core/medical/pii_entity.dart
@@ -1,0 +1,194 @@
+// Copyright 2024 OrionHealth
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+import 'package:equatable/equatable.dart';
+
+/// Represents a detected PII/PHI entity with its position, confidence, and metadata.
+/// Ported from OpenMed (Python/Swift) Apache 2.0.
+class PiiEntity extends Equatable {
+  final String label;
+  final String text;
+  final double confidence;
+  final int start;
+  final int end;
+  final String source; // 'regex', 'model', 'context'
+
+  const PiiEntity({
+    required this.label,
+    required this.text,
+    required this.confidence,
+    required this.start,
+    required this.end,
+    required this.source,
+  });
+
+  factory PiiEntity.fromJson(Map<String, dynamic> json) {
+    return PiiEntity(
+      label: json['label'] as String,
+      text: json['text'] as String,
+      confidence: (json['confidence'] as num).toDouble(),
+      start: json['start'] as int,
+      end: json['end'] as int,
+      source: json['source'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'label': label,
+      'text': text,
+      'confidence': confidence,
+      'start': start,
+      'end': end,
+      'source': source,
+    };
+  }
+
+  @override
+  List<Object?> get props => [label, text, confidence, start, end, source];
+
+  /// Merges this entity with another, taking the union of spans and max confidence.
+  /// Assumes the entities are overlapping or adjacent.
+  PiiEntity merge(PiiEntity other, String originalText) {
+    final newStart = start < other.start ? start : other.start;
+    final newEnd = end > other.end ? end : other.end;
+    return PiiEntity(
+      label: label == other.label ? label : '$label,${other.label}',
+      text: originalText.substring(newStart, newEnd),
+      confidence: confidence > other.confidence ? confidence : other.confidence,
+      start: newStart,
+      end: newEnd,
+      source: source == other.source ? source : 'merger',
+    );
+  }
+
+  /// Checks if this entity overlaps with another.
+  bool overlaps(PiiEntity other) {
+    return (start < other.end && other.start < end);
+  }
+}
+
+/// Represents a match from a regex-based PII detection.
+class PiiMatch extends Equatable {
+  final String label;
+  final String text;
+  final int start;
+  final int end;
+
+  const PiiMatch({
+    required this.label,
+    required this.text,
+    required this.start,
+    required this.end,
+  });
+
+  PiiEntity toEntity({double confidence = 1.0, String source = 'regex'}) {
+    return PiiEntity(
+      label: label,
+      text: text,
+      confidence: confidence,
+      start: start,
+      end: end,
+      source: source,
+    );
+  }
+
+  @override
+  List<Object?> get props => [label, text, start, end];
+}
+
+/// Represents a collection of detected PII entities and provides utilities for processing them.
+class PiiResult extends Equatable {
+  final List<PiiEntity> entities;
+  final String originalText;
+
+  const PiiResult({
+    required this.entities,
+    required this.originalText,
+  });
+
+  String get scrubbedText {
+    if (entities.isEmpty) return originalText;
+
+    final sorted = sortedByPosition();
+    final buffer = StringBuffer();
+    int lastEnd = 0;
+
+    for (final entity in sorted) {
+      if (entity.start < lastEnd) continue; // Skip overlapping
+      buffer.write(originalText.substring(lastEnd, entity.start));
+      buffer.write('[${entity.label.toUpperCase()}]');
+      lastEnd = entity.end;
+    }
+    buffer.write(originalText.substring(lastEnd));
+
+    return buffer.toString();
+  }
+
+  List<PiiEntity> sortedByPosition() {
+    final list = List<PiiEntity>.from(entities);
+    list.sort((a, b) => a.start.compareTo(b.start));
+    return list;
+  }
+
+  List<PiiEntity> sortedByConfidence() {
+    final list = List<PiiEntity>.from(entities);
+    list.sort((a, b) => b.confidence.compareTo(a.confidence));
+    return list;
+  }
+
+  PiiResult mergeOverlapping() {
+    if (entities.isEmpty) return this;
+
+    final sorted = sortedByPosition();
+    final merged = <PiiEntity>[];
+
+    if (sorted.isEmpty) return this;
+
+    PiiEntity current = sorted.first;
+
+    for (int i = 1; i < sorted.length; i++) {
+      final next = sorted[i];
+      if (current.overlaps(next)) {
+        current = current.merge(next, originalText);
+      } else {
+        merged.add(current);
+        current = next;
+      }
+    }
+    merged.add(current);
+
+    return PiiResult(entities: merged, originalText: originalText);
+  }
+
+  factory PiiResult.fromJson(Map<String, dynamic> json) {
+    return PiiResult(
+      entities: (json['entities'] as List)
+          .map((e) => PiiEntity.fromJson(e as Map<String, dynamic>))
+          .toList(),
+      originalText: json['originalText'] as String,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'entities': entities.map((e) => e.toJson()).toList(),
+      'originalText': originalText,
+      'scrubbedText': scrubbedText,
+    };
+  }
+
+  @override
+  List<Object?> get props => [entities, originalText];
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -197,10 +197,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1118,18 +1118,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1578,10 +1578,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/core/medical/pii_entity_test.dart
+++ b/test/core/medical/pii_entity_test.dart
@@ -1,0 +1,178 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/medical/pii_entity.dart';
+
+void main() {
+  group('PiiEntity', () {
+    test('toJson/fromJson works correctly', () {
+      const entity = PiiEntity(
+        label: 'person',
+        text: 'John Doe',
+        confidence: 0.95,
+        start: 0,
+        end: 8,
+        source: 'model',
+      );
+
+      final json = entity.toJson();
+      final fromJson = PiiEntity.fromJson(json);
+
+      expect(fromJson, entity);
+    });
+
+    test('overlaps detects overlapping spans', () {
+      const e1 = PiiEntity(
+        label: 'person',
+        text: 'John',
+        confidence: 0.9,
+        start: 0,
+        end: 4,
+        source: 'model',
+      );
+      const e2 = PiiEntity(
+        label: 'person',
+        text: 'ohn',
+        confidence: 0.8,
+        start: 1,
+        end: 4,
+        source: 'model',
+      );
+      const e3 = PiiEntity(
+        label: 'person',
+        text: 'Doe',
+        confidence: 0.9,
+        start: 5,
+        end: 8,
+        source: 'model',
+      );
+
+      expect(e1.overlaps(e2), isTrue);
+      expect(e1.overlaps(e3), isFalse);
+    });
+
+    test('merge combines overlapping entities', () {
+      const originalText = 'John Doe is here';
+      const e1 = PiiEntity(
+        label: 'person',
+        text: 'John',
+        confidence: 0.9,
+        start: 0,
+        end: 4,
+        source: 'model',
+      );
+      const e2 = PiiEntity(
+        label: 'person',
+        text: 'ohn Doe',
+        confidence: 0.95,
+        start: 1,
+        end: 8,
+        source: 'model',
+      );
+
+      final merged = e1.merge(e2, originalText);
+
+      expect(merged.start, 0);
+      expect(merged.end, 8);
+      expect(merged.text, 'John Doe');
+      expect(merged.confidence, 0.95);
+    });
+  });
+
+  group('PiiMatch', () {
+    test('toEntity converts match correctly', () {
+      const match = PiiMatch(
+        label: 'email',
+        text: 'test@example.com',
+        start: 10,
+        end: 26,
+      );
+
+      final entity = match.toEntity(confidence: 1.0, source: 'regex');
+
+      expect(entity.label, 'email');
+      expect(entity.text, 'test@example.com');
+      expect(entity.start, 10);
+      expect(entity.end, 26);
+      expect(entity.confidence, 1.0);
+      expect(entity.source, 'regex');
+    });
+  });
+
+  group('PiiResult', () {
+    const originalText = 'My name is John Doe and my email is john@example.com';
+    final entities = [
+      const PiiEntity(
+        label: 'person',
+        text: 'John Doe',
+        confidence: 0.9,
+        start: 11,
+        end: 19,
+        source: 'model',
+      ),
+      const PiiEntity(
+        label: 'email',
+        text: 'john@example.com',
+        confidence: 1.0,
+        start: 36,
+        end: 52,
+        source: 'regex',
+      ),
+    ];
+
+    test('scrubbedText replaces entities with labels', () {
+      final result = PiiResult(entities: entities, originalText: originalText);
+      expect(
+        result.scrubbedText,
+        'My name is [PERSON] and my email is [EMAIL]',
+      );
+    });
+
+    test('sortedByPosition sorts by start index', () {
+      final result = PiiResult(
+        entities: entities.reversed.toList(),
+        originalText: originalText,
+      );
+      final sorted = result.sortedByPosition();
+
+      expect(sorted[0].start, 11);
+      expect(sorted[1].start, 36);
+    });
+
+    test('mergeOverlapping merges overlapping entities', () {
+      const text = 'Alice Smith';
+      final overlapping = [
+        const PiiEntity(
+          label: 'person',
+          text: 'Alice',
+          confidence: 0.9,
+          start: 0,
+          end: 5,
+          source: 'model',
+        ),
+        const PiiEntity(
+          label: 'person',
+          text: 'Alice Smith',
+          confidence: 0.8,
+          start: 0,
+          end: 11,
+          source: 'model',
+        ),
+      ];
+
+      final result = PiiResult(entities: overlapping, originalText: text);
+      final merged = result.mergeOverlapping();
+
+      expect(merged.entities.length, 1);
+      expect(merged.entities.first.text, 'Alice Smith');
+      expect(merged.entities.first.confidence, 0.9);
+    });
+
+    test('toJson/fromJson works correctly', () {
+      final result = PiiResult(entities: entities, originalText: originalText);
+      final json = result.toJson();
+      final fromJson = PiiResult.fromJson(json);
+
+      expect(fromJson, result);
+      expect(json['scrubbedText'], 'My name is [PERSON] and my email is [EMAIL]');
+    });
+  });
+}


### PR DESCRIPTION
Create lib/core/medical/pii_entity.dart with PII entity data models, ported from OpenMed's core/decoding/spans.py and OpenMedKit's EntityPrediction.swift (Apache 2.0).

- Create PiiEntity class (label, text, confidence, start, end, source)
- Create PiiMatch class (from regex detection)
- Create PiiResult class (collection of detected entities)
- Implement JSON serialization (toJson/fromJson)
- Add merge() method for overlapping entities
- Add sortedByPosition() and sortedByConfidence() utilities
- Add automated text scrubbing in PiiResult.scrubbedText
- Zero dart analyze errors
- All unit tests passing

Fixes #433

---
*PR created automatically by Jules for task [3912661989480218857](https://jules.google.com/task/3912661989480218857) started by @iberi22*