### PR TITLE
Port OpenMed international ID validators to Dart

### DIFF
--- a/lib/core/medical/i18n_validators.dart
+++ b/lib/core/medical/i18n_validators.dart
@@ -1,0 +1,102 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 OrionHealth
+
+/// Interface for international ID validators.
+abstract class I18nValidator {
+  /// Validates the [input] based on the provided [countryCode].
+  /// [countryCode] should be an ISO 3166-1 alpha-2 code (e.g., 'BR', 'ES', 'PE', 'MX').
+  bool validate(String input, String countryCode);
+}
+
+/// Implementation of international ID validators.
+class I18nValidatorImpl implements I18nValidator {
+  @override
+  bool validate(String input, String countryCode) {
+    switch (countryCode.toUpperCase()) {
+      case 'BR':
+        return validateCpf(input);
+      case 'ES':
+        return validateDniSpain(input);
+      case 'PE':
+        return validateDniPeru(input);
+      case 'MX':
+        return validateCurp(input);
+      default:
+        return false;
+    }
+  }
+}
+
+const String _dniLetters = "TRWAGMYFPDXBNJZSQVHLCKE";
+
+/// Validates Brazilian CPF (Cadastro de Pessoas Físicas).
+/// Ported from OpenMed validate_portuguese_cpf.
+bool validateCpf(String text) {
+  final digits = text.replaceAll(RegExp(r'[^0-9]'), '');
+  if (digits.length != 11) return false;
+
+  // Reject all same digits (e.g., 111.111.111-11)
+  if (RegExp(r'^(\d)\1{10}$').hasMatch(digits)) return false;
+
+  final numbers = digits.split('').map(int.parse).toList();
+
+  // First check digit
+  int firstSum = 0;
+  for (int i = 0; i < 9; i++) {
+    firstSum += numbers[i] * (10 - i);
+  }
+  int firstCheck = (firstSum * 10) % 11;
+  if (firstCheck == 10) firstCheck = 0;
+
+  if (numbers[9] != firstCheck) return false;
+
+  // Second check digit
+  int secondSum = 0;
+  for (int i = 0; i < 10; i++) {
+    secondSum += numbers[i] * (11 - i);
+  }
+  int secondCheck = (secondSum * 10) % 11;
+  if (secondCheck == 10) secondCheck = 0;
+
+  return numbers[10] == secondCheck;
+}
+
+/// Validates Spanish DNI (Documento Nacional de Identidad).
+/// Ported from OpenMed validate_spanish_dni.
+bool validateDniSpain(String text) {
+  final cleaned = text.replaceAll(RegExp(r'\s'), '').toUpperCase();
+  if (cleaned.length != 9) return false;
+
+  final match = RegExp(r'^(\d{8})([A-Z])$').firstMatch(cleaned);
+  if (match == null) return false;
+
+  final numberStr = match.group(1)!;
+  final letter = match.group(2)!;
+  final number = int.parse(numberStr);
+
+  return letter == _dniLetters[number % 23];
+}
+
+/// Validates Peruvian DNI (Documento Nacional de Identidad).
+/// Requirement: 8 digits.
+bool validateDniPeru(String text) {
+  final digits = text.replaceAll(RegExp(r'[^0-9]'), '');
+  return digits.length == 8;
+}
+
+/// Validates Mexican CURP (Clave Única de Registro de Población).
+/// Requirement: 18 characters, format validation.
+bool validateCurp(String text) {
+  final cleaned = text.replaceAll(RegExp(r'\s'), '').toUpperCase();
+  if (cleaned.length != 18) return false;
+
+  // Official CURP format:
+  // 4 letters (name/surname initials)
+  // 6 digits (birth date YYMMDD)
+  // 1 letter (Gender H/M)
+  // 2 letters (State code)
+  // 3 letters (consonants)
+  // 2 chars (homonym and check digit)
+  final pattern = RegExp(r'^[A-Z]{4}\d{6}[HM][A-Z]{5}[A-Z0-9]\d$');
+  return pattern.hasMatch(cleaned);
+}

