### PR TITLE
feat: eps_connection application layer

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -9,8 +9,8 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:dio/dio.dart' as _i13;
-import 'package:flutter_appauth/flutter_appauth.dart' as _i52;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i53;
+import 'package:flutter_appauth/flutter_appauth.dart' as _i53;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i54;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:http/http.dart' as _i10;
 import 'package:injectable/injectable.dart' as _i2;
@@ -19,142 +19,145 @@ import 'package:isar_agent_memory/isar_agent_memory.dart' as _i14;
 import 'package:medical_standards/medical_standards.dart' as _i33;
 
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i81;
+    as _i82;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i3;
 import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
-    as _i82;
+    as _i83;
 import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i85;
+    as _i86;
 import '../../features/appointments/domain/services/appointment_service.dart'
     as _i4;
 import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
-    as _i86;
-import '../../features/auth/application/auth_cubit.dart' as _i119;
+    as _i87;
+import '../../features/auth/application/auth_cubit.dart' as _i121;
 import '../../features/auth/application/bloc/auth_cubit.dart' as _i120;
-import '../../features/auth/domain/auth_service.dart' as _i89;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i87;
+import '../../features/auth/domain/auth_service.dart' as _i90;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i88;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
-    as _i88;
+    as _i89;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i5;
 import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
-    as _i90;
+    as _i91;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
     as _i15;
 import '../../features/calendar_import/data/calendar_repository.dart' as _i9;
 import '../../features/calendar_import/domain/calendar_import_cubit.dart'
-    as _i91;
+    as _i92;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
-    as _i96;
+    as _i97;
 import '../../features/doctor_verification/data/datasources/license_registry_local.dart'
     as _i23;
 import '../../features/doctor_verification/data/repositories/isar_doctor_profile_repository.dart'
-    as _i95;
+    as _i96;
 import '../../features/doctor_verification/data/repositories/isar_rating_repository.dart'
-    as _i58;
+    as _i59;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
-    as _i94;
+    as _i95;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
-    as _i57;
+    as _i58;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
     as _i24;
-import '../../features/eps_connection/domain/eps_connection_cubit.dart' as _i97;
-import '../../features/eps_connection/infrastructure/oauth_repository.dart'
+import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
+    as _i98;
+import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
     as _i51;
+import '../../features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart'
+    as _i52;
 import '../../features/health_data_import/application/health_import_cubit.dart'
-    as _i101;
+    as _i102;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i18;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i121;
+    as _i122;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i102;
-import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
     as _i103;
+import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+    as _i104;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i17;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
     as _i19;
 import '../../features/health_record/infrastructure/services/ocr_service.dart'
-    as _i54;
-import '../../features/health_sharing/application/sharing_cubit.dart' as _i63;
+    as _i55;
+import '../../features/health_sharing/application/sharing_cubit.dart' as _i64;
 import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
     as _i6;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i7;
 import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
     as _i49;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i64;
+    as _i65;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i116;
+    as _i117;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i35;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i25;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i75;
+    as _i76;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
     as _i26;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i27;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i104;
-import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i105;
-import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i106;
+import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+    as _i107;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
     as _i28;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i109;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i108;
+    as _i110;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i109;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
-    as _i122;
+    as _i123;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i36;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i37;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i36;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i76;
+    as _i77;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i107;
+    as _i108;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i31;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i123;
+    as _i124;
 import '../../features/local_agent/infrastructure/services/model_download_service.dart'
     as _i48;
 import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i113;
+    as _i114;
 import '../../features/medical_assistant/application/medical_assistant_cubit.dart'
-    as _i111;
+    as _i112;
 import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
     as _i21;
 import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
-    as _i70;
+    as _i71;
 import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
-    as _i77;
+    as _i78;
 import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
-    as _i92;
+    as _i93;
 import '../../features/medical_assistant/domain/services/health_context_service.dart'
-    as _i99;
+    as _i100;
 import '../../features/medical_assistant/domain/services/medical_analysis_service.dart'
     as _i32;
 import '../../features/medical_assistant/domain/services/medical_guidelines_service.dart'
     as _i34;
 import '../../features/medical_assistant/domain/services/risk_calculator_service.dart'
-    as _i62;
+    as _i63;
 import '../../features/medical_assistant/infrastructure/analysis/lab_interpreter.dart'
     as _i22;
 import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
-    as _i61;
+    as _i62;
 import '../../features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart'
-    as _i78;
+    as _i79;
 import '../../features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart'
     as _i38;
 import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
-    as _i93;
+    as _i94;
 import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
