### PR TITLE
feat: onboarding - add Infrastructure layer

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -29,8 +29,8 @@ import '../../features/appointments/domain/services/appointment_service.dart'
     as _i4;
 import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
     as _i86;
-import '../../features/auth/application/auth_cubit.dart' as _i119;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i120;
+import '../../features/auth/application/auth_cubit.dart' as _i121;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i122;
 import '../../features/auth/domain/auth_service.dart' as _i89;
 import '../../features/auth/domain/repositories/auth_repository.dart' as _i87;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
@@ -66,7 +66,7 @@ import '../../features/health_data_import/application/health_import_cubit.dart'
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i18;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i121;
+    as _i123;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
     as _i102;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
@@ -86,7 +86,7 @@ import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
     as _i64;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i116;
+    as _i118;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i35;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i25;
@@ -108,7 +108,7 @@ import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
     as _i109;
 import '../../features/local_agent/infrastructure/llm_service.dart' as _i108;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
-    as _i122;
+    as _i124;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
     as _i36;
 import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
@@ -120,11 +120,11 @@ import '../../features/local_agent/infrastructure/services/llm_adapter_factory.d
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i31;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i123;
+    as _i125;
 import '../../features/local_agent/infrastructure/services/model_download_service.dart'
     as _i48;
 import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i113;
+    as _i115;
 import '../../features/medical_assistant/application/medical_assistant_cubit.dart'
     as _i111;
 import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
@@ -175,24 +175,30 @@ import '../../features/medications/domain/repositories/medication_repository.dar
     as _i45;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
     as _i46;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i55;
-import '../../features/onboarding/application/sync_cubit.dart' as _i117;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i124;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i126;
+import '../../features/onboarding/application/sync_cubit.dart' as _i119;
+import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
+    as _i113;
+import '../../features/onboarding/domain/services/profile_analysis_service.dart'
+    as _i55;
+import '../../features/onboarding/infrastructure/onboarding_repository_impl.dart'
+    as _i114;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i127;
 import '../../features/reports/domain/repositories/report_repository.dart'
     as _i59;
 import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i114;
+    as _i116;
 import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i60;
 import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i115;
+    as _i117;
 import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i47;
 import '../../features/settings/application/llm_settings_cubit.dart' as _i110;
 import '../../features/settings/domain/repositories/llm_settings_repository.dart'
     as _i29;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i11;
+    as _i12;
 import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
     as _i30;
 import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i66;
@@ -211,7 +217,7 @@ import '../../features/sync/data/node_discovery_service.dart' as _i50;
 import '../../features/sync/data/sync_repository.dart' as _i71;
 import '../../features/sync/domain/sync_cubit.dart' as _i98;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i118;
+    as _i120;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
     as _i72;
 import '../../features/user_profile/domain/services/user_profile_service.dart'
@@ -222,16 +228,16 @@ import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
     as _i79;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
     as _i80;
-import '../services/device_capability_service.dart' as _i12;
+import '../services/device_capability_service.dart' as _i11;
 import '../services/privacy_anonymizer.dart' as _i56;
-import 'database_module.dart' as _i128;
-import 'fhir_module.dart' as _i125;
-import 'memory_module.dart' as _i127;
-import 'network_module.dart' as _i126;
+import 'database_module.dart' as _i131;
+import 'fhir_module.dart' as _i128;
+import 'memory_module.dart' as _i130;
+import 'network_module.dart' as _i129;
 
-const String _mobile = 'mobile';
 const String _desktop = 'desktop';
 const String _test = 'test';
+const String _mobile = 'mobile';
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -352,7 +358,8 @@ extension GetItInjectableX on _i1.GetIt {
           refreshTokenKey: gh<String>(),
         ));
     gh.lazySingleton<_i54.OcrService>(() => _i54.MlKitOcrService());
