### PR TITLE
Add Golden Screenshot Tests - Batch 2

### DIFF
--- a/lib/features/dashboard/presentation/pages/home_dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/home_dashboard_page.dart
@@ -5,7 +5,7 @@ import '../../../../../core/widgets/glassmorphic_card.dart';
 import '../../../local_agent/infrastructure/llm_service.dart';
 import '../../../local_agent/presentation/chat_page.dart';
 import '../../../vitals/presentation/pages/vitals_page.dart';
-import '../../../medications/presentation/pages/medications_page.dart';
+import '../../../medications/presentation/pages/medications_page.dart' hide getIt;
 import '../../../reports/presentation/pages/reports_page.dart';
 import '../../../health_record/presentation/pages/timeline_page.dart';
 import '../../../medical_research/presentation/pages/medical_research_page.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1166,18 +1166,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1634,10 +1634,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/core/golden_test_utils.dart
+++ b/test/core/golden_test_utils.dart
@@ -1,0 +1,26 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:google_fonts/google_fonts.dart';
+import 'package:orionhealth_health/l10n/app_localizations.dart';
+import 'package:orionhealth_health/core/theme/app_theme.dart';
+
+Widget wrapWithMaterial(Widget child) {
+  return MaterialApp(
+    theme: AppTheme.darkTheme,
+    localizationsDelegates: AppLocalizations.localizationsDelegates,
+    supportedLocales: AppLocalizations.supportedLocales,
+    locale: const Locale('es'),
+    home: child,
+  );
+}
+
+void setupGoldenTest(WidgetTester tester) {
+  GoogleFonts.config.allowRuntimeFetching = false;
+  tester.view.physicalSize = const Size(360, 640);
+  tester.view.devicePixelRatio = 1.0;
+}
+
+void resetGoldenTest(WidgetTester tester) {
+  tester.view.resetPhysicalSize();
+  tester.view.resetDevicePixelRatio();
+}

