### PR TITLE
Port OpenMed quality gates: quality_gates.dart (threshold config)

### DIFF
--- a/lib/core/medical/pii_entity.dart
+++ b/lib/core/medical/pii_entity.dart
@@ -23,6 +23,7 @@ class PiiEntity extends Equatable {
   final int start;
   final int end;
   final String source; // 'regex', 'model', 'context'
+  final Map<String, dynamic>? metadata;
 
   const PiiEntity({
     required this.label,
@@ -31,6 +32,7 @@ class PiiEntity extends Equatable {
     required this.start,
     required this.end,
     required this.source,
+    this.metadata,
   });
 
   factory PiiEntity.fromJson(Map<String, dynamic> json) {
@@ -41,6 +43,7 @@ class PiiEntity extends Equatable {
       start: json['start'] as int,
       end: json['end'] as int,
       source: json['source'] as String,
+      metadata: json['metadata'] as Map<String, dynamic>?,
     );
   }
 
@@ -52,17 +55,23 @@ class PiiEntity extends Equatable {
       'start': start,
       'end': end,
       'source': source,
+      if (metadata != null) 'metadata': metadata,
     };
   }
 
   @override
-  List<Object?> get props => [label, text, confidence, start, end, source];
+  List<Object?> get props =>
+      [label, text, confidence, start, end, source, metadata];
 
   /// Merges this entity with another, taking the union of spans and max confidence.
   /// Assumes the entities are overlapping or adjacent.
   PiiEntity merge(PiiEntity other, String originalText) {
     final newStart = start < other.start ? start : other.start;
     final newEnd = end > other.end ? end : other.end;
+    final newMetadata = <String, dynamic>{};
+    if (metadata != null) newMetadata.addAll(metadata!);
+    if (other.metadata != null) newMetadata.addAll(other.metadata!);
+
     return PiiEntity(
       label: label == other.label ? label : '$label,${other.label}',
       text: originalText.substring(newStart, newEnd),
@@ -70,6 +79,27 @@ class PiiEntity extends Equatable {
       start: newStart,
       end: newEnd,
       source: source == other.source ? source : 'merger',
+      metadata: newMetadata.isEmpty ? null : newMetadata,
+    );
+  }
+
+  PiiEntity copyWith({
+    String? label,
+    String? text,
+    double? confidence,
+    int? start,
+    int? end,
+    String? source,
+    Map<String, dynamic>? metadata,
+  }) {
+    return PiiEntity(
+      label: label ?? this.label,
+      text: text ?? this.text,
+      confidence: confidence ?? this.confidence,
+      start: start ?? this.start,
+      end: end ?? this.end,
+      source: source ?? this.source,
+      metadata: metadata ?? this.metadata,
     );
   }
 

--- a/lib/core/medical/quality_gates.dart
+++ b/lib/core/medical/quality_gates.dart
@@ -1,0 +1,160 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 OrionHealth
+
+import 'dart:developer' as developer;
+import 'pii_entity.dart';
+
+/// Configuration for PII quality gates, defining confidence thresholds.
+class QualityGateConfig {
+  final double defaultMinConfidence;
+  final Map<String, double> labelThresholds;
+
+  const QualityGateConfig({
+    this.defaultMinConfidence = 0.7,
+    this.labelThresholds = const {},
+  });
+
+  factory QualityGateConfig.fromJson(Map<String, dynamic> json) {
+    return QualityGateConfig(
+      defaultMinConfidence: (json['defaultMinConfidence'] as num?)?.toDouble() ?? 0.7,
+      labelThresholds: (json['labelThresholds'] as Map<String, dynamic>?)?.map(
+            (key, value) => MapEntry(key, (value as num).toDouble()),
+          ) ??
+          {},
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'defaultMinConfidence': defaultMinConfidence,
+      'labelThresholds': labelThresholds,
+    };
+  }
+}
+
+/// Span-boundary guards for entity predictions.
+///
+/// Ported from OpenMed (Python) Apache 2.0.
+class QualityGate {
+  QualityGate._();
+
+  /// Validate span boundaries for every entity against [text].
+  ///
+  /// Checks performed per entity:
+  /// - start < end (no inverted or zero-length spans)
+  /// - start >= 0 and end <= text.length
+  /// - text[start:end] matches entity.text (catch stale spans)
+  ///
+  /// Violations are logged and a 'span_valid' flag is written into entity.metadata.
+  /// Returns a new list of entities with updated metadata.
+  static List<PiiEntity> validateSpans(List<PiiEntity> entities, String text) {
+    final textLen = text.length;
+
+    return entities.map((entity) {
+      final problems = <String>[];
+      final start = entity.start;
+      final end = entity.end;
+
+      // --- invariant checks ---
+      if (start >= end) {
+        if (start == end) {
+          problems.append("zero-length span");
+        } else {
+          problems.append("inverted span (start=$start >= end=$end)");
+        }
+      }
+
+      if (start < 0) {
+        problems.append("negative start ($start)");
+      }
+
+      if (end > textLen) {
+        problems.append("end ($end) exceeds text length ($textLen)");
+      }
+
+      // --- text-match check (only when bounds are sane) ---
+      if (problems.isEmpty && start >= 0 && end <= textLen) {
+        final actual = text.substring(start, end);
+        if (actual != entity.text) {
+          // Allow whitespace-only differences (common after span trimming)
+          if (actual.split(RegExp(r'\s+')).join(' ') ==
+              entity.text.split(RegExp(r'\s+')).join(' ')) {
+            developer.log(
+              "SpanValidation: Entity '${entity.label}' @ [$start:$end]: "
+              "whitespace-only text difference (span='$actual', stored='${entity.text}')",
+              name: 'QualityGate',
+            );
+          } else {
+            problems.append(
+                "text mismatch: span gives '$actual', entity stores '${entity.text}'");
+          }
+        }
+      }
+
+      // --- report ---
+      if (problems.isNotEmpty) {
+        final msg = "Entity '${entity.label}' @ [$start:$end]: ${problems.join('; ')}";
+        developer.log("SpanValidation: $msg", name: 'QualityGate', level: 900); // Warning level
+      }
+
+      final meta = Map<String, dynamic>.from(entity.metadata ?? {});
+      meta['span_valid'] = problems.isEmpty;
+
+      return entity.copyWith(metadata: meta);
+    }).toList();
+  }
+
+  /// Return pairs of entities whose character spans overlap.
+  static List<(PiiEntity, PiiEntity)> detectOverlaps(List<PiiEntity> entities) {
+    final sortedEnts = List<PiiEntity>.from(entities)
+      ..sort((a, b) => a.start.compareTo(b.start));
+
+    final overlaps = <(PiiEntity, PiiEntity)>[];
+    for (var i = 0; i < sortedEnts.length - 1; i++) {
+      final a = sortedEnts[i];
+      for (var j = i + 1; j < sortedEnts.length; j++) {
+        final b = sortedEnts[j];
+        if (b.start < a.end) {
+          overlaps.add((a, b));
+        } else {
+          break; // No further overlaps possible for 'a'
+        }
+      }
+    }
+    return overlaps;
+  }
+
+  /// Filters results based on confidence thresholds and (optionally) span validity.
+  static List<PiiEntity> applyGates(
+    List<PiiEntity> entities, {
+    String? text,
+    QualityGateConfig config = const QualityGateConfig(),
+    bool dropInvalidSpans = false,
+  }) {
+    var results = entities;
+
+    if (text != null) {
+      results = validateSpans(results, text);
+    }
+
+    return results.where((entity) {
+      // Threshold check
+      final threshold = config.labelThresholds[entity.label] ?? config.defaultMinConfidence;
+      if (entity.confidence < threshold) {
+        return false;
+      }
+
+      // Optional span validity drop
+      if (dropInvalidSpans && text != null) {
+        final isValid = entity.metadata?['span_valid'] as bool? ?? true;
+        if (!isValid) return false;
+      }
+
+      return true;
+    }).toList();
+  }
+}
+
+extension _StringList on List<String> {
+  void append(String value) => add(value);
+}

--- a/test/core/medical/quality_gates_test.dart
+++ b/test/core/medical/quality_gates_test.dart
@@ -1,0 +1,289 @@
+// SPDX-License-Identifier: Apache-2.0
+// Copyright (c) 2025 OrionHealth
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/medical/pii_entity.dart';
+import 'package:orionhealth_health/core/medical/quality_gates.dart';
+
+void main() {
+  group('QualityGateConfig', () {
+    test('default values', () {
+      const config = QualityGateConfig();
+      expect(config.defaultMinConfidence, 0.7);
+      expect(config.labelThresholds, isEmpty);
+    });
+
+    test('fromJson/toJson', () {
+      final json = {
+        'defaultMinConfidence': 0.8,
+        'labelThresholds': {'PERSON': 0.9, 'EMAIL': 0.95},
+      };
+      final config = QualityGateConfig.fromJson(json);
+      expect(config.defaultMinConfidence, 0.8);
+      expect(config.labelThresholds['PERSON'], 0.9);
+      expect(config.labelThresholds['EMAIL'], 0.95);
+
+      expect(config.toJson(), json);
+    });
+  });
+
+  group('QualityGate.validateSpans', () {
+    const text = 'Hello John Doe, your email is john@example.com';
+
+    test('valid spans', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: 'John Doe',
+          confidence: 0.9,
+          start: 6,
+          end: 14,
+          source: 'test',
+        ),
+        const PiiEntity(
+          label: 'EMAIL',
+          text: 'john@example.com',
+          confidence: 1.0,
+          start: 30,
+          end: 46,
+          source: 'test',
+        ),
+      ];
+
+      final validated = QualityGate.validateSpans(entities, text);
+      expect(validated[0].metadata?['span_valid'], isTrue);
+      expect(validated[1].metadata?['span_valid'], isTrue);
+    });
+
+    test('inverted span', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: 'John Doe',
+          confidence: 0.9,
+          start: 14,
+          end: 6,
+          source: 'test',
+        ),
+      ];
+
+      final validated = QualityGate.validateSpans(entities, text);
+      expect(validated[0].metadata?['span_valid'], isFalse);
+    });
+
+    test('zero-length span', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: '',
+          confidence: 0.9,
+          start: 6,
+          end: 6,
+          source: 'test',
+        ),
+      ];
+
+      final validated = QualityGate.validateSpans(entities, text);
+      expect(validated[0].metadata?['span_valid'], isFalse);
+    });
+
+    test('out of bounds (negative)', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: 'Hello',
+          confidence: 0.9,
+          start: -5,
+          end: 0,
+          source: 'test',
+        ),
+      ];
+
+      final validated = QualityGate.validateSpans(entities, text);
+      expect(validated[0].metadata?['span_valid'], isFalse);
+    });
+
+    test('out of bounds (exceeds length)', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: '!',
+          confidence: 0.9,
+          start: 46,
+          end: 47,
+          source: 'test',
+        ),
+      ];
+
+      final validated = QualityGate.validateSpans(entities, text);
+      expect(validated[0].metadata?['span_valid'], isFalse);
+    });
+
+    test('text mismatch', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: 'Jane Doe',
+          confidence: 0.9,
+          start: 6,
+          end: 14,
+          source: 'test',
+        ),
+      ];
+
+      final validated = QualityGate.validateSpans(entities, text);
+      expect(validated[0].metadata?['span_valid'], isFalse);
+    });
+
+    test('whitespace-only mismatch (should be valid)', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: 'John  Doe', // extra space
+          confidence: 0.9,
+          start: 6,
+          end: 14, // 'John Doe' in original text
+          source: 'test',
+        ),
+      ];
+
+      final validated = QualityGate.validateSpans(entities, text);
+      expect(validated[0].metadata?['span_valid'], isTrue);
+    });
+  });
+
+  group('QualityGate.detectOverlaps', () {
+    test('detects overlaps', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: 'John Doe',
+          confidence: 0.9,
+          start: 6,
+          end: 14,
+          source: 'test',
+        ),
+        const PiiEntity(
+          label: 'FIRST_NAME',
+          text: 'John',
+          confidence: 0.8,
+          start: 6,
+          end: 10,
+          source: 'test',
+        ),
+        const PiiEntity(
+          label: 'EMAIL',
+          text: 'john@example.com',
+          confidence: 1.0,
+          start: 30,
+          end: 46,
+          source: 'test',
+        ),
+      ];
+
+      final overlaps = QualityGate.detectOverlaps(entities);
+      expect(overlaps, hasLength(1));
+      expect(overlaps[0].$1.label, 'PERSON');
+      expect(overlaps[0].$2.label, 'FIRST_NAME');
+    });
+
+    test('no overlaps', () {
+      final entities = [
+        const PiiEntity(
+          label: 'PERSON',
+          text: 'John',
+          confidence: 0.9,
+          start: 0,
+          end: 4,
+          source: 'test',
+        ),
+        const PiiEntity(
+          label: 'PERSON',
+          text: 'Doe',
+          confidence: 0.9,
+          start: 5,
+          end: 8,
+          source: 'test',
+        ),
+      ];
+
+      final overlaps = QualityGate.detectOverlaps(entities);
+      expect(overlaps, isEmpty);
+    });
+  });
+
+  group('QualityGate.applyGates', () {
+    final entities = [
+      const PiiEntity(
+        label: 'PERSON',
+        text: 'John Doe',
+        confidence: 0.65,
+        start: 0,
+        end: 8,
+        source: 'test',
+      ),
+      const PiiEntity(
+        label: 'EMAIL',
+        text: 'john@example.com',
+        confidence: 0.95,
+        start: 20,
+        end: 36,
+        source: 'test',
+      ),
+    ];
+
+    test('default confidence filtering', () {
+      final filtered = QualityGate.applyGates(entities);
+      expect(filtered, hasLength(1));
+      expect(filtered[0].label, 'EMAIL');
+    });
+
+    test('custom default confidence filtering', () {
+      final filtered = QualityGate.applyGates(
+        entities,
+        config: const QualityGateConfig(defaultMinConfidence: 0.6),
+      );
+      expect(filtered, hasLength(2));
+    });
+
+    test('per-label confidence filtering', () {
+      final filtered = QualityGate.applyGates(
+        entities,
+        config: const QualityGateConfig(
+          defaultMinConfidence: 0.8,
+          labelThresholds: {'PERSON': 0.6},
+        ),
+      );
+      expect(filtered, hasLength(2));
+    });
+
+    test('span validation filtering', () {
+      final invalidEntities = [
+        const PiiEntity(
+          label: 'EMAIL',
+          text: 'wrong',
+          confidence: 0.95,
+          start: 0,
+          end: 5,
+          source: 'test',
+        ),
+      ];
+      const text = 'Valid text here';
+
+      final filtered = QualityGate.applyGates(
+        invalidEntities,
+        text: text,
+        dropInvalidSpans: true,
+      );
+      expect(filtered, isEmpty);
+
+      final kept = QualityGate.applyGates(
+        invalidEntities,
+        text: text,
+        dropInvalidSpans: false,
+      );
+      expect(kept, hasLength(1));
+      expect(kept[0].metadata?['span_valid'], isFalse);
+    });
+  });
+}


### PR DESCRIPTION
This PR ports the quality gate system from OpenMed (Python) to native Dart for on-device PII detection in OrionHealth. It introduces a configurable threshold system and span-boundary guards to ensure the accuracy and reliability of detected PII entities.

Key changes:
- `PiiEntity` now supports a `metadata` map for auxiliary information like `span_valid`.
- `QualityGateConfig` allows for fine-tuning sensitivity per PII label.
- `QualityGate` provides static methods for span validation, overlap detection, and result gating.
- Full unit test coverage for the new functionality.

Fixes #444

---
*PR created automatically by Jules for task [490487198787951765](https://jules.google.com/task/490487198787951765) started by @iberi22*