-    as _i100;
+    as _i101;
 import '../../features/medical_research/domain/services/medical_scraper_service.dart'
     as _i39;
 import '../../features/medical_research/domain/services/medical_standards_service.dart'
@@ -164,7 +167,7 @@ import '../../features/medical_research/domain/services/medical_web_search_servi
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i8;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i112;
+    as _i113;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i40;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
@@ -175,63 +178,63 @@ import '../../features/medications/domain/repositories/medication_repository.dar
     as _i45;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
     as _i46;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i55;
-import '../../features/onboarding/application/sync_cubit.dart' as _i117;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i124;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i56;
+import '../../features/onboarding/application/sync_cubit.dart' as _i118;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i125;
 import '../../features/reports/domain/repositories/report_repository.dart'
-    as _i59;
-import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i114;
-import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i60;
-import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+import '../../features/reports/domain/services/report_generation_service.dart'
     as _i115;
+import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
+    as _i61;
+import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+    as _i116;
 import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i47;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i110;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i111;
 import '../../features/settings/domain/repositories/llm_settings_repository.dart'
     as _i29;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i11;
+    as _i12;
 import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
     as _i30;
-import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i66;
-import '../../features/ssi/domain/services/anoncreds_service.dart' as _i83;
-import '../../features/ssi/domain/services/ssi_service.dart' as _i68;
+import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i67;
+import '../../features/ssi/domain/services/anoncreds_service.dart' as _i84;
+import '../../features/ssi/domain/services/ssi_service.dart' as _i69;
 import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
-    as _i67;
+    as _i68;
 import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
-    as _i84;
+    as _i85;
 import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
-    as _i65;
+    as _i66;
 import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
-    as _i69;
+    as _i70;
 import '../../features/sync/data/fhir_client.dart' as _i16;
 import '../../features/sync/data/node_discovery_service.dart' as _i50;
-import '../../features/sync/data/sync_repository.dart' as _i71;
-import '../../features/sync/domain/sync_cubit.dart' as _i98;
+import '../../features/sync/data/sync_repository.dart' as _i72;
+import '../../features/sync/domain/sync_cubit.dart' as _i99;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i118;
+    as _i119;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i72;
-import '../../features/user_profile/domain/services/user_profile_service.dart'
-    as _i74;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
     as _i73;
+import '../../features/user_profile/domain/services/user_profile_service.dart'
+    as _i75;
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+    as _i74;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i79;
-import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
     as _i80;
-import '../services/device_capability_service.dart' as _i12;
-import '../services/privacy_anonymizer.dart' as _i56;
-import 'database_module.dart' as _i128;
-import 'fhir_module.dart' as _i125;
-import 'memory_module.dart' as _i127;
-import 'network_module.dart' as _i126;
+import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+    as _i81;
+import '../services/device_capability_service.dart' as _i11;
+import '../services/privacy_anonymizer.dart' as _i57;
+import 'database_module.dart' as _i129;
+import 'fhir_module.dart' as _i126;
+import 'memory_module.dart' as _i128;
+import 'network_module.dart' as _i127;
 
-const String _mobile = 'mobile';
 const String _desktop = 'desktop';
 const String _test = 'test';
