### PR TITLE
Add Infrastructure layer to Home feature

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -29,8 +29,8 @@ import '../../features/appointments/domain/services/appointment_service.dart'
     as _i4;
 import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
     as _i86;
-import '../../features/auth/application/auth_cubit.dart' as _i119;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i120;
+import '../../features/auth/application/auth_cubit.dart' as _i120;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i119;
 import '../../features/auth/domain/auth_service.dart' as _i89;
 import '../../features/auth/domain/repositories/auth_repository.dart' as _i87;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
@@ -85,6 +85,9 @@ import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
     as _i49;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
     as _i64;
+import '../../features/home/application/home_cubit.dart' as _i127;
+import '../../features/home/domain/repositories/home_repository.dart' as _i125;
+import '../../features/home/infrastructure/home_repository_impl.dart' as _i126;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
     as _i116;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
@@ -192,7 +195,7 @@ import '../../features/settings/application/llm_settings_cubit.dart' as _i110;
 import '../../features/settings/domain/repositories/llm_settings_repository.dart'
     as _i29;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i11;
+    as _i12;
 import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
     as _i30;
 import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i66;
@@ -222,16 +225,16 @@ import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
     as _i79;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
     as _i80;
-import '../services/device_capability_service.dart' as _i12;
+import '../services/device_capability_service.dart' as _i11;
 import '../services/privacy_anonymizer.dart' as _i56;
-import 'database_module.dart' as _i128;
-import 'fhir_module.dart' as _i125;
-import 'memory_module.dart' as _i127;
-import 'network_module.dart' as _i126;
+import 'database_module.dart' as _i131;
+import 'fhir_module.dart' as _i128;
+import 'memory_module.dart' as _i130;
+import 'network_module.dart' as _i129;
 
-const String _mobile = 'mobile';
 const String _desktop = 'desktop';
 const String _test = 'test';
