### PR TITLE
Phase 4: Doctor Profile entity and repository

### DIFF
--- a/lib/features/doctor_verification/data/models/doctor_profile_model.dart
+++ b/lib/features/doctor_verification/data/models/doctor_profile_model.dart
@@ -1,0 +1,68 @@
+import '../../domain/entities/doctor_profile.dart';
+
+class DoctorProfileModel extends DoctorProfile {
+  const DoctorProfileModel({
+    required super.id,
+    required super.fullName,
+    required super.specialty,
+    super.licenseNumber,
+    required super.countryCode,
+    super.institution,
+    super.yearsOfExperience,
+    super.languages,
+    super.verified,
+    required super.createdAt,
+    required super.updatedAt,
+  });
+
+  factory DoctorProfileModel.fromJson(Map<String, dynamic> json) {
+    return DoctorProfileModel(
+      id: json['id'] as String,
+      fullName: json['fullName'] as String,
+      specialty: json['specialty'] as String,
+      licenseNumber: json['licenseNumber'] as String?,
+      countryCode: json['countryCode'] as String,
+      institution: json['institution'] as String?,
+      yearsOfExperience: json['yearsOfExperience'] as int?,
+      languages: (json['languages'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      verified: json['verified'] as bool? ?? false,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      updatedAt: DateTime.parse(json['updatedAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'fullName': fullName,
+      'specialty': specialty,
+      'licenseNumber': licenseNumber,
+      'countryCode': countryCode,
+      'institution': institution,
+      'yearsOfExperience': yearsOfExperience,
+      'languages': languages,
+      'verified': verified,
+      'createdAt': createdAt.toIso8601String(),
+      'updatedAt': updatedAt.toIso8601String(),
+    };
+  }
+
+  factory DoctorProfileModel.fromEntity(DoctorProfile entity) {
+    return DoctorProfileModel(
+      id: entity.id,
+      fullName: entity.fullName,
+      specialty: entity.specialty,
+      licenseNumber: entity.licenseNumber,
+      countryCode: entity.countryCode,
+      institution: entity.institution,
+      yearsOfExperience: entity.yearsOfExperience,
+      languages: entity.languages,
+      verified: entity.verified,
+      createdAt: entity.createdAt,
+      updatedAt: entity.updatedAt,
+    );
+  }
+}

--- a/lib/features/doctor_verification/domain/entities/doctor_profile.dart
+++ b/lib/features/doctor_verification/domain/entities/doctor_profile.dart
@@ -1,0 +1,44 @@
+import 'package:equatable/equatable.dart';
+
+class DoctorProfile extends Equatable {
+  final String id;
+  final String fullName;
+  final String specialty;
+  final String? licenseNumber;
+  final String countryCode;
+  final String? institution;
+  final int? yearsOfExperience;
+  final List<String> languages;
+  final bool verified;
+  final DateTime createdAt;
+  final DateTime updatedAt;
+
+  const DoctorProfile({
+    required this.id,
+    required this.fullName,
+    required this.specialty,
+    this.licenseNumber,
+    required this.countryCode,
+    this.institution,
+    this.yearsOfExperience,
+    this.languages = const [],
+    this.verified = false,
+    required this.createdAt,
+    required this.updatedAt,
+  });
+
+  @override
+  List<Object?> get props => [
+        id,
+        fullName,
+        specialty,
+        licenseNumber,
+        countryCode,
+        institution,
+        yearsOfExperience,
+        languages,
+        verified,
+        createdAt,
+        updatedAt,
+      ];
+}

--- a/lib/features/doctor_verification/domain/repositories/doctor_profile_repository.dart
+++ b/lib/features/doctor_verification/domain/repositories/doctor_profile_repository.dart
@@ -1,0 +1,8 @@
+import '../entities/doctor_profile.dart';
+
+abstract interface class DoctorProfileRepository {
+  Future<DoctorProfile?> getDoctorProfile(String id);
+  Future<void> saveDoctorProfile(DoctorProfile profile);
+  Future<void> deleteDoctorProfile(String id);
+  Future<List<DoctorProfile>> getAllDoctorProfiles();
+}

--- a/test/features/doctor_verification/domain/entities/doctor_profile_test.dart
+++ b/test/features/doctor_verification/domain/entities/doctor_profile_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/data/models/doctor_profile_model.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/doctor_profile.dart';
+
+void main() {
+  final tDate = DateTime(2023, 1, 1);
+  final tDoctorProfile = DoctorProfile(
+    id: '1',
+    fullName: 'John Doe',
+    specialty: 'Cardiology',
+    licenseNumber: '12345',
+    countryCode: 'US',
+    institution: 'General Hospital',
+    yearsOfExperience: 10,
+    languages: const ['English', 'Spanish'],
+    verified: true,
+    createdAt: tDate,
+    updatedAt: tDate,
+  );
+
+  final tDoctorProfileModel = DoctorProfileModel(
+    id: '1',
+    fullName: 'John Doe',
+    specialty: 'Cardiology',
+    licenseNumber: '12345',
+    countryCode: 'US',
+    institution: 'General Hospital',
+    yearsOfExperience: 10,
+    languages: const ['English', 'Spanish'],
+    verified: true,
+    createdAt: tDate,
+    updatedAt: tDate,
+  );
+
+  group('DoctorProfile', () {
+    test('should support value equality', () {
+      final tDoctorProfile2 = DoctorProfile(
+        id: '1',
+        fullName: 'John Doe',
+        specialty: 'Cardiology',
+        licenseNumber: '12345',
+        countryCode: 'US',
+        institution: 'General Hospital',
+        yearsOfExperience: 10,
+        languages: const ['English', 'Spanish'],
+        verified: true,
+        createdAt: tDate,
+        updatedAt: tDate,
+      );
+
+      expect(tDoctorProfile, equals(tDoctorProfile2));
+    });
+  });
+
+  group('DoctorProfileModel', () {
+    test('should be a subclass of DoctorProfile entity', () {
+      expect(tDoctorProfileModel, isA<DoctorProfile>());
+    });
+
+    test('fromJson should return a valid model', () {
+      final Map<String, dynamic> jsonMap = {
+        'id': '1',
+        'fullName': 'John Doe',
+        'specialty': 'Cardiology',
+        'licenseNumber': '12345',
+        'countryCode': 'US',
+        'institution': 'General Hospital',
+        'yearsOfExperience': 10,
+        'languages': ['English', 'Spanish'],
+        'verified': true,
+        'createdAt': tDate.toIso8601String(),
+        'updatedAt': tDate.toIso8601String(),
+      };
+
+      final result = DoctorProfileModel.fromJson(jsonMap);
+
+      expect(result, tDoctorProfileModel);
+    });
+
+    test('toJson should return a JSON map containing the proper data', () {
+      final result = tDoctorProfileModel.toJson();
+
+      final expectedMap = {
+        'id': '1',
+        'fullName': 'John Doe',
+        'specialty': 'Cardiology',
+        'licenseNumber': '12345',
+        'countryCode': 'US',
+        'institution': 'General Hospital',
+        'yearsOfExperience': 10,
+        'languages': ['English', 'Spanish'],
+        'verified': true,
+        'createdAt': tDate.toIso8601String(),
+        'updatedAt': tDate.toIso8601String(),
+      };
+
+      expect(result, expectedMap);
+    });
+
+    test('fromEntity should return a valid model from entity', () {
+      final result = DoctorProfileModel.fromEntity(tDoctorProfile);
+      expect(result, tDoctorProfileModel);
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces the core domain and data models for Phase 4 Doctor Verification. 
It includes the DoctorProfile entity, a JSON-serializable DoctorProfileModel, and the abstract repository interface. 
Unit tests are included to ensure correct value equality and serialization.

Fixes #447

---
*PR created automatically by Jules for task [4596192413548416621](https://jules.google.com/task/4596192413548416621) started by @iberi22*