### PR TITLE
fix: unskip 2 wifi_direct_service network tests

### DIFF
--- a/lib/features/health_sharing/application/sharing_cubit.dart
+++ b/lib/features/health_sharing/application/sharing_cubit.dart
@@ -347,7 +347,7 @@ class SharingCubit extends Cubit<SharingState> {
         await _nfcService.startListening();
         break;
       case TransferMethod.wifi:
-        await _wifiService.startServer();
+        await _wifiService.startServer(expectedPin: pin);
         break;
     }
   }

--- a/lib/features/health_sharing/infrastructure/wifi_direct_service.dart
+++ b/lib/features/health_sharing/infrastructure/wifi_direct_service.dart
@@ -12,9 +12,9 @@ class WifiDirectService {
   static const Duration transferTimeout = Duration(minutes: 3);
 
   HttpServer? _server;
-  Socket? _socket;
   bool _isRunning = false;
   String? _deviceIp;
+  String? _expectedPinHash;
 
   final _stateController = StreamController<WifiSharingState>.broadcast();
   Stream<WifiSharingState> get stateStream => _stateController.stream;
@@ -58,8 +58,12 @@ class WifiDirectService {
   }
 
   /// Start HTTP server to receive data
-  Future<void> startServer({int port = kDefaultPort}) async {
+  Future<void> startServer({int port = kDefaultPort, String? expectedPin}) async {
     if (_isRunning) return;
+
+    if (expectedPin != null) {
+      _expectedPinHash = SharedHealthPackage.hashPin(expectedPin);
+    }
 
     try {
       _server = await HttpServer.bind(
@@ -110,8 +114,14 @@ class WifiDirectService {
       }
 
       // Verify PIN if provided
-      if (package.metadata.pinHash != null) {
-        // PIN verification would happen here
+      if (_expectedPinHash != null) {
+        if (package.metadata.pinHash != _expectedPinHash) {
+          request.response.statusCode = 401; // Unauthorized
+          request.response.writeln('Invalid PIN');
+          request.response.close();
+          _stateController.add(WifiSharingState.error('Invalid PIN verification'));
+          return;
+        }
       }
 
       _dataController.add(package);
@@ -137,6 +147,7 @@ class WifiDirectService {
     _stateController.add(WifiSharingState.connecting(targetIp));
 
     final startTime = DateTime.now();
+    final client = HttpClient();
 
     try {
       // Parse port from targetIp (format: 'ip:port') or use default
@@ -144,26 +155,18 @@ class WifiDirectService {
       final host = parts.isNotEmpty ? parts[0] : targetIp;
       final port = parts.length > 1 ? int.tryParse(parts[1]) ?? kDefaultPort : kDefaultPort;
 
-      _socket = await Socket.connect(
-        host,
-        port,
-        timeout: connectionTimeout,
-      );
+      final url = Uri.parse('http://$host:$port/orion/share');
+      final request = await client.postUrl(url).timeout(connectionTimeout);
 
       _stateController.add(WifiSharingState.transferring('Sending...'));
 
       final data = package.encode();
-      _socket!.add(utf8.encode(data));
-      await _socket!.flush();
+      request.write(data);
 
-      // Wait for response
-      final response = await _socket!.first.timeout(const Duration(seconds: 10));
-      final responseStr = utf8.decode(response);
+      final response = await request.close().timeout(transferTimeout);
+      final responseBody = await response.transform(utf8.decoder).join();
 
-      await _socket!.close();
-      _socket = null;
-
-      if (responseStr.contains('OK')) {
+      if (response.statusCode == 200) {
         final transferTime = DateTime.now().difference(startTime);
         _stateController.add(WifiSharingState.completed(data.length, transferTime));
 
@@ -173,12 +176,9 @@ class WifiDirectService {
           transferTime: transferTime,
         );
       } else {
-        throw Exception('Remote rejected transfer');
+        throw Exception('Remote rejected transfer: ${response.statusCode} $responseBody');
       }
     } catch (e) {
-      _socket?.close();
-      _socket = null;
-
       _stateController.add(WifiSharingState.error('Send failed: $e'));
 
       return SharingResult(
@@ -187,19 +187,19 @@ class WifiDirectService {
         bytesTransferred: 0,
         transferTime: DateTime.now().difference(startTime),
       );
+    } finally {
+      client.close();
     }
   }
 
   /// Stop server and clean up
   Future<void> stop() async {
-    _socket?.close();
-    _socket = null;
-
     await _server?.close(force: true);
     _server = null;
 
     _isRunning = false;
     _deviceIp = null;
+    _expectedPinHash = null;
 
     _stateController.add(WifiSharingState.ready());
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1166,18 +1166,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1634,10 +1634,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/health_sharing/infrastructure/wifi_direct_service_test.dart
+++ b/test/features/health_sharing/infrastructure/wifi_direct_service_test.dart
@@ -45,13 +45,12 @@ void main() {
     });
 
     test('full transfer with PIN verification success', () async {
-      // Requires real network — skip in CI mode
-      // Run with `flutter test` to execute
+      // Requires real network
       await service.initialize();
       const pin = '1234';
 
       // Start server with PIN
-      await service.startServer(port: 0);
+      await service.startServer(port: 0, expectedPin: pin);
       final address = service.serverAddress!;
 
       final package = SharedHealthPackage(
@@ -80,14 +79,14 @@ void main() {
       expect(result.success, isTrue);
       final receivedPackage = await dataFuture;
       expect(receivedPackage.id, 'test');
-    }, skip: true);
+    });
 
     test('transfer with PIN verification failure', () async {
-      // Requires real network — skip in CI mode
+      // Requires real network
       await service.initialize();
 
       // Start server with one PIN
-      await service.startServer(port: 0);
+      await service.startServer(port: 0, expectedPin: '1234');
       final address = service.serverAddress!;
 
       final package = SharedHealthPackage(
@@ -111,7 +110,7 @@ void main() {
 
       expect(result.success, isFalse);
       expect(result.error, contains('401'));
-    }, skip: true);
+    });
 
     test('stop() resets state correctly', () async {
       await service.initialize();


### PR DESCRIPTION
This PR unskips and fixes the two network transfer tests in `WifiDirectService`. 

Key changes:
1. **WifiDirectService Implementation**:
   - Added `_expectedPinHash` to store the hashed PIN for verification.
   - Updated `startServer` to accept an `expectedPin`.
   - Implemented PIN verification in `_handleRequest`, returning 401 Unauthorized on mismatch.
   - Refactored `sendData` to use `HttpClient` for proper HTTP POST communication, replacing the previous incorrect raw Socket implementation.
   
2. **SharingCubit Integration**:
   - Updated `startListening` to pass the optional PIN from the UI/Cubit state down to `WifiDirectService.startServer`.

3. **Test Updates**:
   - Removed `skip: true` from "full transfer with PIN verification success" and "transfer with PIN verification failure" in `wifi_direct_service_test.dart`.
   - Updated test cases to correctly configure the server with an expected PIN.

All tests in `test/features/health_sharing/` now pass.

Fixes #478

---
*PR created automatically by Jules for task [7314809935003251990](https://jules.google.com/task/7314809935003251990) started by @iberi22*