+const String _mobile = 'mobile';
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -471,7 +474,7 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.factory<_i110.LlmSettingsCubit>(() => _i110.LlmSettingsCubit(
           gh<_i29.LlmSettingsRepository>(),
-          gh<_i11.DeviceCapabilityService>(),
+          gh<_i12.DeviceCapabilityService>(),
           gh<_i25.LlmAdapter>(instanceName: 'gemma'),
         ));
     gh.factory<_i111.MedicalAssistantCubit>(() => _i111.MedicalAssistantCubit(
@@ -511,12 +514,12 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.factory<_i118.UserProfileCubit>(
         () => _i118.UserProfileCubit(gh<_i72.UserProfileRepository>()));
-    gh.factory<_i119.AuthCubit>(() => _i119.AuthCubit(gh<_i89.AuthService>()));
-    gh.factory<_i120.AuthCubit>(() => _i120.AuthCubit(
+    gh.factory<_i119.AuthCubit>(() => _i119.AuthCubit(
           gh<_i87.AuthRepository>(),
           gh<_i15.EncryptionService>(),
           gh<_i5.BiometricService>(),
         ));
+    gh.factory<_i120.AuthCubit>(() => _i120.AuthCubit(gh<_i89.AuthService>()));
     gh.factory<_i121.HealthRecordCubit>(() => _i121.HealthRecordCubit(
           gh<_i102.HealthRecordRepository>(),
           gh<_i17.FilePickerService>(),
@@ -543,14 +546,22 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i59.ReportRepository>(),
           gh<_i114.ReportGenerationService>(),
         ));
+    gh.lazySingleton<_i125.HomeRepository>(() => _i126.HomeRepositoryImpl(
+          gh<_i79.VitalSignRepository>(),
+          gh<_i123.MedicalIndexingService>(),
+          gh<_i32.MedicalAnalysisService>(),
+          gh<_i72.UserProfileRepository>(),
+        ));
+    gh.factory<_i127.HomeCubit>(
+        () => _i127.HomeCubit(gh<_i125.HomeRepository>()));
     return this;
   }
 }
 
-class _$FhirModule extends _i125.FhirModule {}
+class _$FhirModule extends _i128.FhirModule {}
 
-class _$NetworkModule extends _i126.NetworkModule {}
+class _$NetworkModule extends _i129.NetworkModule {}
 
-class _$MemoryModule extends _i127.MemoryModule {}
+class _$MemoryModule extends _i130.MemoryModule {}
 
-class _$DatabaseModule extends _i128.DatabaseModule {}
+class _$DatabaseModule extends _i131.DatabaseModule {}

--- a/lib/features/home/application/home_cubit.dart
+++ b/lib/features/home/application/home_cubit.dart
@@ -1,34 +1,22 @@
 import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:medical_standards/medical_standards.dart';
-import '../domain/services/icd10_catalog.dart';
-import '../../vitals/domain/repositories/vital_sign_repository.dart';
-import '../../vitals/domain/entities/vital_sign.dart' as entity;
-import '../../local_agent/infrastructure/services/medical_indexing_service.dart';
-import '../../medical_assistant/domain/services/medical_analysis_service.dart';
-import '../../user_profile/domain/repositories/user_profile_repository.dart';
+import 'package:injectable/injectable.dart';
+import '../domain/repositories/home_repository.dart';
 import 'home_state.dart';
 
+@injectable
 class HomeCubit extends Cubit<HomeState> {
-  final VitalSignRepository _vitalSignRepository;
-  final MedicalIndexingService _indexingService;
-  final MedicalAnalysisService _analysisService;
-  final UserProfileRepository _userProfileRepository;
+  final HomeRepository _homeRepository;
   StreamSubscription<bool>? _indexingSubscription;
 
-  HomeCubit(
-    this._vitalSignRepository,
-    this._indexingService,
-    this._analysisService,
-    this._userProfileRepository,
-  ) : super(const HomeState()) {
+  HomeCubit(this._homeRepository) : super(const HomeState()) {
     _init();
   }
 
   void _init() {
-    emit(state.copyWith(isIndexing: !_indexingService.hasIndexed));
+    emit(state.copyWith(isIndexing: !_homeRepository.hasIndexed));
 
-    _indexingSubscription = _indexingService.statusStream.listen((isDone) {
+    _indexingSubscription = _homeRepository.indexingStatusStream.listen((isDone) {
       emit(state.copyWith(
         isIndexing: !isDone,
         indexingError: false,
@@ -40,12 +28,8 @@ class HomeCubit extends Cubit<HomeState> {
 
   Future<void> retryIndexing() async {
     emit(state.copyWith(isIndexing: true, indexingError: false));
-    try {
-      final result = await _indexingService.indexAll(force: true);
-      if (!result.success) {
-        emit(state.copyWith(isIndexing: false, indexingError: true));
-      }
-    } catch (e) {
+    final success = await _homeRepository.retryIndexing();
+    if (!success) {
       emit(state.copyWith(isIndexing: false, indexingError: true));
     }
   }
@@ -53,56 +37,8 @@ class HomeCubit extends Cubit<HomeState> {
   Future<void> loadVitals() async {
     emit(state.copyWith(isLoadingVitals: true));
     try {
-      final vitals = await _vitalSignRepository.getLatestVitals();
-
-      // Convert latest vitals to a map suitable for MedicalAnalysisService
-      final vitalsMap = <String, double>{};
-      final hr = vitals[entity.VitalSignType.heartRate];
-      if (hr != null) {
-        vitalsMap['heartRate'] = hr.value;
-      }
-      final systolic = vitals[entity.VitalSignType.bloodPressureSystolic];
-      if (systolic != null) {
-        vitalsMap['systolic'] = systolic.value;
-      }
-      final diastolic = vitals[entity.VitalSignType.bloodPressureDiastolic];
-      if (diastolic != null) {
-        vitalsMap['diastolic'] = diastolic.value;
-      }
-      final temp = vitals[entity.VitalSignType.temperature];
-      if (temp != null) {
-        vitalsMap['temperature'] = temp.value;
-      }
-      final spo2 = vitals[entity.VitalSignType.oxygenSaturation];
-      if (spo2 != null) {
-        vitalsMap['oxygenSaturation'] = spo2.value;
-      }
-
-      // Load chronic conditions from user profile (parallelized)
-      final userProfile = await _userProfileRepository.getUserProfile();
-      final chronicConditions = <Icd10Code>[];
-      if (userProfile != null && userProfile.medicalConditions.isNotEmpty) {
-        for (final s in userProfile.medicalConditions) {
-          final code = Icd10Catalog.findByCode(s);
-          if (code != null) chronicConditions.add(code);
-        }
-      }
-
-      // Perform analysis
-      final vitalInsights = await _analysisService.analyzeVitals(
-        vitals: vitalsMap,
-        chronicConditions: chronicConditions,
-      );
-
-      final riskInsights = await _analysisService.calculateRisks(
-        labValues: {}, // Home dashboard focus on vitals for now
-        vitals: vitalsMap,
-        conditions: chronicConditions,
-      );
-
-      final allInsights = [...vitalInsights, ...riskInsights];
-      // Sort by severity (critical > alert > warning > info)
-      allInsights.sort((a, b) => b.severity.index.compareTo(a.severity.index));
+      final vitals = await _homeRepository.getLatestVitals();
+      final allInsights = await _homeRepository.getRecentInsights();
 
       emit(state.copyWith(
         latestVitals: vitals,

--- a/lib/features/home/domain/repositories/home_repository.dart
+++ b/lib/features/home/domain/repositories/home_repository.dart
@@ -1,0 +1,21 @@
+import 'package:medical_standards/medical_standards.dart' hide VitalSign;
+import '../../../vitals/domain/entities/vital_sign.dart';
+import '../../../medical_assistant/domain/entities/medical_insight.dart';
+
+/// Repository interface for Home dashboard data orchestration.
+abstract class HomeRepository {
+  /// Whether the medical standards indexing has completed.
+  bool get hasIndexed;
+
+  /// Stream of indexing status updates.
+  Stream<bool> get indexingStatusStream;
+
+  /// Retries the indexing process.
+  Future<bool> retryIndexing();
+
+  /// Retrieves the latest recorded vital signs.
+  Future<Map<VitalSignType, VitalSign?>> getLatestVitals();
+
+  /// Retrieves recent medical insights based on vitals and conditions.
+  Future<List<MedicalInsight>> getRecentInsights();
+}

--- a/lib/features/home/infrastructure/home_repository_impl.dart
+++ b/lib/features/home/infrastructure/home_repository_impl.dart
@@ -1,0 +1,103 @@
+import 'dart:async';
+import 'package:injectable/injectable.dart';
+import 'package:medical_standards/medical_standards.dart' hide VitalSign;
+import '../domain/repositories/home_repository.dart';
+import '../domain/services/icd10_catalog.dart';
+import '../../vitals/domain/repositories/vital_sign_repository.dart';
+import '../../vitals/domain/entities/vital_sign.dart' as entity;
+import '../../local_agent/infrastructure/services/medical_indexing_service.dart';
+import '../../medical_assistant/domain/services/medical_analysis_service.dart';
+import '../../user_profile/domain/repositories/user_profile_repository.dart';
+import '../../medical_assistant/domain/entities/medical_insight.dart';
+
+@LazySingleton(as: HomeRepository)
+class HomeRepositoryImpl implements HomeRepository {
+  final VitalSignRepository _vitalSignRepository;
+  final MedicalIndexingService _indexingService;
+  final MedicalAnalysisService _analysisService;
+  final UserProfileRepository _userProfileRepository;
+
+  HomeRepositoryImpl(
+    this._vitalSignRepository,
+    this._indexingService,
+    this._analysisService,
+    this._userProfileRepository,
+  );
+
+  @override
+  bool get hasIndexed => _indexingService.hasIndexed;
+
+  @override
+  Stream<bool> get indexingStatusStream => _indexingService.statusStream;
+
+  @override
+  Future<bool> retryIndexing() async {
+    try {
+      final result = await _indexingService.indexAll(force: true);
+      return result.success;
+    } catch (_) {
+      return false;
+    }
+  }
+
+  @override
+  Future<Map<entity.VitalSignType, entity.VitalSign?>> getLatestVitals() async {
+    return await _vitalSignRepository.getLatestVitals();
+  }
+
+  @override
+  Future<List<MedicalInsight>> getRecentInsights() async {
+    final vitals = await _vitalSignRepository.getLatestVitals();
+
+    // Convert latest vitals to a map suitable for MedicalAnalysisService
+    final vitalsMap = <String, double>{};
+    final hr = vitals[entity.VitalSignType.heartRate];
+    if (hr != null) {
+      vitalsMap['heartRate'] = hr.value;
+    }
+    final systolic = vitals[entity.VitalSignType.bloodPressureSystolic];
+    if (systolic != null) {
+      vitalsMap['systolic'] = systolic.value;
+    }
+    final diastolic = vitals[entity.VitalSignType.bloodPressureDiastolic];
+    if (diastolic != null) {
+      vitalsMap['diastolic'] = diastolic.value;
+    }
+    final temp = vitals[entity.VitalSignType.temperature];
+    if (temp != null) {
+      vitalsMap['temperature'] = temp.value;
+    }
+    final spo2 = vitals[entity.VitalSignType.oxygenSaturation];
+    if (spo2 != null) {
+      vitalsMap['oxygenSaturation'] = spo2.value;
+    }
+
+    // Load chronic conditions from user profile
+    final userProfile = await _userProfileRepository.getUserProfile();
+    final chronicConditions = <Icd10Code>[];
+    if (userProfile != null && userProfile.medicalConditions.isNotEmpty) {
+      for (final s in userProfile.medicalConditions) {
+        final code = Icd10Catalog.findByCode(s);
+        if (code != null) chronicConditions.add(code);
+      }
+    }
+
+    // Perform analysis
+    final vitalInsights = await _analysisService.analyzeVitals(
+      vitals: vitalsMap,
+      chronicConditions: chronicConditions,
+    );
+
+    final riskInsights = await _analysisService.calculateRisks(
+      labValues: {}, // Home dashboard focus on vitals for now
+      vitals: vitalsMap,
+      conditions: chronicConditions,
+    );
+
+    final allInsights = [...vitalInsights, ...riskInsights];
+    // Sort by severity (critical > alert > warning > info)
+    allInsights.sort((a, b) => b.severity.index.compareTo(a.severity.index));
+
+    return allInsights;
+  }
+}

--- a/lib/features/home/presentation/pages/home_page.dart
+++ b/lib/features/home/presentation/pages/home_page.dart
@@ -6,13 +6,9 @@ import '../../../../core/theme/app_theme.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
 import '../../../../core/widgets/page_header.dart';
 import '../../../../l10n/app_localizations.dart';
-import '../../../local_agent/infrastructure/services/medical_indexing_service.dart';
 import '../../../medical_assistant/domain/entities/medical_insight.dart';
-import '../../../medical_assistant/domain/services/medical_analysis_service.dart';
 import '../../../medical_assistant/presentation/pages/medical_assistant_page.dart';
-import '../../../user_profile/domain/repositories/user_profile_repository.dart';
 import '../../../vitals/domain/entities/vital_sign.dart';
-import '../../../vitals/domain/repositories/vital_sign_repository.dart';
 import '../../../vitals/presentation/pages/vitals_monitor_page.dart';
 import '../../application/home_cubit.dart';
 import '../../application/home_state.dart';
@@ -24,12 +20,7 @@ class HomePage extends StatelessWidget {
   Widget build(BuildContext context) {
     final l10n = AppLocalizations.of(context)!;
     return BlocProvider(
-      create: (_) => HomeCubit(
-        getIt<VitalSignRepository>(),
-        getIt<MedicalIndexingService>(),
-        getIt<MedicalAnalysisService>(),
-        getIt<UserProfileRepository>(),
-      ),
+      create: (_) => getIt<HomeCubit>(),
       child: Scaffold(
         body: SafeArea(
           child: SingleChildScrollView(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1166,18 +1166,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1634,10 +1634,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/home/presentation/pages/home_page_test.dart
+++ b/test/features/home/presentation/pages/home_page_test.dart
@@ -6,52 +6,29 @@ import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/home/presentation/pages/home_page.dart';
 import 'package:orionhealth_health/features/home/application/home_cubit.dart';
-import 'package:orionhealth_health/features/home/application/home_state.dart';
-import 'package:orionhealth_health/features/vitals/domain/repositories/vital_sign_repository.dart';
-import 'package:orionhealth_health/features/local_agent/infrastructure/services/medical_indexing_service.dart';
-import 'package:orionhealth_health/features/medical_assistant/domain/services/medical_analysis_service.dart';
-import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
+import 'package:orionhealth_health/features/home/domain/repositories/home_repository.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
 import 'package:orionhealth_health/l10n/app_localizations.dart';
 
-class MockVitalSignRepository extends Mock implements VitalSignRepository {}
-class MockMedicalIndexingService extends Mock implements MedicalIndexingService {}
-class MockMedicalAnalysisService extends Mock implements MedicalAnalysisService {}
-class MockUserProfileRepository extends Mock implements UserProfileRepository {}
+class MockHomeRepository extends Mock implements HomeRepository {}
 
 void main() {
   final getIt = GetIt.instance;
-  late MockVitalSignRepository mockVitalSignRepository;
-  late MockMedicalIndexingService mockMedicalIndexingService;
-  late MockMedicalAnalysisService mockMedicalAnalysisService;
-  late MockUserProfileRepository mockUserProfileRepository;
+  late MockHomeRepository mockHomeRepository;
 
   setUpAll(() {
-    mockVitalSignRepository = MockVitalSignRepository();
-    mockMedicalIndexingService = MockMedicalIndexingService();
-    mockMedicalAnalysisService = MockMedicalAnalysisService();
-    mockUserProfileRepository = MockUserProfileRepository();
+    mockHomeRepository = MockHomeRepository();
 
-    getIt.registerLazySingleton<VitalSignRepository>(() => mockVitalSignRepository);
-    getIt.registerLazySingleton<MedicalIndexingService>(() => mockMedicalIndexingService);
-    getIt.registerLazySingleton<MedicalAnalysisService>(() => mockMedicalAnalysisService);
-    getIt.registerLazySingleton<UserProfileRepository>(() => mockUserProfileRepository);
+    getIt.registerLazySingleton<HomeRepository>(() => mockHomeRepository);
+    getIt.registerFactory<HomeCubit>(() => HomeCubit(getIt<HomeRepository>()));
   });
 
   setUp(() {
     // Default mock behavior for each test
-    when(() => mockMedicalIndexingService.hasIndexed).thenReturn(true);
-    when(() => mockMedicalIndexingService.statusStream).thenAnswer((_) => const Stream.empty());
-    when(() => mockVitalSignRepository.getLatestVitals()).thenAnswer((_) async => {});
-    when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => null);
-    when(() => mockMedicalAnalysisService.analyzeVitals(
-      vitals: any(named: 'vitals'),
-      chronicConditions: any(named: 'chronicConditions'),
-    )).thenAnswer((_) async => []);
-    when(() => mockMedicalAnalysisService.calculateRisks(
-      labValues: any(named: 'labValues'),
-      vitals: any(named: 'vitals'),
-      conditions: any(named: 'conditions'),
-    )).thenAnswer((_) async => []);
+    when(() => mockHomeRepository.hasIndexed).thenReturn(true);
+    when(() => mockHomeRepository.indexingStatusStream).thenAnswer((_) => const Stream.empty());
+    when(() => mockHomeRepository.getLatestVitals()).thenAnswer((_) async => <VitalSignType, VitalSign?>{});
+    when(() => mockHomeRepository.getRecentInsights()).thenAnswer((_) async => []);
   });
 
   tearDownAll(() {
@@ -105,8 +82,8 @@ void main() {
 
   testWidgets('IndexingStatusBanner shows syncing state', (WidgetTester tester) async {
     final controller = StreamController<bool>();
-    when(() => mockMedicalIndexingService.hasIndexed).thenReturn(false);
-    when(() => mockMedicalIndexingService.statusStream).thenAnswer((_) => controller.stream);
+    when(() => mockHomeRepository.hasIndexed).thenReturn(false);
+    when(() => mockHomeRepository.indexingStatusStream).thenAnswer((_) => controller.stream);
 
     await tester.pumpWidget(createWidgetUnderTest());
     await tester.pump();
@@ -122,9 +99,9 @@ void main() {
   });
 
   testWidgets('IndexingStatusBanner shows error state and retry works', (WidgetTester tester) async {
-    when(() => mockMedicalIndexingService.hasIndexed).thenReturn(false);
-    when(() => mockMedicalIndexingService.statusStream).thenAnswer((_) => Stream.value(false));
-    when(() => mockMedicalIndexingService.indexAll(force: true)).thenAnswer((_) async => const IndexingResult(total: 0, indexed: 0, errors: 1));
+    when(() => mockHomeRepository.hasIndexed).thenReturn(false);
+    when(() => mockHomeRepository.indexingStatusStream).thenAnswer((_) => Stream.value(false));
+    when(() => mockHomeRepository.retryIndexing()).thenAnswer((_) async => false);
 
     await tester.pumpWidget(createWidgetUnderTest());
     await tester.pump();
@@ -142,13 +119,13 @@ void main() {
     expect(find.text('Reintentar'), findsOneWidget);
 
     await tester.tap(find.text('Reintentar'));
-    verify(() => mockMedicalIndexingService.indexAll(force: true)).called(2); // once from our manual call, once from tap
+    verify(() => mockHomeRepository.retryIndexing()).called(2); // once from our manual call, once from tap
   });
 
   testWidgets('IndexingStatusBanner shows success state then disappears', (WidgetTester tester) async {
     final controller = StreamController<bool>();
-    when(() => mockMedicalIndexingService.hasIndexed).thenReturn(false);
-    when(() => mockMedicalIndexingService.statusStream).thenAnswer((_) => controller.stream);
+    when(() => mockHomeRepository.hasIndexed).thenReturn(false);
+    when(() => mockHomeRepository.indexingStatusStream).thenAnswer((_) => controller.stream);
 
     await tester.pumpWidget(createWidgetUnderTest());
 


### PR DESCRIPTION
This PR introduces the Infrastructure layer for the Home feature. 

Key changes:
- **Domain Layer**: Added `HomeRepository` interface to define the data requirements for the home dashboard.
- **Infrastructure Layer**: Added `HomeRepositoryImpl` which acts as a facade, orchestrating data retrieval from `VitalSignRepository`, `MedicalIndexingService`, `MedicalAnalysisService`, and `UserProfileRepository`. This moves complex orchestration logic out of the application layer.
- **Application Layer**: Refactored `HomeCubit` to depend on `HomeRepository` instead of multiple concrete services and repositories. Added `@injectable` annotation.
- **Presentation Layer**: Updated `HomePage` to use `getIt<HomeCubit>()`.
- **Tests**: Updated `home_page_test.dart` to use a mocked `HomeRepository`.
- **DI**: Regenerated `injection.config.dart` using `build_runner`.

Fixes #480

---
*PR created automatically by Jules for task [11749063596164694241](https://jules.google.com/task/11749063596164694241) started by @iberi22*