+const String _mobile = 'mobile';
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -302,15 +305,15 @@ extension GetItInjectableX on _i1.GetIt {
     gh.factory<_i34.MedicalGuidelinesService>(
         () => _i34.MedicalGuidelinesService());
     gh.factory<_i35.MedicalKnowledgeRepository>(
-      () => _i36.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
-    );
-    gh.factory<_i35.MedicalKnowledgeRepository>(
-      () => _i37.JsonMedicalKnowledgeRepository(),
+      () => _i36.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
+    );
+    gh.factory<_i35.MedicalKnowledgeRepository>(
+      () => _i37.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
     );
     gh.factory<_i38.MedicalLlmAdapter>(() => _i38.MedicalLlmAdapter());
     gh.lazySingleton<_i39.MedicalScraperService>(
@@ -340,9 +343,9 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i49.NfcSharingService>(() => _i49.NfcSharingService());
     gh.lazySingleton<_i50.NodeDiscoveryService>(
         () => _i50.NodeDiscoveryService());
-    gh.lazySingleton<_i51.OAuthRepository>(() => _i51.OAuthRepositoryImpl(
-          appAuth: gh<_i52.FlutterAppAuth>(),
-          secureStorage: gh<_i53.FlutterSecureStorage>(),
+    gh.lazySingleton<_i51.OAuthRepository>(() => _i52.OAuthRepositoryImpl(
+          appAuth: gh<_i53.FlutterAppAuth>(),
+          secureStorage: gh<_i54.FlutterSecureStorage>(),
           clientId: gh<String>(),
           redirectUrl: gh<String>(),
           discoveryUrl: gh<String>(),
@@ -351,206 +354,206 @@ extension GetItInjectableX on _i1.GetIt {
           idTokenKey: gh<String>(),
           refreshTokenKey: gh<String>(),
         ));
-    gh.lazySingleton<_i54.OcrService>(() => _i54.MlKitOcrService());
-    gh.factory<_i55.OnboardingCubit>(() => _i55.OnboardingCubit());
-    gh.lazySingleton<_i56.PromptScrubber>(
-        () => _i56.PromptScrubber(gh<_i20.Isar>()));
-    gh.lazySingleton<_i57.RatingRepository>(
-        () => _i58.IsarRatingRepository(gh<_i20.Isar>()));
-    gh.lazySingleton<_i59.ReportRepository>(
-        () => _i60.IsarReportRepository(gh<_i20.Isar>()));
-    gh.factory<_i61.RiskCalculator>(() => _i61.RiskCalculator());
-    gh.factory<_i62.RiskCalculatorService>(() =>
-        _i62.RiskCalculatorService(calculator: gh<_i61.RiskCalculator>()));
-    gh.factory<_i63.SharingCubit>(() => _i63.SharingCubit(
+    gh.lazySingleton<_i55.OcrService>(() => _i55.MlKitOcrService());
+    gh.factory<_i56.OnboardingCubit>(() => _i56.OnboardingCubit());
+    gh.lazySingleton<_i57.PromptScrubber>(
+        () => _i57.PromptScrubber(gh<_i20.Isar>()));
+    gh.lazySingleton<_i58.RatingRepository>(
+        () => _i59.IsarRatingRepository(gh<_i20.Isar>()));
+    gh.lazySingleton<_i60.ReportRepository>(
+        () => _i61.IsarReportRepository(gh<_i20.Isar>()));
+    gh.factory<_i62.RiskCalculator>(() => _i62.RiskCalculator());
+    gh.factory<_i63.RiskCalculatorService>(() =>
+        _i63.RiskCalculatorService(calculator: gh<_i62.RiskCalculator>()));
+    gh.factory<_i64.SharingCubit>(() => _i64.SharingCubit(
           bleService: gh<_i6.BleSharingService>(),
           nfcService: gh<_i49.NfcSharingService>(),
-          wifiService: gh<_i64.WifiDirectService>(),
+          wifiService: gh<_i65.WifiDirectService>(),
         ));
-    gh.lazySingleton<_i65.SidetreeAnchorClient>(
-        () => _i65.SidetreeAnchorClient.create());
-    gh.lazySingleton<_i66.SsiRepository>(
-        () => _i67.IsarSsiRepository(gh<_i20.Isar>()));
-    gh.lazySingleton<_i68.SsiService>(() => _i69.SsiServiceImpl(
-          gh<_i66.SsiRepository>(),
-          gh<_i65.SidetreeAnchorClient>(),
+    gh.lazySingleton<_i66.SidetreeAnchorClient>(
+        () => _i66.SidetreeAnchorClient.create());
+    gh.lazySingleton<_i67.SsiRepository>(
+        () => _i68.IsarSsiRepository(gh<_i20.Isar>()));
+    gh.lazySingleton<_i69.SsiService>(() => _i70.SsiServiceImpl(
+          gh<_i67.SsiRepository>(),
+          gh<_i66.SidetreeAnchorClient>(),
         ));
-    gh.factory<_i70.SymptomAnalysisStrategy>(
-        () => _i70.SymptomAnalysisStrategy());
-    gh.lazySingleton<_i71.SyncRepository>(() => _i71.SyncRepository(
+    gh.factory<_i71.SymptomAnalysisStrategy>(
+        () => _i71.SymptomAnalysisStrategy());
+    gh.lazySingleton<_i72.SyncRepository>(() => _i72.SyncRepository(
           gh<_i16.FhirClient>(),
           gh<_i20.Isar>(),
-          gh<_i53.FlutterSecureStorage>(),
+          gh<_i54.FlutterSecureStorage>(),
           gh<_i50.NodeDiscoveryService>(),
         ));
     gh.lazySingleton<_i33.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i72.UserProfileRepository>(
-        () => _i73.UserProfileRepositoryImpl(gh<_i20.Isar>()));
-    gh.lazySingleton<_i74.UserProfileService>(
-        () => _i74.UserProfileService(gh<_i72.UserProfileRepository>()));
-    gh.lazySingleton<_i75.VectorStoreService>(() => _i76.IsarVectorStoreService(
+    gh.lazySingleton<_i73.UserProfileRepository>(
+        () => _i74.UserProfileRepositoryImpl(gh<_i20.Isar>()));
+    gh.lazySingleton<_i75.UserProfileService>(
+        () => _i75.UserProfileService(gh<_i73.UserProfileRepository>()));
+    gh.lazySingleton<_i76.VectorStoreService>(() => _i77.IsarVectorStoreService(
           gh<_i14.MemoryGraph>(),
           gh<_i35.MedicalKnowledgeRepository>(),
         ));
-    gh.factory<_i77.VitalAnalysisStrategy>(() => _i77.VitalAnalysisStrategy());
-    gh.factory<_i78.VitalSignAnalyzer>(() => _i78.VitalSignAnalyzer());
-    gh.lazySingleton<_i79.VitalSignRepository>(
-        () => _i80.VitalSignRepositoryImpl(gh<_i20.Isar>()));
-    gh.lazySingleton<_i64.WifiDirectService>(() => _i64.WifiDirectService());
-    gh.lazySingleton<_i81.AllergyRepository>(
-        () => _i82.IsarAllergyRepository(gh<_i20.Isar>()));
-    gh.lazySingleton<_i83.AnonCredsService>(
-        () => _i84.AnonCredsServiceImpl(gh<_i66.SsiRepository>()));
-    gh.lazySingleton<_i85.AppointmentRepository>(
-        () => _i86.IsarAppointmentRepository(gh<_i20.Isar>()));
-    gh.lazySingleton<_i87.AuthRepository>(
-        () => _i88.AuthRepositoryImpl(gh<_i20.Isar>()));
-    gh.lazySingleton<_i89.AuthService>(
-        () => _i89.AuthServiceImpl(gh<_i15.EncryptionService>()));
-    gh.lazySingleton<_i90.BleMedicalSharingService>(
-        () => _i90.BleMedicalSharingService(
+    gh.factory<_i78.VitalAnalysisStrategy>(() => _i78.VitalAnalysisStrategy());
+    gh.factory<_i79.VitalSignAnalyzer>(() => _i79.VitalSignAnalyzer());
+    gh.lazySingleton<_i80.VitalSignRepository>(
+        () => _i81.VitalSignRepositoryImpl(gh<_i20.Isar>()));
+    gh.lazySingleton<_i65.WifiDirectService>(() => _i65.WifiDirectService());
+    gh.lazySingleton<_i82.AllergyRepository>(
+        () => _i83.IsarAllergyRepository(gh<_i20.Isar>()));
+    gh.lazySingleton<_i84.AnonCredsService>(
+        () => _i85.AnonCredsServiceImpl(gh<_i67.SsiRepository>()));
+    gh.lazySingleton<_i86.AppointmentRepository>(
+        () => _i87.IsarAppointmentRepository(gh<_i20.Isar>()));
+    gh.lazySingleton<_i88.AuthRepository>(
+        () => _i89.AuthRepositoryImpl(gh<_i20.Isar>()));
+    gh.lazySingleton<_i90.AuthService>(
+        () => _i90.AuthServiceImpl(gh<_i15.EncryptionService>()));
+    gh.lazySingleton<_i91.BleMedicalSharingService>(
+        () => _i91.BleMedicalSharingService(
               gh<_i6.BleSharingService>(),
               gh<_i15.EncryptionService>(),
-              gh<_i68.SsiService>(),
+              gh<_i69.SsiService>(),
             ));
-    gh.factory<_i91.CalendarImportCubit>(() => _i91.CalendarImportCubit(
+    gh.factory<_i92.CalendarImportCubit>(() => _i92.CalendarImportCubit(
           gh<_i9.CalendarRepository>(),
-          gh<_i85.AppointmentRepository>(),
-          gh<_i72.UserProfileRepository>(),
+          gh<_i86.AppointmentRepository>(),
+          gh<_i73.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i92.ClinicalReasonerService>(
-        () => _i93.SymphonyClinicalReasonerService(
+    gh.lazySingleton<_i93.ClinicalReasonerService>(
+        () => _i94.SymphonyClinicalReasonerService(
               gh<_i35.MedicalKnowledgeRepository>(),
-              gh<_i56.PromptScrubber>(),
+              gh<_i57.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i94.DoctorProfileRepository>(
-        () => _i95.IsarDoctorProfileRepository(gh<_i20.Isar>()));
-    gh.factoryAsync<_i96.DoctorVerificationCubit>(
-        () async => _i96.DoctorVerificationCubit(
-              gh<_i94.DoctorProfileRepository>(),
-              gh<_i57.RatingRepository>(),
+    gh.lazySingleton<_i95.DoctorProfileRepository>(
+        () => _i96.IsarDoctorProfileRepository(gh<_i20.Isar>()));
+    gh.factoryAsync<_i97.DoctorVerificationCubit>(
+        () async => _i97.DoctorVerificationCubit(
+              gh<_i95.DoctorProfileRepository>(),
+              gh<_i58.RatingRepository>(),
               await getAsync<_i24.LicenseVerifier>(),
             ));
-    gh.factory<_i97.EpsConnectionCubit>(() => _i97.EpsConnectionCubit(
+    gh.factory<_i98.EpsConnectionCubit>(() => _i98.EpsConnectionCubit(
           gh<_i51.OAuthRepository>(),
-          gh<_i72.UserProfileRepository>(),
+          gh<_i73.UserProfileRepository>(),
         ));
-    gh.factory<_i98.FhirSyncCubit>(
-        () => _i98.FhirSyncCubit(gh<_i71.SyncRepository>()));
-    gh.lazySingleton<_i99.HealthContextService>(
-        () => _i100.IsarHealthContextService(
-              gh<_i79.VitalSignRepository>(),
+    gh.factory<_i99.FhirSyncCubit>(
+        () => _i99.FhirSyncCubit(gh<_i72.SyncRepository>()));
+    gh.lazySingleton<_i100.HealthContextService>(
+        () => _i101.IsarHealthContextService(
+              gh<_i80.VitalSignRepository>(),
               gh<_i45.MedicationRepository>(),
-              gh<_i72.UserProfileRepository>(),
+              gh<_i73.UserProfileRepository>(),
               gh<_i14.MemoryGraph>(),
             ));
-    gh.factory<_i101.HealthImportCubit>(() => _i101.HealthImportCubit(
+    gh.factory<_i102.HealthImportCubit>(() => _i102.HealthImportCubit(
           gh<_i18.HealthDataImportService>(),
-          gh<_i79.VitalSignRepository>(),
+          gh<_i80.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i102.HealthRecordRepository>(
-        () => _i103.HealthRecordRepositoryImpl(gh<_i20.Isar>()));
+    gh.lazySingleton<_i103.HealthRecordRepository>(
+        () => _i104.HealthRecordRepositoryImpl(gh<_i20.Isar>()));
     gh.lazySingleton<_i25.LlmAdapter>(
-      () => _i104.GeminiLlmAdapter(
-        scrubber: gh<_i56.PromptScrubber>(),
-        userProfileRepository: gh<_i72.UserProfileRepository>(),
-        modelWrapper: gh<_i105.GeminiModelWrapper>(),
+      () => _i105.GeminiLlmAdapter(
+        scrubber: gh<_i57.PromptScrubber>(),
+        userProfileRepository: gh<_i73.UserProfileRepository>(),
+        modelWrapper: gh<_i106.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
     );
     gh.factory<_i25.LlmAdapter>(
-      () => _i106.MockLlmAdapter(gh<_i56.PromptScrubber>()),
+      () => _i107.MockLlmAdapter(gh<_i57.PromptScrubber>()),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i107.LlmAdapterFactory>(
-        () => _i107.LlmAdapterFactory(gh<_i29.LlmSettingsRepository>()));
-    gh.lazySingleton<_i108.LlmService>(() => _i109.GemmaLlmService(
-          gh<_i75.VectorStoreService>(),
-          gh<_i72.UserProfileRepository>(),
+    gh.lazySingleton<_i108.LlmAdapterFactory>(
+        () => _i108.LlmAdapterFactory(gh<_i29.LlmSettingsRepository>()));
+    gh.lazySingleton<_i109.LlmService>(() => _i110.GemmaLlmService(
+          gh<_i76.VectorStoreService>(),
+          gh<_i73.UserProfileRepository>(),
           gh<_i25.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i110.LlmSettingsCubit>(() => _i110.LlmSettingsCubit(
+    gh.factory<_i111.LlmSettingsCubit>(() => _i111.LlmSettingsCubit(
           gh<_i29.LlmSettingsRepository>(),
-          gh<_i11.DeviceCapabilityService>(),
+          gh<_i12.DeviceCapabilityService>(),
           gh<_i25.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i111.MedicalAssistantCubit>(() => _i111.MedicalAssistantCubit(
+    gh.factory<_i112.MedicalAssistantCubit>(() => _i112.MedicalAssistantCubit(
           llmAdapter: gh<_i38.MedicalLlmAdapter>(),
           analysisService: gh<_i32.MedicalAnalysisService>(),
-          healthContextService: gh<_i99.HealthContextService>(),
+          healthContextService: gh<_i100.HealthContextService>(),
         ));
-    gh.lazySingleton<_i112.MedicalResearchService>(
-        () => _i112.MedicalResearchService(
+    gh.lazySingleton<_i113.MedicalResearchService>(
+        () => _i113.MedicalResearchService(
               gh<_i43.MedicalWebSearchService>(),
               gh<_i39.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i113.PatientContextIndexer>(
-      () => _i113.PatientContextIndexer(
+    gh.lazySingleton<_i114.PatientContextIndexer>(
+      () => _i114.PatientContextIndexer(
         gh<_i20.Isar>(),
-        gh<_i75.VectorStoreService>(),
-        gh<_i102.HealthRecordRepository>(),
+        gh<_i76.VectorStoreService>(),
+        gh<_i103.HealthRecordRepository>(),
         gh<_i45.MedicationRepository>(),
-        gh<_i81.AllergyRepository>(),
-        gh<_i79.VitalSignRepository>(),
-        gh<_i85.AppointmentRepository>(),
+        gh<_i82.AllergyRepository>(),
+        gh<_i80.VitalSignRepository>(),
+        gh<_i86.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i114.ReportGenerationService>(
-        () => _i115.GemmaReportGenerationService(
+    gh.lazySingleton<_i115.ReportGenerationService>(
+        () => _i116.GemmaReportGenerationService(
               gh<_i25.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i75.VectorStoreService>(),
-              gh<_i72.UserProfileRepository>(),
-              gh<_i56.PromptScrubber>(),
+              gh<_i76.VectorStoreService>(),
+              gh<_i73.UserProfileRepository>(),
+              gh<_i57.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i116.SmartSearchUseCase>(
-        () => _i116.SmartSearchUseCase(gh<_i75.VectorStoreService>()));
-    gh.factory<_i117.SyncCubit>(() => _i117.SyncCubit(
+    gh.lazySingleton<_i117.SmartSearchUseCase>(
+        () => _i117.SmartSearchUseCase(gh<_i76.VectorStoreService>()));
+    gh.factory<_i118.SyncCubit>(() => _i118.SyncCubit(
           gh<_i33.SyncService>(),
-          gh<_i75.VectorStoreService>(),
+          gh<_i76.VectorStoreService>(),
         ));
-    gh.factory<_i118.UserProfileCubit>(
-        () => _i118.UserProfileCubit(gh<_i72.UserProfileRepository>()));
-    gh.factory<_i119.AuthCubit>(() => _i119.AuthCubit(gh<_i89.AuthService>()));
+    gh.factory<_i119.UserProfileCubit>(
+        () => _i119.UserProfileCubit(gh<_i73.UserProfileRepository>()));
     gh.factory<_i120.AuthCubit>(() => _i120.AuthCubit(
-          gh<_i87.AuthRepository>(),
+          gh<_i88.AuthRepository>(),
           gh<_i15.EncryptionService>(),
           gh<_i5.BiometricService>(),
         ));
-    gh.factory<_i121.HealthRecordCubit>(() => _i121.HealthRecordCubit(
-          gh<_i102.HealthRecordRepository>(),
+    gh.factory<_i121.AuthCubit>(() => _i121.AuthCubit(gh<_i90.AuthService>()));
+    gh.factory<_i122.HealthRecordCubit>(() => _i122.HealthRecordCubit(
+          gh<_i103.HealthRecordRepository>(),
           gh<_i17.FilePickerService>(),
           gh<_i19.ImagePickerService>(),
-          gh<_i54.OcrService>(),
-          gh<_i75.VectorStoreService>(),
+          gh<_i55.OcrService>(),
+          gh<_i76.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i108.LlmService>(
-      () => _i122.RagLlmService(
-        gh<_i75.VectorStoreService>(),
-        gh<_i112.MedicalResearchService>(),
-        gh<_i72.UserProfileRepository>(),
+    gh.lazySingleton<_i109.LlmService>(
+      () => _i123.RagLlmService(
+        gh<_i76.VectorStoreService>(),
+        gh<_i113.MedicalResearchService>(),
+        gh<_i73.UserProfileRepository>(),
         gh<_i25.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
-    gh.lazySingleton<_i123.MedicalIndexingService>(
-        () => _i123.MedicalIndexingService(
+    gh.lazySingleton<_i124.MedicalIndexingService>(
+        () => _i124.MedicalIndexingService(
               gh<_i35.MedicalKnowledgeRepository>(),
-              gh<_i75.VectorStoreService>(),
-              gh<_i113.PatientContextIndexer>(),
+              gh<_i76.VectorStoreService>(),
+              gh<_i114.PatientContextIndexer>(),
             ));
-    gh.factory<_i124.ReportBloc>(() => _i124.ReportBloc(
-          gh<_i59.ReportRepository>(),
-          gh<_i114.ReportGenerationService>(),
+    gh.factory<_i125.ReportBloc>(() => _i125.ReportBloc(
+          gh<_i60.ReportRepository>(),
+          gh<_i115.ReportGenerationService>(),
         ));
     return this;
   }
 }
 
-class _$FhirModule extends _i125.FhirModule {}
+class _$FhirModule extends _i126.FhirModule {}
 
-class _$NetworkModule extends _i126.NetworkModule {}
+class _$NetworkModule extends _i127.NetworkModule {}
 
-class _$MemoryModule extends _i127.MemoryModule {}
+class _$MemoryModule extends _i128.MemoryModule {}
 
-class _$DatabaseModule extends _i128.DatabaseModule {}
+class _$DatabaseModule extends _i129.DatabaseModule {}

--- a/lib/features/eps_connection/application/bloc/eps_connection_cubit.dart
+++ b/lib/features/eps_connection/application/bloc/eps_connection_cubit.dart
@@ -1,43 +1,8 @@
 import 'package:flutter_bloc/flutter_bloc.dart';
-import 'package:equatable/equatable.dart';
 import 'package:injectable/injectable.dart';
-import '../infrastructure/oauth_repository.dart';
-import '../../user_profile/domain/repositories/user_profile_repository.dart';
-
-abstract class EpsConnectionState extends Equatable {
-  const EpsConnectionState();
-
-  @override
-  List<Object?> get props => [];
-}
-
-class EpsConnectionInitial extends EpsConnectionState {
-  const EpsConnectionInitial();
-}
-
-class EpsConnectionLoading extends EpsConnectionState {
-  const EpsConnectionLoading();
-}
-
-class EpsConnectionConnected extends EpsConnectionState {
-  final String patientId;
-  const EpsConnectionConnected(this.patientId);
-
-  @override
-  List<Object?> get props => [patientId];
-}
-
-class EpsConnectionDisconnected extends EpsConnectionState {
-  const EpsConnectionDisconnected();
-}
-
-class EpsConnectionError extends EpsConnectionState {
-  final String message;
-  const EpsConnectionError(this.message);
-
-  @override
-  List<Object?> get props => [message];
-}
+import '../../domain/repositories/oauth_repository.dart';
+import '../../../user_profile/domain/repositories/user_profile_repository.dart';
+import 'eps_connection_state.dart';
 
 @injectable
 class EpsConnectionCubit extends Cubit<EpsConnectionState> {

--- a/lib/features/eps_connection/application/bloc/eps_connection_state.dart
+++ b/lib/features/eps_connection/application/bloc/eps_connection_state.dart
@@ -1,0 +1,36 @@
+import 'package:equatable/equatable.dart';
+
+sealed class EpsConnectionState extends Equatable {
+  const EpsConnectionState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class EpsConnectionInitial extends EpsConnectionState {
+  const EpsConnectionInitial();
+}
+
+class EpsConnectionLoading extends EpsConnectionState {
+  const EpsConnectionLoading();
+}
+
+class EpsConnectionConnected extends EpsConnectionState {
+  final String patientId;
+  const EpsConnectionConnected(this.patientId);
+
+  @override
+  List<Object?> get props => [patientId];
+}
+
+class EpsConnectionDisconnected extends EpsConnectionState {
+  const EpsConnectionDisconnected();
+}
+
+class EpsConnectionError extends EpsConnectionState {
+  final String message;
+  const EpsConnectionError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}

--- a/lib/features/eps_connection/domain/repositories/oauth_repository.dart
+++ b/lib/features/eps_connection/domain/repositories/oauth_repository.dart
@@ -1,0 +1,9 @@
+import 'package:flutter_appauth/flutter_appauth.dart';
+
+abstract class OAuthRepository {
+  Future<AuthorizationTokenResponse?> login();
+  Future<void> logout();
+  Future<String?> getAccessToken();
+  Future<String?> getIdToken();
+  Future<TokenResponse?> refreshToken();
+}

--- a/lib/features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart
+++ b/lib/features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart
@@ -1,14 +1,7 @@
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:injectable/injectable.dart';
-
-abstract class OAuthRepository {
-  Future<AuthorizationTokenResponse?> login();
-  Future<void> logout();
-  Future<String?> getAccessToken();
-  Future<String?> getIdToken();
-  Future<TokenResponse?> refreshToken();
-}
+import '../../domain/repositories/oauth_repository.dart';
 
 @LazySingleton(as: OAuthRepository)
 class OAuthRepositoryImpl implements OAuthRepository {

--- a/lib/features/eps_connection/presentation/eps_connect_button.dart
+++ b/lib/features/eps_connection/presentation/eps_connect_button.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
-import '../domain/eps_connection_cubit.dart';
+import '../application/bloc/eps_connection_cubit.dart';
+import '../application/bloc/eps_connection_state.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
 

--- a/lib/features/onboarding/presentation/pages/basic_info_step.dart
+++ b/lib/features/onboarding/presentation/pages/basic_info_step.dart
@@ -5,7 +5,7 @@ import '../../application/onboarding_cubit.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
 import '../../../eps_connection/presentation/eps_connect_button.dart';
-import '../../../eps_connection/domain/eps_connection_cubit.dart';
+import '../../../eps_connection/application/bloc/eps_connection_cubit.dart';
 import '../../../../core/di/injection.dart';
 
 class BasicInfoStep extends StatefulWidget {

--- a/test/features/auth/ssi_auth_integration_test.dart
+++ b/test/features/auth/ssi_auth_integration_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:orionhealth_health/features/eps_connection/infrastructure/oauth_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart';
 import 'package:orionhealth_health/features/ssi/domain/entities/did.dart';
 import 'package:orionhealth_health/features/ssi/domain/entities/verifiable_credential.dart';
 import 'package:orionhealth_health/features/ssi/domain/repositories/ssi_repository.dart';

--- a/test/features/eps_connection/application/eps_connection_cubit_test.dart
+++ b/test/features/eps_connection/application/eps_connection_cubit_test.dart
@@ -1,8 +1,9 @@
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:orionhealth_health/features/eps_connection/domain/eps_connection_cubit.dart';
-import 'package:orionhealth_health/features/eps_connection/infrastructure/oauth_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_cubit.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_state.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/repositories/oauth_repository.dart';
 import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
 import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
 

--- a/test/features/eps_connection/infrastructure/multi_provider_test.dart
+++ b/test/features/eps_connection/infrastructure/multi_provider_test.dart
@@ -2,7 +2,7 @@ import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:orionhealth_health/features/eps_connection/infrastructure/oauth_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart';
 
 class MockFlutterAppAuth extends Mock implements FlutterAppAuth {}
 class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}

--- a/test/features/eps_connection/infrastructure/oauth_repository_impl_test.dart
+++ b/test/features/eps_connection/infrastructure/oauth_repository_impl_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:orionhealth_health/features/eps_connection/infrastructure/oauth_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart';
 
 class MockFlutterAppAuth extends Mock implements FlutterAppAuth {}
 class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}

--- a/test/features/eps_connection/infrastructure/oauth_repository_test.dart
+++ b/test/features/eps_connection/infrastructure/oauth_repository_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
-import 'package:orionhealth_health/features/eps_connection/infrastructure/oauth_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart';
 
 import 'oauth_repository_test.mocks.dart';
 


### PR DESCRIPTION
This PR implements the application layer for the `eps_connection` feature as part of the Clean Architecture alignment. 

Key changes:
- Created `lib/features/eps_connection/application/bloc/` and moved `EpsConnectionCubit` there.
- Refactored `EpsConnectionState` to a `sealed class` in its own file.
- Moved `OAuthRepository` interface to `lib/features/eps_connection/domain/repositories/`.
- Moved `OAuthRepositoryImpl` to `lib/features/eps_connection/infrastructure/repositories/`.
- Updated all presentation components (`EpsConnectButton`, `BasicInfoStep`) and tests to reflect these changes.
- Regenerated DI configuration using `build_runner`.
- All tests (Cubit, Repository, and Integration) pass successfully.

Fixes #495

---
*PR created automatically by Jules for task [2607491838305034763](https://jules.google.com/task/2607491838305034763) started by @iberi22*