-    gh.factory<_i55.OnboardingCubit>(() => _i55.OnboardingCubit());
+    gh.factory<_i55.ProfileAnalysisService>(
+        () => _i55.ProfileAnalysisService());
     gh.lazySingleton<_i56.PromptScrubber>(
         () => _i56.PromptScrubber(gh<_i20.Isar>()));
     gh.lazySingleton<_i57.RatingRepository>(
@@ -471,7 +478,7 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.factory<_i110.LlmSettingsCubit>(() => _i110.LlmSettingsCubit(
           gh<_i29.LlmSettingsRepository>(),
-          gh<_i11.DeviceCapabilityService>(),
+          gh<_i12.DeviceCapabilityService>(),
           gh<_i25.LlmAdapter>(instanceName: 'gemma'),
         ));
     gh.factory<_i111.MedicalAssistantCubit>(() => _i111.MedicalAssistantCubit(
@@ -484,8 +491,10 @@ extension GetItInjectableX on _i1.GetIt {
               gh<_i43.MedicalWebSearchService>(),
               gh<_i39.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i113.PatientContextIndexer>(
-      () => _i113.PatientContextIndexer(
+    gh.lazySingleton<_i113.OnboardingRepository>(
+        () => _i114.OnboardingRepositoryImpl(gh<_i72.UserProfileRepository>()));
+    gh.lazySingleton<_i115.PatientContextIndexer>(
+      () => _i115.PatientContextIndexer(
         gh<_i20.Isar>(),
         gh<_i75.VectorStoreService>(),
         gh<_i102.HealthRecordRepository>(),
@@ -496,28 +505,28 @@ extension GetItInjectableX on _i1.GetIt {
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i114.ReportGenerationService>(
-        () => _i115.GemmaReportGenerationService(
+    gh.lazySingleton<_i116.ReportGenerationService>(
+        () => _i117.GemmaReportGenerationService(
               gh<_i25.LlmAdapter>(instanceName: 'gemma'),
               gh<_i75.VectorStoreService>(),
               gh<_i72.UserProfileRepository>(),
               gh<_i56.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i116.SmartSearchUseCase>(
-        () => _i116.SmartSearchUseCase(gh<_i75.VectorStoreService>()));
-    gh.factory<_i117.SyncCubit>(() => _i117.SyncCubit(
+    gh.lazySingleton<_i118.SmartSearchUseCase>(
+        () => _i118.SmartSearchUseCase(gh<_i75.VectorStoreService>()));
+    gh.factory<_i119.SyncCubit>(() => _i119.SyncCubit(
           gh<_i33.SyncService>(),
           gh<_i75.VectorStoreService>(),
         ));
-    gh.factory<_i118.UserProfileCubit>(
-        () => _i118.UserProfileCubit(gh<_i72.UserProfileRepository>()));
-    gh.factory<_i119.AuthCubit>(() => _i119.AuthCubit(gh<_i89.AuthService>()));
-    gh.factory<_i120.AuthCubit>(() => _i120.AuthCubit(
+    gh.factory<_i120.UserProfileCubit>(
+        () => _i120.UserProfileCubit(gh<_i72.UserProfileRepository>()));
+    gh.factory<_i121.AuthCubit>(() => _i121.AuthCubit(gh<_i89.AuthService>()));
+    gh.factory<_i122.AuthCubit>(() => _i122.AuthCubit(
           gh<_i87.AuthRepository>(),
           gh<_i15.EncryptionService>(),
           gh<_i5.BiometricService>(),
         ));
-    gh.factory<_i121.HealthRecordCubit>(() => _i121.HealthRecordCubit(
+    gh.factory<_i123.HealthRecordCubit>(() => _i123.HealthRecordCubit(
           gh<_i102.HealthRecordRepository>(),
           gh<_i17.FilePickerService>(),
           gh<_i19.ImagePickerService>(),
@@ -525,7 +534,7 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i75.VectorStoreService>(),
         ));
     gh.lazySingleton<_i108.LlmService>(
-      () => _i122.RagLlmService(
+      () => _i124.RagLlmService(
         gh<_i75.VectorStoreService>(),
         gh<_i112.MedicalResearchService>(),
         gh<_i72.UserProfileRepository>(),
@@ -533,24 +542,28 @@ extension GetItInjectableX on _i1.GetIt {
       ),
       instanceName: 'rag',
     );
-    gh.lazySingleton<_i123.MedicalIndexingService>(
-        () => _i123.MedicalIndexingService(
+    gh.lazySingleton<_i125.MedicalIndexingService>(
+        () => _i125.MedicalIndexingService(
               gh<_i35.MedicalKnowledgeRepository>(),
               gh<_i75.VectorStoreService>(),
-              gh<_i113.PatientContextIndexer>(),
+              gh<_i115.PatientContextIndexer>(),
             ));
-    gh.factory<_i124.ReportBloc>(() => _i124.ReportBloc(
+    gh.factory<_i126.OnboardingCubit>(() => _i126.OnboardingCubit(
+          gh<_i113.OnboardingRepository>(),
+          gh<_i55.ProfileAnalysisService>(),
+        ));
+    gh.factory<_i127.ReportBloc>(() => _i127.ReportBloc(
           gh<_i59.ReportRepository>(),
-          gh<_i114.ReportGenerationService>(),
+          gh<_i116.ReportGenerationService>(),
         ));
     return this;
   }
 }
 
-class _$FhirModule extends _i125.FhirModule {}
+class _$FhirModule extends _i128.FhirModule {}
 
-class _$NetworkModule extends _i126.NetworkModule {}
+class _$NetworkModule extends _i129.NetworkModule {}
 
-class _$MemoryModule extends _i127.MemoryModule {}
+class _$MemoryModule extends _i130.MemoryModule {}
 
-class _$DatabaseModule extends _i128.DatabaseModule {}
+class _$DatabaseModule extends _i131.DatabaseModule {}

--- a/lib/features/onboarding/application/onboarding_cubit.dart
+++ b/lib/features/onboarding/application/onboarding_cubit.dart
@@ -2,6 +2,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:injectable/injectable.dart';
 import '../domain/entities/user_profile.dart';
+import '../domain/repositories/onboarding_repository.dart';
 import '../domain/services/profile_analysis_service.dart';
 
 // ============================================================================
@@ -129,17 +130,28 @@ enum OnboardingStep {
 
 @injectable
 class OnboardingCubit extends Cubit<OnboardingState> {
+  final OnboardingRepository _repository;
   final ProfileAnalysisService _analysisService;
 
-  OnboardingCubit()
-      : _analysisService = ProfileAnalysisService(),
-        super(OnboardingInitial());
+  OnboardingCubit(this._repository, this._analysisService)
+      : super(OnboardingInitial());
 
   static final int totalSteps = OnboardingStep.values.length;
 
   /// Start onboarding flow
   Future<void> startOnboarding() async {
     emit(const OnboardingLoading('Iniciando...'));
+
+    // Check for saved progress
+    final savedProfile = await _repository.getOnboardingProfile();
+    if (savedProfile != null) {
+      emit(OnboardingInProgress(
+        currentStep: savedProfile.onboardingStep,
+        totalSteps: totalSteps,
+        profile: savedProfile,
+      ));
+      return;
+    }
 
     final now = DateTime.now();
     final profile = UserProfile(
@@ -187,6 +199,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       updatedAt: DateTime.now(),
     );
 
+    await _repository.saveOnboardingProfile(updatedProfile);
+
     emit(currentState.copyWith(
       currentStep: OnboardingStep.basicInfo.index,
       profile: updatedProfile,
@@ -202,6 +216,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       conditions: conditions,
       updatedAt: DateTime.now(),
     );
+
+    await _repository.saveOnboardingProfile(updatedProfile);
 
     emit(currentState.copyWith(
       currentStep: OnboardingStep.conditions.index,
@@ -219,6 +235,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       updatedAt: DateTime.now(),
     );
 
+    await _repository.saveOnboardingProfile(updatedProfile);
+
     emit(currentState.copyWith(
       currentStep: OnboardingStep.familyHistory.index,
       profile: updatedProfile,
@@ -234,6 +252,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       medications: medications,
       updatedAt: DateTime.now(),
     );
+
+    await _repository.saveOnboardingProfile(updatedProfile);
 
     emit(currentState.copyWith(
       currentStep: OnboardingStep.medications.index,
@@ -254,6 +274,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       locale: locale,
       updatedAt: DateTime.now(),
     );
+
+    await _repository.saveOnboardingProfile(updatedProfile);
 
     emit(currentState.copyWith(
       currentStep: OnboardingStep.privacy.index,
@@ -307,6 +329,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       updatedAt: DateTime.now(),
     );
 
+    await _repository.completeOnboarding(completedProfile);
+
     emit(OnboardingCompleted(profile: completedProfile));
   }
 
@@ -354,6 +378,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
         updatedAt: DateTime.now(),
       );
 
+      await _repository.saveOnboardingProfile(updatedProfile);
+
       emit(currentState.copyWith(
         currentStep: currentState.currentStep + 1,
         profile: updatedProfile,
@@ -372,6 +398,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
         updatedAt: DateTime.now(),
       );
 
+      await _repository.saveOnboardingProfile(updatedProfile);
+
       emit(currentState.copyWith(
         currentStep: currentState.currentStep - 1,
         profile: updatedProfile,
@@ -389,6 +417,8 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       onboardingCompleted: true,
       updatedAt: DateTime.now(),
     );
+
+    await _repository.completeOnboarding(skippedProfile);
 
     emit(OnboardingCompleted(profile: skippedProfile));
   }
@@ -410,6 +440,7 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       name: name,
       updatedAt: DateTime.now(),
     );
+    await _repository.saveOnboardingProfile(updatedProfile);
     emit(currentState.copyWith(profile: updatedProfile));
   }
 
@@ -421,6 +452,7 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       weightKg: weightKg,
       updatedAt: DateTime.now(),
     );
+    await _repository.saveOnboardingProfile(updatedProfile);
     emit(currentState.copyWith(profile: updatedProfile));
   }
 
@@ -432,6 +464,7 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       heightCm: heightCm,
       updatedAt: DateTime.now(),
     );
+    await _repository.saveOnboardingProfile(updatedProfile);
     emit(currentState.copyWith(profile: updatedProfile));
   }
 
@@ -443,6 +476,7 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       birthDate: birthDate,
       updatedAt: DateTime.now(),
     );
+    await _repository.saveOnboardingProfile(updatedProfile);
     emit(currentState.copyWith(profile: updatedProfile));
   }
 
@@ -454,12 +488,20 @@ class OnboardingCubit extends Cubit<OnboardingState> {
       sex: sex,
       updatedAt: DateTime.now(),
     );
+    await _repository.saveOnboardingProfile(updatedProfile);
     emit(currentState.copyWith(profile: updatedProfile));
   }
 
   /// Update allergies (from medications_step)
   Future<void> updateAllergies(List<String> allergies) async {
-    // Store allergies in profile; medications_step uses this
+    final currentState = state;
+    if (currentState is! OnboardingInProgress) return;
+    final updatedProfile = currentState.profile.copyWith(
+      allergies: allergies,
+      updatedAt: DateTime.now(),
+    );
+    await _repository.saveOnboardingProfile(updatedProfile);
+    emit(currentState.copyWith(profile: updatedProfile));
   }
 
   /// Save and complete (from privacy_step)

--- a/lib/features/onboarding/domain/repositories/onboarding_repository.dart
+++ b/lib/features/onboarding/domain/repositories/onboarding_repository.dart
@@ -1,0 +1,19 @@
+import '../entities/user_profile.dart';
+
+abstract class OnboardingRepository {
+  /// Gets the current onboarding progress (temporary profile)
+  Future<UserProfile?> getOnboardingProfile();
+
+  /// Saves the current onboarding progress
+  Future<void> saveOnboardingProfile(UserProfile profile);
+
+  /// Completes onboarding, persists the final profile to main storage,
+  /// and marks onboarding as finished.
+  Future<void> completeOnboarding(UserProfile profile);
+
+  /// Checks if the onboarding process has been completed.
+  Future<bool> isOnboardingCompleted();
+
+  /// Resets onboarding status (mainly for testing)
+  Future<void> resetOnboarding();
+}

--- a/lib/features/onboarding/domain/services/profile_analysis_service.dart
+++ b/lib/features/onboarding/domain/services/profile_analysis_service.dart
@@ -1,3 +1,4 @@
+import 'package:injectable/injectable.dart';
 import '../entities/user_profile.dart';
 
 /// Result of analyzing a user profile for relevant medical standards.
@@ -18,6 +19,7 @@ class RelevantStandards {
 }
 
 /// Service to analyze user profile and determine relevant medical context
+@injectable
 class ProfileAnalysisService {
   /// Analyze user profile and return relevant standards
   RelevantStandards analyzeProfile(UserProfile profile) {

--- a/lib/features/onboarding/infrastructure/onboarding_repository_impl.dart
+++ b/lib/features/onboarding/infrastructure/onboarding_repository_impl.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'package:injectable/injectable.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import '../../user_profile/domain/repositories/user_profile_repository.dart';
+import '../../user_profile/domain/entities/user_profile.dart' as domain;
+import '../domain/entities/user_profile.dart' as onboarding;
+import '../domain/repositories/onboarding_repository.dart';
+
+@LazySingleton(as: OnboardingRepository)
+class OnboardingRepositoryImpl implements OnboardingRepository {
+  final UserProfileRepository _userProfileRepository;
+  static const String _onboardingProfileKey = 'onboarding_profile';
+  static const String _onboardingCompletedKey = 'onboarding_completed';
+
+  OnboardingRepositoryImpl(this._userProfileRepository);
+
+  @override
+  Future<onboarding.UserProfile?> getOnboardingProfile() async {
+    final prefs = await SharedPreferences.getInstance();
+    final profileJson = prefs.getString(_onboardingProfileKey);
+    if (profileJson == null) return null;
+
+    try {
+      return onboarding.UserProfile.fromJson(jsonDecode(profileJson));
+    } catch (e) {
+      return null;
+    }
+  }
+
+  @override
+  Future<void> saveOnboardingProfile(onboarding.UserProfile profile) async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setString(_onboardingProfileKey, jsonEncode(profile.toJson()));
+  }
+
+  @override
+  Future<void> completeOnboarding(onboarding.UserProfile profile) async {
+    // 1. Save to main Isar storage via UserProfileRepository
+    final domainProfile = _mapToDomain(profile);
+    await _userProfileRepository.saveUserProfile(domainProfile);
+
+    // 2. Mark as completed in SharedPreferences
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_onboardingCompletedKey, true);
+
+    // 3. Clear temporary onboarding profile
+    await prefs.remove(_onboardingProfileKey);
+  }
+
+  @override
+  Future<bool> isOnboardingCompleted() async {
+    final prefs = await SharedPreferences.getInstance();
+    return prefs.getBool(_onboardingCompletedKey) ?? false;
+  }
+
+  @override
+  Future<void> resetOnboarding() async {
+    final prefs = await SharedPreferences.getInstance();
+    await prefs.setBool(_onboardingCompletedKey, false);
+    await prefs.remove(_onboardingProfileKey);
+    await _userProfileRepository.deleteUserProfile();
+  }
+
+  domain.UserProfile _mapToDomain(onboarding.UserProfile profile) {
+    return domain.UserProfile(
+      name: profile.name,
+      birthDate: profile.birthDate,
+      sex: profile.sex,
+      weight: profile.weightKg,
+      height: profile.heightCm,
+      medicalConditions: profile.conditions,
+      currentMedications: profile.medications,
+      onboardingCompleted: true,
+      isEpsConnected: profile.isEpsConnected,
+      epsPatientId: profile.epsPatientId,
+      // Map other fields as necessary
+      allergyName: profile.allergies.isNotEmpty ? profile.allergies.join(', ') : null,
+      familyHistoryCvd: profile.familyHistory.any((e) => e.toLowerCase().contains('corazón') || e.toLowerCase().contains('cardio')),
+      familyHistoryDiabetes: profile.familyHistory.any((e) => e.toLowerCase().contains('diabetes')),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -13,6 +13,7 @@ import 'core/theme/app_theme.dart';
 
 import 'package:isar_agent_memory/isar_agent_memory.dart';
 import 'features/local_agent/infrastructure/services/medical_indexing_service.dart';
+import 'features/onboarding/domain/repositories/onboarding_repository.dart';
 import 'features/onboarding/presentation/pages/onboarding_page.dart';
 import 'features/onboarding/application/onboarding_cubit.dart';
 import 'features/sync/data/sync_repository.dart';
@@ -153,8 +154,7 @@ class _StartupRouter extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return FutureBuilder<bool>(
-      future: SharedPreferences.getInstance()
-          .then((p) => p.getBool('onboarding_completed') ?? false),
+      future: getIt<OnboardingRepository>().isOnboardingCompleted(),
       builder: (context, snap) {
         if (!snap.hasData) {
           return const Scaffold(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1166,18 +1166,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1634,10 +1634,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/onboarding/application/onboarding_cubit_test.dart
+++ b/test/features/onboarding/application/onboarding_cubit_test.dart
@@ -1,12 +1,37 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/onboarding/application/onboarding_cubit.dart';
 import 'package:orionhealth_health/features/onboarding/domain/entities/user_profile.dart';
+import 'package:orionhealth_health/features/onboarding/domain/repositories/onboarding_repository.dart';
+import 'package:orionhealth_health/features/onboarding/domain/services/profile_analysis_service.dart';
+
+class MockOnboardingRepository extends Mock implements OnboardingRepository {}
+class MockProfileAnalysisService extends Mock implements ProfileAnalysisService {}
 
 void main() {
   late OnboardingCubit cubit;
+  late MockOnboardingRepository mockRepository;
+  late MockProfileAnalysisService mockAnalysisService;
 
   setUp(() {
-    cubit = OnboardingCubit();
+    mockRepository = MockOnboardingRepository();
+    mockAnalysisService = MockProfileAnalysisService();
+
+    registerFallbackValue(UserProfile(
+      createdAt: DateTime.now(),
+      updatedAt: DateTime.now(),
+    ));
+
+    when(() => mockRepository.getOnboardingProfile())
+        .thenAnswer((_) async => null);
+    when(() => mockRepository.saveOnboardingProfile(any()))
+        .thenAnswer((_) async => {});
+    when(() => mockRepository.completeOnboarding(any()))
+        .thenAnswer((_) async => {});
+    when(() => mockAnalysisService.analyzeProfile(any()))
+        .thenReturn(const RelevantStandards());
+
+    cubit = OnboardingCubit(mockRepository, mockAnalysisService);
   });
 
   tearDown(() {
@@ -24,6 +49,28 @@ void main() {
         emitsInOrder([
           isA<OnboardingLoading>(),
           isA<OnboardingInProgress>().having((s) => s.currentStep, 'currentStep', 0),
+        ]),
+      );
+
+      await cubit.startOnboarding();
+      await expectation;
+      verify(() => mockRepository.getOnboardingProfile()).called(1);
+    });
+
+    test('startOnboarding resumes if saved profile exists', () async {
+      final savedProfile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        onboardingStep: 3,
+      );
+      when(() => mockRepository.getOnboardingProfile())
+          .thenAnswer((_) async => savedProfile);
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          isA<OnboardingLoading>(),
+          isA<OnboardingInProgress>().having((s) => s.currentStep, 'currentStep', 3),
         ]),
       );
 
@@ -190,6 +237,7 @@ void main() {
       expect(state.profile.weightKg, 80);
       expect(state.profile.heightCm, 180);
       expect(state.currentStep, OnboardingStep.basicInfo.index);
+      verify(() => mockRepository.saveOnboardingProfile(any())).called(1);
     });
 
     test('completeOnboarding emits syncing states then Completed', () async {
@@ -205,6 +253,7 @@ void main() {
 
       expect(cubit.state, isA<OnboardingCompleted>());
       expect((cubit.state as OnboardingCompleted).profile.onboardingCompleted, true);
+      verify(() => mockRepository.completeOnboarding(any())).called(1);
     });
   });
 }


### PR DESCRIPTION
This PR introduces the Infrastructure layer for the onboarding feature to handle persistence of user progress.

Key changes:
- Defined `OnboardingRepository` interface in `lib/features/onboarding/domain/repositories/`.
- Implemented `OnboardingRepositoryImpl` in `lib/features/onboarding/infrastructure/`, providing a bridge between temporary `SharedPreferences` storage (for drafts) and permanent `Isar` storage (for completed profiles).
- Refactored `OnboardingCubit` to accept `OnboardingRepository` and `ProfileAnalysisService` via constructor injection, enabling automated saving of progress at each step.
- Updated `_StartupRouter` in `main.dart` to utilize the new repository for checking onboarding completion status.
- Updated unit tests in `test/features/onboarding/application/onboarding_cubit_test.dart` with comprehensive mocks and persistence verifications.
- Regenerated dependency injection configuration using `build_runner`.

Fixes #481

---
*PR created automatically by Jules for task [17030320099479332690](https://jules.google.com/task/17030320099479332690) started by @iberi22*