--- a/test/core/medical/i18n_validators_test.dart
+++ b/test/core/medical/i18n_validators_test.dart
@@ -1,0 +1,68 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 OrionHealth
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/medical/i18n_validators.dart';
+
+void main() {
+  final validator = I18nValidatorImpl();
+
+  group('I18nValidatorImpl', () {
+    test('BR (CPF) validation', () {
+      expect(validator.validate('123.456.789-09', 'BR'), isTrue);
+      expect(validator.validate('12345678909', 'BR'), isTrue);
+      expect(validator.validate('111.111.111-11', 'BR'), isFalse);
+      expect(validator.validate('123.456.789-00', 'BR'), isFalse);
+      expect(validator.validate('123456789', 'BR'), isFalse);
+    });
+
+    test('ES (DNI) validation', () {
+      expect(validator.validate('12345678Z', 'ES'), isTrue);
+      expect(validator.validate('12345678 Z', 'ES'), isTrue);
+      expect(validator.validate('12345678A', 'ES'), isFalse);
+      expect(validator.validate('1234567Z', 'ES'), isFalse);
+    });
+
+    test('PE (DNI) validation', () {
+      expect(validator.validate('12345678', 'PE'), isTrue);
+      expect(validator.validate('12-34-56-78', 'PE'), isTrue);
+      expect(validator.validate('1234567', 'PE'), isFalse);
+      expect(validator.validate('123456789', 'PE'), isFalse);
+    });
+
+    test('MX (CURP) validation', () {
+      // Example CURP: ABCD123456HABCDE01
+      expect(validator.validate('ABCD123456HABCDE01', 'MX'), isTrue);
+      expect(validator.validate('ABCD123456MABCDE01', 'MX'), isTrue);
+      expect(validator.validate('ABCD123456XABCDE01', 'MX'), isFalse); // Invalid gender
+      expect(validator.validate('ABCD12345HABCDE01', 'MX'), isFalse); // Too short
+      expect(validator.validate('ABCD123456HABCDE0A', 'MX'), isFalse); // Last char must be digit
+    });
+
+    test('Unsupported country code', () {
+      expect(validator.validate('123', 'ZZ'), isFalse);
+    });
+  });
+
+  group('Direct function tests', () {
+    test('validateCpf', () {
+      expect(validateCpf('123.456.789-09'), isTrue);
+      expect(validateCpf('111.111.111-11'), isFalse);
+    });
+
+    test('validateDniSpain', () {
+      expect(validateDniSpain('12345678Z'), isTrue);
+      expect(validateDniSpain('12345678A'), isFalse);
+    });
+
+    test('validateDniPeru', () {
+      expect(validateDniPeru('12345678'), isTrue);
+      expect(validateDniPeru('1234567'), isFalse);
+    });
+
+    test('validateCurp', () {
+      expect(validateCurp('ABCD123456HABCDE01'), isTrue);
+      expect(validateCurp('INVALID'), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Ported OpenMed's `pii_i18n.py` validators to native Dart for offline validation of international ID documents in the OrionHealth PII pipeline.

Summary of changes:
- Created `lib/core/medical/i18n_validators.dart` with `I18nValidator` interface and implementations for CPF (BR), DNI (ES), DNI (PE), and CURP (MX).
- Added `test/core/medical/i18n_validators_test.dart` with unit tests for all validators.
- Ensured zero warnings/errors via `dart analyze`.
- Verified all tests pass via `flutter test`.

Fixes #442

---
*PR created automatically by Jules for task [1163069574422808376](https://jules.google.com/task/1163069574422808376) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features
* Added international identification number validation support for Brazil (CPF), Spain (DNI), Peru (DNI), and Mexico (CURP) with format normalization and checksum verification.

## Tests
* Added comprehensive test coverage for all international ID validators including edge cases and invalid inputs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->