### PR TITLE
feat: implement Domain layer for sync feature

### DIFF
--- a/lib/features/sync/data/sync_repository.dart
+++ b/lib/features/sync/data/sync_repository.dart
@@ -7,24 +7,25 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:injectable/injectable.dart';
 import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
+import '../domain/entities/sync_node.dart';
+import '../domain/sync_repository.dart';
 import '../../../features/user_profile/domain/entities/user_profile.dart';
 import '../../../features/medications/domain/entities/medication.dart' as app_med;
 import '../../../features/allergies/domain/entities/allergy.dart';
 import '../../../features/vitals/domain/entities/vital_sign.dart' as app_vital;
-import 'package:medical_standards/medical_standards.dart';
 import 'fhir_client.dart';
 import 'fhir_mapper.dart';
 import 'rda_parser.dart';
 import 'node_discovery_service.dart';
 
-@lazySingleton
-class SyncRepository {
+@LazySingleton(as: SyncRepository)
+class SyncRepositoryImpl implements SyncRepository {
   final FhirClient _fhirClient;
   final Isar _isar;
   final FlutterSecureStorage _secureStorage;
   final NodeDiscoveryService _discoveryService;
 
-  SyncRepository(
+  SyncRepositoryImpl(
     this._fhirClient,
     this._isar,
     this._secureStorage,
@@ -33,16 +34,17 @@ class SyncRepository {
 
   static const String _lastSyncKey = 'last_fhir_sync_timestamp';
 
-  /// Get access token from secure storage
+  @override
   Future<String?> getAccessToken() async {
     return await _secureStorage.read(key: 'ihce_access_token');
   }
 
-  /// Save access token to secure storage
+  @override
   Future<void> saveAccessToken(String token) async {
     await _secureStorage.write(key: 'ihce_access_token', value: token);
   }
 
+  @override
   Future<DateTime?> getLastSyncTime() async {
     final prefs = await SharedPreferences.getInstance();
     final timestamp = prefs.getInt(_lastSyncKey);
@@ -51,42 +53,20 @@ class SyncRepository {
         : null;
   }
 
-  Future<void> _setLastSyncTime(DateTime time) async {
+  @override
+  Future<void> setLastSyncTime(DateTime time) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_lastSyncKey, time.millisecondsSinceEpoch);
   }
 
-  /// Full sync: Patient profile + RDA (medications, allergies, vitals, conditions) + P2P Medical Standards
-  Future<void> syncAll() async {
-    // 0. Sync Medical Standards via P2P if possible
-    await syncMedicalStandards();
-
-    final token = await getAccessToken();
-    if (token == null) {
-      throw Exception('No hay conexión con IHCE. Conectá tu EPS primero.');
-    }
-
-    final profile = await _isar.userProfiles.where().findFirst();
-    if (profile == null || profile.epsPatientId == null) {
-      throw Exception('Perfil no encontrado o sin ID de paciente IHCE.');
-    }
-
-    final patientId = profile.epsPatientId!;
-
-    // 1. Sync Patient -> UserProfile
-    await _syncPatient(patientId, token, profile);
-
-    // 2. Sync RDA
-    await _syncRda(patientId, token);
-
-    await _setLastSyncTime(DateTime.now());
-  }
-
-  Future<void> _syncPatient(
+  @override
+  Future<void> syncPatient(
     String patientId,
     String token,
-    UserProfile existingProfile,
   ) async {
+    final existingProfile = await _isar.userProfiles.where().findFirst();
+    if (existingProfile == null) return;
+
     try {
       final patientData = await _fhirClient.getPatient(patientId, token);
       final updatedProfile = FhirMapper.mapPatient(patientData, existingProfile);
@@ -99,7 +79,8 @@ class SyncRepository {
     }
   }
 
-  Future<void> _syncRda(String patientId, String token) async {
+  @override
+  Future<void> syncRda(String patientId, String token) async {
     try {
       final rdaBundle = await _fhirClient.getRDA(patientId, token);
       final parsed = RdaParser.parse(rdaBundle);
@@ -111,9 +92,6 @@ class SyncRepository {
       final conditions = <String>[];
       final vitals = <app_vital.VitalSign>[];
 
-      // Process each section - entries from IHCE RDA
-      // In a real scenario, we'd also fetch the full Bundle resources
-      // For now, search for resources referenced in the Composition
       for (final section in sections) {
         final sectionMap = section as Map<String, dynamic>;
         final entries = sectionMap['entries'] as List<dynamic>? ?? [];
@@ -180,7 +158,6 @@ class SyncRepository {
                 .dateTimeEqualTo(vital.dateTime)
                 .findFirst();
             if (existing != null) {
-              // Only update if value is different or to ensure we have the latest
               vital.id = existing.id;
             }
             await _isar.vitalSigns.put(vital);
@@ -202,32 +179,13 @@ class SyncRepository {
     }
   }
 
-  /// Sync medical standards from peers if any are discovered
-  Future<void> syncMedicalStandards() async {
-    final peers = _discoveryService.currentNodes;
-    final syncService = SyncService();
-
-    if (peers.isNotEmpty) {
-      // Try to sync from the first available peer
-      final peer = peers.first;
-      final peerIp = '${peer.host}:${peer.port}';
-      await syncService.syncAll(peerIp: peerIp);
-    } else {
-      // Fallback to default (GitHub)
-      await syncService.syncAll();
-    }
-  }
-
-  /// Quick sync - only refresh if last sync was > 6 hours ago
-  Future<bool> syncIfStale() async {
-    final lastSync = await getLastSyncTime();
-    if (lastSync != null) {
-      final staleThreshold = DateTime.now().subtract(const Duration(hours: 6));
-      if (lastSync.isAfter(staleThreshold)) {
-        return false; // Not stale, skip
-      }
-    }
-    await syncAll();
-    return true; // Synced
+  @override
+  List<SyncNode> getDiscoveredNodes() {
+    return _discoveryService.currentNodes.map((node) => SyncNode(
+      id: node.attributes['nodeId'] ?? node.name,
+      name: node.name,
+      host: node.host,
+      port: node.port,
+    )).toList();
   }
 }

--- a/lib/features/sync/domain/entities/sync_node.dart
+++ b/lib/features/sync/domain/entities/sync_node.dart
@@ -1,0 +1,19 @@
+import 'package:equatable/equatable.dart';
+
+/// Entity representing a discovered node on the local network.
+class SyncNode extends Equatable {
+  final String id;
+  final String name;
+  final String? host;
+  final int port;
+
+  const SyncNode({
+    required this.id,
+    required this.name,
+    this.host,
+    required this.port,
+  });
+
+  @override
+  List<Object?> get props => [id, name, host, port];
+}

--- a/lib/features/sync/domain/sync_cubit.dart
+++ b/lib/features/sync/domain/sync_cubit.dart
@@ -1,7 +1,7 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:injectable/injectable.dart';
-import '../data/sync_repository.dart';
+import 'sync_service.dart';
 
 enum SyncStatus { initial, loading, success, failure }
 
@@ -34,22 +34,22 @@ class SyncState extends Equatable {
 
 @injectable
 class FhirSyncCubit extends Cubit<SyncState> {
-  final SyncRepository _syncRepository;
+  final SyncService _syncService;
 
-  FhirSyncCubit(this._syncRepository) : super(const SyncState()) {
+  FhirSyncCubit(this._syncService) : super(const SyncState()) {
     _loadLastSyncTime();
   }
 
   Future<void> _loadLastSyncTime() async {
-    final lastSync = await _syncRepository.getLastSyncTime();
+    final lastSync = await _syncService.getLastSyncTime();
     emit(state.copyWith(lastSyncTime: lastSync));
   }
 
   Future<void> performSync() async {
     emit(state.copyWith(status: SyncStatus.loading));
     try {
-      await _syncRepository.syncAll();
-      final lastSync = await _syncRepository.getLastSyncTime();
+      await _syncService.syncAll();
+      final lastSync = await _syncService.getLastSyncTime();
       emit(state.copyWith(
         status: SyncStatus.success,
         lastSyncTime: lastSync,

--- a/lib/features/sync/domain/sync_repository.dart
+++ b/lib/features/sync/domain/sync_repository.dart
@@ -1,0 +1,24 @@
+import 'entities/sync_node.dart';
+
+abstract class SyncRepository {
+  /// Get access token from secure storage
+  Future<String?> getAccessToken();
+
+  /// Save access token to secure storage
+  Future<void> saveAccessToken(String token);
+
+  /// Get the timestamp of the last successful sync
+  Future<DateTime?> getLastSyncTime();
+
+  /// Update the timestamp of the last successful sync
+  Future<void> setLastSyncTime(DateTime time);
+
+  /// Synchronize patient profile from IHCE
+  Future<void> syncPatient(String patientId, String token);
+
+  /// Synchronize RDA (medications, allergies, vitals, conditions) from IHCE
+  Future<void> syncRda(String patientId, String token);
+
+  /// Get list of discovered OrionHealth nodes on the local network
+  List<SyncNode> getDiscoveredNodes();
+}

--- a/lib/features/sync/domain/sync_service.dart
+++ b/lib/features/sync/domain/sync_service.dart
@@ -1,0 +1,72 @@
+import 'package:injectable/injectable.dart';
+import 'package:medical_standards/medical_standards.dart' as medical;
+import '../../user_profile/domain/repositories/user_profile_repository.dart';
+import 'sync_repository.dart';
+
+@lazySingleton
+class SyncService {
+  final SyncRepository _syncRepository;
+  final UserProfileRepository _userProfileRepository;
+
+  SyncService(this._syncRepository, this._userProfileRepository);
+
+  /// Full sync: Patient profile + RDA (medications, allergies, vitals, conditions) + P2P Medical Standards
+  Future<void> syncAll() async {
+    // 0. Sync Medical Standards via P2P if possible
+    await _syncMedicalStandards();
+
+    final token = await _syncRepository.getAccessToken();
+    if (token == null) {
+      throw Exception('No hay conexión con IHCE. Conectá tu EPS primero.');
+    }
+
+    final profile = await _userProfileRepository.getUserProfile();
+    if (profile == null || profile.epsPatientId == null) {
+      throw Exception('Perfil no encontrado o sin ID de paciente IHCE.');
+    }
+
+    final patientId = profile.epsPatientId!;
+
+    // 1. Sync Patient -> UserProfile
+    await _syncRepository.syncPatient(patientId, token);
+
+    // 2. Sync RDA
+    await _syncRepository.syncRda(patientId, token);
+
+    await _syncRepository.setLastSyncTime(DateTime.now());
+  }
+
+  /// Sync medical standards from peers if any are discovered
+  Future<void> _syncMedicalStandards() async {
+    final peers = _syncRepository.getDiscoveredNodes();
+    final medicalSyncService = medical.SyncService();
+
+    if (peers.isNotEmpty) {
+      // Try to sync from the first available peer
+      final peer = peers.first;
+      if (peer.host != null) {
+        final peerIp = '${peer.host}:${peer.port}';
+        await medicalSyncService.syncAll(peerIp: peerIp);
+        return;
+      }
+    }
+
+    // Fallback to default (GitHub)
+    await medicalSyncService.syncAll();
+  }
+
+  /// Quick sync - only refresh if last sync was > 6 hours ago
+  Future<bool> syncIfStale() async {
+    final lastSync = await _syncRepository.getLastSyncTime();
+    if (lastSync != null) {
+      final staleThreshold = DateTime.now().subtract(const Duration(hours: 6));
+      if (lastSync.isAfter(staleThreshold)) {
+        return false; // Not stale, skip
+      }
+    }
+    await syncAll();
+    return true; // Synced
+  }
+
+  Future<DateTime?> getLastSyncTime() => _syncRepository.getLastSyncTime();
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1166,18 +1166,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1634,10 +1634,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/sync/data/sync_repository_test.dart
+++ b/test/features/sync/data/sync_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/sync/data/fhir_client.dart';
 import 'package:orionhealth_health/features/sync/data/sync_repository.dart';
 import 'package:orionhealth_health/features/sync/data/node_discovery_service.dart';
+import 'package:orionhealth_health/features/sync/domain/sync_repository.dart';
 import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
 import 'package:orionhealth_health/features/medications/domain/entities/medication.dart';
 import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
@@ -39,7 +40,7 @@ void main() {
       directory: tempDir.path,
     );
 
-    syncRepository = SyncRepository(
+    syncRepository = SyncRepositoryImpl(
       mockFhirClient,
       isar,
       mockSecureStorage,
@@ -53,16 +54,9 @@ void main() {
     await isar.close();
   });
 
-  group('SyncRepository Conflict Resolution', () {
-    test('syncAll should not create duplicate medications', () async {
+  group('SyncRepositoryImpl Conflict Resolution', () {
+    test('syncRda should not create duplicate medications', () async {
       // Setup
-      when(() => mockSecureStorage.read(key: 'ihce_access_token'))
-          .thenAnswer((_) async => 'fake_token');
-
-      await isar.writeTxn(() async {
-        await isar.userProfiles.put(UserProfile(epsPatientId: 'pat123'));
-      });
-
       final medicationJson = {
         'resourceType': 'MedicationStatement',
         'status': 'active',
@@ -94,29 +88,20 @@ void main() {
         ]
       };
 
-      when(() => mockFhirClient.getPatient(any(), any()))
-          .thenAnswer((_) async => {'resourceType': 'Patient', 'id': 'pat123'});
       when(() => mockFhirClient.getRDA(any(), any()))
           .thenAnswer((_) async => rdaBundle);
 
       // Perform first sync
-      await syncRepository.syncAll();
+      await syncRepository.syncRda('pat123', 'fake_token');
       expect(await isar.medications.count(), 1);
 
       // Perform second sync with same data
-      await syncRepository.syncAll();
+      await syncRepository.syncRda('pat123', 'fake_token');
       expect(await isar.medications.count(), 1, reason: 'Should not create duplicate medication');
     });
 
-    test('syncAll should update existing medication if data changed', () async {
+    test('syncRda should update existing medication if data changed', () async {
       // Setup
-      when(() => mockSecureStorage.read(key: 'ihce_access_token'))
-          .thenAnswer((_) async => 'fake_token');
-
-      await isar.writeTxn(() async {
-        await isar.userProfiles.put(UserProfile(epsPatientId: 'pat123'));
-      });
-
       final medicationJson1 = {
         'resourceType': 'MedicationStatement',
         'status': 'active',
@@ -139,10 +124,9 @@ void main() {
         ]
       };
 
-      when(() => mockFhirClient.getPatient(any(), any())).thenAnswer((_) async => {});
       when(() => mockFhirClient.getRDA(any(), any())).thenAnswer((_) async => rdaBundle1);
 
-      await syncRepository.syncAll();
+      await syncRepository.syncRda('pat123', 'fake_token');
       var med = await isar.medications.where().findFirst();
       expect(med?.notes, 'Initial note');
 
@@ -154,21 +138,14 @@ void main() {
 
       when(() => mockFhirClient.getRDA(any(), any())).thenAnswer((_) async => rdaBundle2);
 
-      await syncRepository.syncAll();
+      await syncRepository.syncRda('pat123', 'fake_token');
 
       expect(await isar.medications.count(), 1);
       med = await isar.medications.where().findFirst();
       expect(med?.notes, 'Updated note');
     });
 
-    test('syncAll should not duplicate vitals with same type and timestamp', () async {
-       when(() => mockSecureStorage.read(key: 'ihce_access_token'))
-          .thenAnswer((_) async => 'fake_token');
-
-      await isar.writeTxn(() async {
-        await isar.userProfiles.put(UserProfile(epsPatientId: 'pat123'));
-      });
-
+    test('syncRda should not duplicate vitals with same type and timestamp', () async {
       final observationJson = {
         'resourceType': 'Observation',
         'code': {
@@ -191,13 +168,12 @@ void main() {
         ]
       };
 
-      when(() => mockFhirClient.getPatient(any(), any())).thenAnswer((_) async => {});
       when(() => mockFhirClient.getRDA(any(), any())).thenAnswer((_) async => rdaBundle);
 
-      await syncRepository.syncAll();
+      await syncRepository.syncRda('pat123', 'fake_token');
       expect(await isar.vitalSigns.count(), 1);
 
-      await syncRepository.syncAll();
+      await syncRepository.syncRda('pat123', 'fake_token');
       expect(await isar.vitalSigns.count(), 1);
     });
   });

--- a/test/features/sync/domain/sync_service_test.dart
+++ b/test/features/sync/domain/sync_service_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/sync/domain/sync_service.dart';
+import 'package:orionhealth_health/features/sync/domain/sync_repository.dart';
+import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
+import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
+import 'package:orionhealth_health/features/sync/domain/entities/sync_node.dart';
+
+class MockSyncRepository extends Mock implements SyncRepository {}
+class MockUserProfileRepository extends Mock implements UserProfileRepository {}
+
+void main() {
+  late SyncService syncService;
+  late MockSyncRepository mockSyncRepository;
+  late MockUserProfileRepository mockUserProfileRepository;
+
+  setUp(() {
+    mockSyncRepository = MockSyncRepository();
+    mockUserProfileRepository = MockUserProfileRepository();
+    syncService = SyncService(mockSyncRepository, mockUserProfileRepository);
+
+    // Default mock for getDiscoveredNodes to avoid TypeError
+    when(() => mockSyncRepository.getDiscoveredNodes()).thenReturn([]);
+  });
+
+  group('SyncService', () {
+    test('syncAll throws exception when no token', () async {
+      when(() => mockSyncRepository.getAccessToken()).thenAnswer((_) async => null);
+
+      expect(() => syncService.syncAll(), throwsException);
+    });
+
+    test('syncAll throws exception when no profile', () async {
+      when(() => mockSyncRepository.getAccessToken()).thenAnswer((_) async => 'token');
+      when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => null);
+
+      expect(() => syncService.syncAll(), throwsException);
+    });
+
+    test('syncAll performs sync correctly when everything is set', () async {
+      when(() => mockSyncRepository.getAccessToken()).thenAnswer((_) async => 'token');
+      when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => UserProfile(epsPatientId: '123'));
+      when(() => mockSyncRepository.syncPatient(any(), any())).thenAnswer((_) async => {});
+      when(() => mockSyncRepository.syncRda(any(), any())).thenAnswer((_) async => {});
+      when(() => mockSyncRepository.setLastSyncTime(any())).thenAnswer((_) async => {});
+
+      await syncService.syncAll();
+
+      verify(() => mockSyncRepository.syncPatient('123', 'token')).called(1);
+      verify(() => mockSyncRepository.syncRda('123', 'token')).called(1);
+      verify(() => mockSyncRepository.setLastSyncTime(any())).called(1);
+    });
+
+    test('syncIfStale does not sync if not stale', () async {
+      final lastSync = DateTime.now().subtract(const Duration(hours: 1));
+      when(() => mockSyncRepository.getLastSyncTime()).thenAnswer((_) async => lastSync);
+
+      final result = await syncService.syncIfStale();
+
+      expect(result, false);
+      verifyNever(() => mockSyncRepository.syncPatient(any(), any()));
+    });
+
+    test('syncIfStale syncs if stale', () async {
+      final lastSync = DateTime.now().subtract(const Duration(hours: 7));
+      when(() => mockSyncRepository.getLastSyncTime()).thenAnswer((_) async => lastSync);
+      when(() => mockSyncRepository.getAccessToken()).thenAnswer((_) async => 'token');
+      when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => UserProfile(epsPatientId: '123'));
+      when(() => mockSyncRepository.syncPatient(any(), any())).thenAnswer((_) async => {});
+      when(() => mockSyncRepository.syncRda(any(), any())).thenAnswer((_) async => {});
+      when(() => mockSyncRepository.setLastSyncTime(any())).thenAnswer((_) async => {});
+
+      final result = await syncService.syncIfStale();
+
+      expect(result, true);
+      verify(() => mockSyncRepository.syncPatient('123', 'token')).called(1);
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces a proper Domain layer for the sync feature, following Clean Architecture principles. 

Key changes:
- New `SyncNode` entity in `lib/features/sync/domain/entities/sync_node.dart` to represent discovered peers.
- New `SyncRepository` interface in `lib/features/sync/domain/sync_repository.dart` to decouple domain from data.
- New `SyncService` in `lib/features/sync/domain/sync_service.dart` which now handles the orchestration logic previously located in the data layer (syncing FHIR data, RDA, and P2P medical standards).
- Refactored the old `SyncRepository` to `SyncRepositoryImpl` in `lib/features/sync/data/sync_repository.dart`.
- Updated `FhirSyncCubit` to utilize the new `SyncService`.
- Added comprehensive unit tests for the `SyncService` and updated existing tests for the repository implementation.

Fixes #479

---
*PR created automatically by Jules for task [1356084477399627650](https://jules.google.com/task/1356084477399627650) started by @iberi22*