--- a/test/features/dashboard/presentation/pages/dashboard_page_golden_test.dart
+++ b/test/features/dashboard/presentation/pages/dashboard_page_golden_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/dashboard/presentation/pages/home_dashboard_page.dart';
+import 'package:orionhealth_health/features/local_agent/infrastructure/llm_service.dart';
+import '../../../../core/golden_test_utils.dart';
+
+class MockLlmService extends Mock implements LlmService {}
+
+void main() {
+  late MockLlmService mockLlmService;
+
+  setUpAll(() {
+    mockLlmService = MockLlmService();
+    GetIt.I.registerSingleton<LlmService>(mockLlmService);
+  });
+
+  tearDownAll(() {
+    GetIt.I.reset();
+  });
+
+  group('Dashboard Golden Tests', () {
+    testWidgets('Home Dashboard Page', (tester) async {
+      setupGoldenTest(tester);
+
+      await tester.pumpWidget(wrapWithMaterial(const HomeDashboardPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(HomeDashboardPage),
+        matchesGoldenFile('goldens/home_dashboard_page.png'),
+      );
+      resetGoldenTest(tester);
+    });
+  });
+}

--- a/test/features/doctor_verification/presentation/pages/doctor_profile_page_golden_test.dart
+++ b/test/features/doctor_verification/presentation/pages/doctor_profile_page_golden_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/doctor_verification/presentation/pages/doctor_list_page.dart';
+import 'package:orionhealth_health/features/doctor_verification/presentation/pages/doctor_detail_page.dart';
+import 'package:orionhealth_health/features/doctor_verification/presentation/widgets/rating_dialog.dart';
+import 'package:orionhealth_health/features/doctor_verification/application/doctor_verification_cubit.dart';
+import 'package:orionhealth_health/features/doctor_verification/application/doctor_verification_state.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/doctor_profile.dart';
+import '../../../../core/golden_test_utils.dart';
+
+class MockDoctorVerificationCubit extends Mock implements DoctorVerificationCubit {}
+
+void main() {
+  late MockDoctorVerificationCubit mockCubit;
+  final doctorVerified = DoctorProfile(
+    id: '1',
+    fullName: 'Dr. Gregory House',
+    specialty: 'Diagnostic Medicine',
+    verified: true,
+    licenseNumber: 'MD12345',
+    institution: 'Princeton-Plainsboro',
+    yearsOfExperience: 20,
+    languages: ['English', 'Spanish'],
+    countryCode: 'US',
+  );
+  final doctorUnverified = DoctorProfile(
+    id: '2',
+    fullName: 'Dr. John Watson',
+    specialty: 'General Practice',
+    verified: false,
+    licenseNumber: 'MD67890',
+    institution: 'St. Bartholomew\'s',
+    yearsOfExperience: 10,
+    languages: ['English'],
+    countryCode: 'UK',
+  );
+
+  setUpAll(() {
+    mockCubit = MockDoctorVerificationCubit();
+    GetIt.I.registerSingleton<DoctorVerificationCubit>(mockCubit);
+  });
+
+  tearDownAll(() {
+    GetIt.I.reset();
+  });
+
+  group('Doctor Verification Golden Tests', () {
+    testWidgets('Doctor List Page', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(DoctorVerificationLoaded(
+        doctors: [doctorVerified, doctorUnverified],
+        averageRatings: {'1': 4.5, '2': 3.8},
+      ));
+      when(() => mockCubit.loadDoctors()).thenAnswer((_) async {});
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(wrapWithMaterial(const DoctorListPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(DoctorListPage),
+        matchesGoldenFile('goldens/doctor_list_page.png'),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('Doctor Detail Page - Verified', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(DoctorVerificationLoaded(
+        doctors: [doctorVerified],
+        averageRatings: {'1': 4.5},
+      ));
+      when(() => mockCubit.loadDoctors()).thenAnswer((_) async {});
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(wrapWithMaterial(DoctorDetailPage(doctor: doctorVerified)));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(DoctorDetailPage),
+        matchesGoldenFile('goldens/doctor_detail_verified.png'),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('Doctor Detail Page - Unverified', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(DoctorVerificationLoaded(
+        doctors: [doctorUnverified],
+        averageRatings: {'2': 3.8},
+      ));
+
+      await tester.pumpWidget(wrapWithMaterial(DoctorDetailPage(doctor: doctorUnverified)));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(DoctorDetailPage),
+        matchesGoldenFile('goldens/doctor_detail_unverified.png'),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('Rating Dialog', (tester) async {
+      setupGoldenTest(tester);
+
+      await tester.pumpWidget(wrapWithMaterial(
+        Scaffold(
+          body: RatingDialog(
+            doctorId: '1',
+            onSubmitted: (_) {},
+          ),
+        ),
+      ));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(RatingDialog),
+        matchesGoldenFile('goldens/rating_dialog.png'),
+      );
+      resetGoldenTest(tester);
+    });
+  });
+}

--- a/test/features/email-citas/presentation/pages/email_citas_page_golden_test.dart
+++ b/test/features/email-citas/presentation/pages/email_citas_page_golden_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/email-citas/presentation/email_connect_page.dart';
+import 'package:orionhealth_health/features/email-citas/application/email_citas_cubit.dart';
+import 'package:orionhealth_health/features/email-citas/application/email_citas_state.dart';
+import '../../../../core/golden_test_utils.dart';
+
+class MockEmailCitasCubit extends Mock implements EmailCitasCubit {}
+
+void main() {
+  late MockEmailCitasCubit mockCubit;
+
+  setUpAll(() {
+    mockCubit = MockEmailCitasCubit();
+    GetIt.I.registerSingleton<EmailCitasCubit>(mockCubit);
+  });
+
+  tearDownAll(() {
+    GetIt.I.reset();
+  });
+
+  group('Email Citas Golden Tests', () {
+    testWidgets('Email Connect Page - Disconnected', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(EmailCitasInitial());
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(wrapWithMaterial(const EmailConnectPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(EmailConnectPage),
+        matchesGoldenFile('goldens/email_connect_disconnected.png'),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('Email Connect Page - Connected', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(const EmailCitasConnected(
+        isGmailConnected: true,
+        isOutlookConnected: false,
+      ));
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(wrapWithMaterial(const EmailConnectPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(EmailConnectPage),
+        matchesGoldenFile('goldens/email_connect_connected.png'),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('Email Connect Page - Loading', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(EmailCitasLoading());
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(wrapWithMaterial(const EmailConnectPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(EmailConnectPage),
+        matchesGoldenFile('goldens/email_connect_loading.png'),
+      );
+      resetGoldenTest(tester);
+    });
+  });
+}

--- a/test/features/eps_connection/presentation/pages/eps_connection_page_golden_test.dart
+++ b/test/features/eps_connection/presentation/pages/eps_connection_page_golden_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/eps_connection/presentation/eps_connect_button.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/eps_connection_cubit.dart' as cubit_lib;
+import '../../../../core/golden_test_utils.dart';
+
+class MockEpsConnectionCubit extends Mock implements cubit_lib.EpsConnectionCubit {}
+
+void main() {
+  late MockEpsConnectionCubit mockCubit;
+
+  setUpAll(() {
+    mockCubit = MockEpsConnectionCubit();
+    GetIt.I.registerSingleton<cubit_lib.EpsConnectionCubit>(mockCubit);
+  });
+
+  tearDownAll(() {
+    GetIt.I.reset();
+  });
+
+  group('EPS Connection Golden Tests', () {
+    testWidgets('EPS Connect Button - Disconnected', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(const cubit_lib.EpsConnectionDisconnected());
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(wrapWithMaterial(const Scaffold(body: Center(child: Padding(padding: EdgeInsets.all(16), child: EpsConnectButton())))));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(EpsConnectButton),
+        matchesGoldenFile('goldens/eps_connect_button_disconnected.png'),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('EPS Connect Button - Connected', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(const cubit_lib.EpsConnectionConnected('PAT-12345'));
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(wrapWithMaterial(const Scaffold(body: Center(child: Padding(padding: EdgeInsets.all(16), child: EpsConnectButton())))));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(EpsConnectButton),
+        matchesGoldenFile('goldens/eps_connect_button_connected.png'),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('EPS Connect Button - Loading', (tester) async {
+      setupGoldenTest(tester);
+      when(() => mockCubit.state).thenReturn(const cubit_lib.EpsConnectionLoading());
+      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+
+      await tester.pumpWidget(wrapWithMaterial(const Scaffold(body: Center(child: Padding(padding: EdgeInsets.all(16), child: EpsConnectButton())))));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(EpsConnectButton),
+        matchesGoldenFile('goldens/eps_connect_button_loading.png'),
+      );
+      resetGoldenTest(tester);
+    });
+  });
+}


### PR DESCRIPTION
I have added the requested golden screenshot tests for the second batch of features. 

Key changes:
1. **Shared Utilities**: Created `test/core/golden_test_utils.dart` to provide standard setup for 360x640 screen size, MaterialApp wrapping with dark theme and Spanish locale, and font loading configuration.
2. **Doctor Verification**: Added tests for `DoctorListPage`, `DoctorDetailPage` (verified/unverified states), and `RatingDialog` in `test/features/doctor_verification/presentation/pages/doctor_profile_page_golden_test.dart`.
3. **Email Citas**: Added tests for `EmailConnectPage` covering initial, connected, and loading states in `test/features/email-citas/presentation/pages/email_citas_page_golden_test.dart`.
4. **EPS Connection**: Added tests for `EpsConnectButton` (the main UI component found for this feature) in `test/features/eps_connection/presentation/pages/eps_connection_page_golden_test.dart`. Fixed an import conflict between the state and cubit files.
5. **Dashboard**: Added tests for `HomeDashboardPage` in `test/features/dashboard/presentation/pages/dashboard_page_golden_test.dart`. Fixed a name collision for `getIt` in the dashboard source file.
6. **Environment**: Ran `flutter gen-l10n` to ensure tests have access to the necessary localization classes.

I encountered several compilation issues during the golden file generation (missing l10n files, import conflicts, and non-const constructors for states) which were all addressed to ensure the tests can run.

Fixes #515

---
*PR created automatically by Jules for task [6031285232372441853](https://jules.google.com/task/6031285232372441853) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added golden test utilities for visual regression testing with consistent theme and locale settings.
  * Added visual regression tests for dashboard, doctor verification, email integration, and EPS connection features.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->