### PR TITLE
feat(about): add domain and application layers, migrate data folder to infrastructure

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -9,257 +9,262 @@
 
 // ignore_for_file: no_leading_underscores_for_library_prefixes
 import 'package:dio/dio.dart' as _i13;
-import 'package:flutter_appauth/flutter_appauth.dart' as _i55;
-import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i56;
+import 'package:flutter_appauth/flutter_appauth.dart' as _i57;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i58;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:http/http.dart' as _i10;
 import 'package:injectable/injectable.dart' as _i2;
-import 'package:isar/isar.dart' as _i22;
+import 'package:isar/isar.dart' as _i24;
 import 'package:isar_agent_memory/isar_agent_memory.dart' as _i16;
-import 'package:medical_standards/medical_standards.dart' as _i35;
+import 'package:medical_standards/medical_standards.dart' as _i37;
 
-import '../../features/allergies/application/allergies_cubit.dart' as _i134;
+import '../../features/about/application/about_cubit.dart' as _i88;
+import '../../features/about/domain/repositories/i_about_repository.dart'
+    as _i21;
+import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
+    as _i22;
+import '../../features/allergies/application/allergies_cubit.dart' as _i137;
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i86;
+    as _i89;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i3;
 import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
-    as _i87;
-import '../../features/appointments/application/appointments_cubit.dart'
-    as _i92;
-import '../../features/appointments/domain/repositories/appointment_repository.dart'
     as _i90;
+import '../../features/appointments/application/appointments_cubit.dart'
+    as _i95;
+import '../../features/appointments/domain/repositories/appointment_repository.dart'
+    as _i93;
 import '../../features/appointments/domain/services/appointment_service.dart'
     as _i4;
 import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
-    as _i91;
-import '../../features/auth/application/auth_cubit.dart' as _i135;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i136;
-import '../../features/auth/domain/auth_service.dart' as _i95;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i93;
-import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
     as _i94;
+import '../../features/auth/application/auth_cubit.dart' as _i139;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i138;
+import '../../features/auth/domain/auth_service.dart' as _i98;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i96;
+import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
+    as _i97;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i5;
 import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
-    as _i96;
+    as _i99;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
     as _i17;
 import '../../features/calendar_import/data/calendar_repository.dart' as _i9;
 import '../../features/calendar_import/domain/calendar_import_cubit.dart'
-    as _i97;
-import '../../features/dashboard/application/dashboard_cubit.dart' as _i137;
-import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
     as _i100;
-import '../../features/dashboard/infrastructure/repositories/dashboard_repository_impl.dart'
-    as _i101;
-import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
-    as _i104;
-import '../../features/doctor_verification/data/datasources/license_registry_local.dart'
-    as _i25;
-import '../../features/doctor_verification/data/repositories/isar_doctor_profile_repository.dart'
+import '../../features/dashboard/application/dashboard_cubit.dart' as _i140;
+import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
     as _i103;
+import '../../features/dashboard/infrastructure/repositories/dashboard_repository_impl.dart'
+    as _i104;
+import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
+    as _i107;
+import '../../features/doctor_verification/data/datasources/license_registry_local.dart'
+    as _i27;
+import '../../features/doctor_verification/data/repositories/isar_doctor_profile_repository.dart'
+    as _i106;
 import '../../features/doctor_verification/data/repositories/isar_rating_repository.dart'
-    as _i61;
+    as _i63;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
-    as _i102;
+    as _i105;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
-    as _i60;
+    as _i62;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
-    as _i26;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i105;
+    as _i28;
+import '../../features/email-citas/application/email_citas_cubit.dart' as _i108;
 import '../../features/email-citas/domain/repositories/email_repository.dart'
     as _i14;
 import '../../features/email-citas/infrastructure/repositories/email_repository_impl.dart'
     as _i15;
 import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
-    as _i106;
-import '../../features/eps_connection/infrastructure/oauth_repository.dart'
-    as _i54;
-import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i109;
+import '../../features/eps_connection/infrastructure/oauth_repository.dart'
+    as _i56;
+import '../../features/health_data_import/application/health_import_cubit.dart'
+    as _i112;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i20;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i140;
+    as _i143;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i110;
+    as _i113;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i111;
+    as _i114;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i19;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
-    as _i21;
+    as _i23;
 import '../../features/health_record/infrastructure/services/ocr_service.dart'
-    as _i57;
-import '../../features/health_sharing/application/sharing_cubit.dart' as _i66;
+    as _i59;
+import '../../features/health_sharing/application/sharing_cubit.dart' as _i68;
 import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
     as _i6;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i7;
 import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
-    as _i52;
+    as _i54;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i67;
-import '../../features/home/domain/repositories/home_repository.dart' as _i145;
-import '../../features/home/infrastructure/home_repository_impl.dart' as _i146;
+    as _i69;
+import '../../features/home/domain/repositories/home_repository.dart' as _i148;
+import '../../features/home/infrastructure/home_repository_impl.dart' as _i149;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i126;
+    as _i129;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
-    as _i37;
-import '../../features/local_agent/domain/services/llm_adapter.dart' as _i27;
-import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i79;
-import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i29;
-import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
-    as _i30;
-import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i112;
-import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
-    as _i113;
-import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i114;
-import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i28;
-import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i117;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i116;
-import '../../features/local_agent/infrastructure/rag_llm_service.dart'
-    as _i141;
-import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
     as _i39;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
-    as _i38;
-import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i80;
-import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i115;
-import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
-    as _i33;
-import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i142;
-import '../../features/local_agent/infrastructure/services/model_download_service.dart'
-    as _i51;
-import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i123;
-import '../../features/medical_assistant/application/medical_assistant_cubit.dart'
-    as _i119;
-import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
-    as _i23;
-import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
-    as _i73;
-import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
+import '../../features/local_agent/domain/services/llm_adapter.dart' as _i29;
+import '../../features/local_agent/domain/services/vector_store_service.dart'
     as _i81;
-import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
-    as _i98;
-import '../../features/medical_assistant/domain/services/health_context_service.dart'
-    as _i107;
-import '../../features/medical_assistant/domain/services/medical_analysis_service.dart'
-    as _i34;
-import '../../features/medical_assistant/domain/services/medical_guidelines_service.dart'
-    as _i36;
-import '../../features/medical_assistant/domain/services/risk_calculator_service.dart'
-    as _i65;
-import '../../features/medical_assistant/infrastructure/analysis/lab_interpreter.dart'
-    as _i24;
-import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
-    as _i64;
-import '../../features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart'
-    as _i82;
-import '../../features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart'
-    as _i40;
-import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
-    as _i99;
-import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
-    as _i108;
-import '../../features/medical_research/application/medical_research_cubit.dart'
-    as _i143;
-import '../../features/medical_research/domain/services/medical_scraper_service.dart'
+import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
+    as _i31;
+import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
+    as _i32;
+import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
+    as _i116;
+import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
+    as _i117;
+import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+    as _i115;
+import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
+    as _i30;
+import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
+    as _i120;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i119;
+import '../../features/local_agent/infrastructure/rag_llm_service.dart'
+    as _i144;
+import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
     as _i41;
-import '../../features/medical_research/domain/services/medical_standards_service.dart'
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i40;
+import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
+    as _i82;
+import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
+    as _i118;
+import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
+    as _i35;
+import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
+    as _i145;
+import '../../features/local_agent/infrastructure/services/model_download_service.dart'
+    as _i53;
+import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
+    as _i126;
+import '../../features/medical_assistant/application/medical_assistant_cubit.dart'
+    as _i122;
+import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
+    as _i25;
+import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
+    as _i75;
+import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
+    as _i83;
+import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
+    as _i101;
+import '../../features/medical_assistant/domain/services/health_context_service.dart'
+    as _i110;
+import '../../features/medical_assistant/domain/services/medical_analysis_service.dart'
+    as _i36;
+import '../../features/medical_assistant/domain/services/medical_guidelines_service.dart'
+    as _i38;
+import '../../features/medical_assistant/domain/services/risk_calculator_service.dart'
+    as _i67;
+import '../../features/medical_assistant/infrastructure/analysis/lab_interpreter.dart'
+    as _i26;
+import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
+    as _i66;
+import '../../features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart'
+    as _i84;
+import '../../features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart'
+    as _i42;
+import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
+    as _i102;
+import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
+    as _i111;
+import '../../features/medical_research/application/medical_research_cubit.dart'
+    as _i146;
+import '../../features/medical_research/domain/services/medical_scraper_service.dart'
     as _i43;
-import '../../features/medical_research/domain/services/medical_web_search_service.dart'
+import '../../features/medical_research/domain/services/medical_standards_service.dart'
     as _i45;
+import '../../features/medical_research/domain/services/medical_web_search_service.dart'
+    as _i47;
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i8;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i120;
+    as _i123;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
-    as _i42;
-import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
     as _i44;
-import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
+import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
     as _i46;
-import '../../features/medications/application/medications_cubit.dart' as _i49;
-import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i47;
-import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
     as _i48;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i58;
-import '../../features/onboarding/application/sync_cubit.dart' as _i128;
-import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i121;
-import '../../features/onboarding/infrastructure/onboarding_repository_impl.dart'
-    as _i122;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i144;
-import '../../features/reports/domain/repositories/report_repository.dart'
-    as _i62;
-import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i124;
-import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
-    as _i63;
-import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i125;
-import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
+import '../../features/medications/application/medications_cubit.dart' as _i51;
+import '../../features/medications/domain/repositories/medication_repository.dart'
+    as _i49;
+import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
     as _i50;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i118;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i60;
+import '../../features/onboarding/application/sync_cubit.dart' as _i131;
+import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
+    as _i124;
+import '../../features/onboarding/infrastructure/onboarding_repository_impl.dart'
+    as _i125;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i147;
+import '../../features/reports/domain/repositories/report_repository.dart'
+    as _i64;
+import '../../features/reports/domain/services/report_generation_service.dart'
+    as _i127;
+import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
+    as _i65;
+import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+    as _i128;
+import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
+    as _i52;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i121;
 import '../../features/settings/domain/repositories/llm_settings_repository.dart'
-    as _i31;
+    as _i33;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i11;
+    as _i12;
 import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
-    as _i32;
-import '../../features/ssi/application/ssi_cubit.dart' as _i127;
-import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i69;
-import '../../features/ssi/domain/services/anoncreds_service.dart' as _i88;
-import '../../features/ssi/domain/services/ssi_service.dart' as _i71;
+    as _i34;
+import '../../features/ssi/application/ssi_cubit.dart' as _i130;
+import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i71;
+import '../../features/ssi/domain/services/anoncreds_service.dart' as _i91;
+import '../../features/ssi/domain/services/ssi_service.dart' as _i73;
 import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
-    as _i70;
-import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
-    as _i89;
-import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
-    as _i68;
-import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
     as _i72;
-import '../../features/sync/application/sync_cubit.dart' as _i138;
+import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
+    as _i92;
+import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
+    as _i70;
+import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
+    as _i74;
+import '../../features/sync/application/sync_cubit.dart' as _i142;
 import '../../features/sync/data/fhir_client.dart' as _i18;
-import '../../features/sync/data/node_discovery_service.dart' as _i53;
-import '../../features/sync/data/sync_repository.dart' as _i75;
-import '../../features/sync/domain/repositories/sync_repository.dart' as _i132;
-import '../../features/sync/domain/services/sync_service.dart' as _i130;
-import '../../features/sync/domain/sync_cubit.dart' as _i139;
-import '../../features/sync/domain/sync_repository.dart' as _i74;
-import '../../features/sync/domain/sync_service.dart' as _i129;
+import '../../features/sync/data/node_discovery_service.dart' as _i55;
+import '../../features/sync/data/sync_repository.dart' as _i77;
+import '../../features/sync/domain/repositories/sync_repository.dart' as _i135;
+import '../../features/sync/domain/services/sync_service.dart' as _i133;
+import '../../features/sync/domain/sync_cubit.dart' as _i141;
+import '../../features/sync/domain/sync_repository.dart' as _i76;
+import '../../features/sync/domain/sync_service.dart' as _i132;
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
-    as _i131;
+    as _i134;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i133;
+    as _i136;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i76;
-import '../../features/user_profile/domain/services/user_profile_service.dart'
     as _i78;
+import '../../features/user_profile/domain/services/user_profile_service.dart'
+    as _i80;
 import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
-    as _i77;
-import '../../features/vitals/application/vitals_cubit.dart' as _i85;
+    as _i79;
+import '../../features/vitals/application/vitals_cubit.dart' as _i87;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i83;
+    as _i85;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
-    as _i84;
-import '../services/device_capability_service.dart' as _i12;
-import '../services/privacy_anonymizer.dart' as _i59;
-import 'database_module.dart' as _i150;
-import 'fhir_module.dart' as _i147;
-import 'memory_module.dart' as _i149;
-import 'network_module.dart' as _i148;
+    as _i86;
+import '../services/device_capability_service.dart' as _i11;
+import '../services/privacy_anonymizer.dart' as _i61;
+import 'database_module.dart' as _i153;
+import 'fhir_module.dart' as _i150;
+import 'memory_module.dart' as _i152;
+import 'network_module.dart' as _i151;
 
 const String _desktop = 'desktop';
 const String _test = 'test';
@@ -304,81 +309,82 @@ extension GetItInjectableX on _i1.GetIt {
         () => _i19.FilePickerServiceImpl());
     gh.lazySingleton<_i20.HealthDataImportService>(
         () => _i20.HealthDataImportService());
-    gh.lazySingleton<_i21.ImagePickerService>(
-        () => _i21.ImagePickerServiceImpl());
-    await gh.factoryAsync<_i22.Isar>(
+    gh.lazySingleton<_i21.IAboutRepository>(() => _i22.AboutRepositoryImpl());
+    gh.lazySingleton<_i23.ImagePickerService>(
+        () => _i23.ImagePickerServiceImpl());
+    await gh.factoryAsync<_i24.Isar>(
       () => databaseModule.isar,
       preResolve: true,
     );
-    gh.factory<_i23.LabAnalysisStrategy>(() => _i23.LabAnalysisStrategy());
-    gh.factory<_i24.LabInterpreter>(() => _i24.LabInterpreter());
-    gh.lazySingletonAsync<_i25.LicenseRegistryLocal>(() {
-      final i = _i25.LicenseRegistryLocal();
+    gh.factory<_i25.LabAnalysisStrategy>(() => _i25.LabAnalysisStrategy());
+    gh.factory<_i26.LabInterpreter>(() => _i26.LabInterpreter());
+    gh.lazySingletonAsync<_i27.LicenseRegistryLocal>(() {
+      final i = _i27.LicenseRegistryLocal();
       return i.load().then((_) => i);
     });
-    gh.lazySingletonAsync<_i26.LicenseVerifier>(() async =>
-        _i26.LicenseVerifier(await getAsync<_i25.LicenseRegistryLocal>()));
-    gh.lazySingleton<_i27.LlmAdapter>(
-      () => _i28.OpenaiCompatibleAdapter(),
+    gh.lazySingletonAsync<_i28.LicenseVerifier>(() async =>
+        _i28.LicenseVerifier(await getAsync<_i27.LicenseRegistryLocal>()));
+    gh.lazySingleton<_i29.LlmAdapter>(
+      () => _i30.OpenaiCompatibleAdapter(),
       instanceName: 'openai',
     );
-    gh.lazySingleton<_i27.LlmAdapter>(
-      () => _i29.FlutterGemmaAdapter(wrapper: gh<_i30.FlutterGemmaWrapper>()),
+    gh.lazySingleton<_i29.LlmAdapter>(
+      () => _i31.FlutterGemmaAdapter(wrapper: gh<_i32.FlutterGemmaWrapper>()),
       instanceName: 'gemma',
     );
-    gh.lazySingleton<_i31.LlmSettingsRepository>(
-        () => _i32.LlmSettingsRepositoryImpl(gh<_i22.Isar>()));
-    gh.lazySingleton<_i33.LocalLlmService>(() => _i33.LocalLlmService());
-    gh.factory<_i34.MedicalAnalysisService>(
-        () => _i34.MedicalAnalysisService());
-    gh.lazySingleton<_i35.MedicalContextProvider>(
+    gh.lazySingleton<_i33.LlmSettingsRepository>(
+        () => _i34.LlmSettingsRepositoryImpl(gh<_i24.Isar>()));
+    gh.lazySingleton<_i35.LocalLlmService>(() => _i35.LocalLlmService());
+    gh.factory<_i36.MedicalAnalysisService>(
+        () => _i36.MedicalAnalysisService());
+    gh.lazySingleton<_i37.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
-    gh.factory<_i36.MedicalGuidelinesService>(
-        () => _i36.MedicalGuidelinesService());
-    gh.factory<_i37.MedicalKnowledgeRepository>(
-      () => _i38.JsonMedicalKnowledgeRepository(),
+    gh.factory<_i38.MedicalGuidelinesService>(
+        () => _i38.MedicalGuidelinesService());
+    gh.factory<_i39.MedicalKnowledgeRepository>(
+      () => _i40.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
     );
-    gh.factory<_i37.MedicalKnowledgeRepository>(
-      () => _i39.AssetMedicalKnowledgeRepository(),
+    gh.factory<_i39.MedicalKnowledgeRepository>(
+      () => _i41.AssetMedicalKnowledgeRepository(),
       registerFor: {_mobile},
     );
-    gh.factory<_i40.MedicalLlmAdapter>(() => _i40.MedicalLlmAdapter());
-    gh.lazySingleton<_i41.MedicalScraperService>(
-        () => _i42.MedicalScraperServiceImpl(
+    gh.factory<_i42.MedicalLlmAdapter>(() => _i42.MedicalLlmAdapter());
+    gh.lazySingleton<_i43.MedicalScraperService>(
+        () => _i44.MedicalScraperServiceImpl(
               gh<_i13.Dio>(),
               gh<_i8.BotBypassHandler>(),
             ));
-    gh.lazySingleton<_i43.MedicalStandardsService>(() =>
-        _i44.MedicalStandardsServiceImpl(gh<_i35.MedicalContextProvider>()));
-    gh.lazySingleton<_i45.MedicalWebSearchService>(
-        () => _i46.MedicalWebSearchServiceImpl(gh<_i13.Dio>()));
-    gh.lazySingleton<_i47.MedicationRepository>(
-        () => _i48.IsarMedicationRepository(gh<_i22.Isar>()));
-    gh.factory<_i49.MedicationsCubit>(
-        () => _i49.MedicationsCubit(gh<_i47.MedicationRepository>()));
+    gh.lazySingleton<_i45.MedicalStandardsService>(() =>
+        _i46.MedicalStandardsServiceImpl(gh<_i37.MedicalContextProvider>()));
+    gh.lazySingleton<_i47.MedicalWebSearchService>(
+        () => _i48.MedicalWebSearchServiceImpl(gh<_i13.Dio>()));
+    gh.lazySingleton<_i49.MedicationRepository>(
+        () => _i50.IsarMedicationRepository(gh<_i24.Isar>()));
+    gh.factory<_i51.MedicationsCubit>(
+        () => _i51.MedicationsCubit(gh<_i49.MedicationRepository>()));
     await gh.lazySingletonAsync<_i16.MemoryGraph>(
       () => memoryModule.memoryGraph(
-        gh<_i22.Isar>(),
+        gh<_i24.Isar>(),
         gh<_i16.EmbeddingsAdapter>(),
       ),
       preResolve: true,
     );
-    gh.lazySingleton<_i50.MockReportGenerationService>(
-      () => _i50.MockReportGenerationService(),
+    gh.lazySingleton<_i52.MockReportGenerationService>(
+      () => _i52.MockReportGenerationService(),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i51.ModelDownloadService>(
-        () => _i51.ModelDownloadService());
-    gh.lazySingleton<_i52.NfcSharingService>(() => _i52.NfcSharingService());
-    gh.lazySingleton<_i53.NodeDiscoveryService>(
-        () => _i53.NodeDiscoveryService());
-    gh.lazySingleton<_i54.OAuthRepository>(() => _i54.OAuthRepositoryImpl(
-          appAuth: gh<_i55.FlutterAppAuth>(),
-          secureStorage: gh<_i56.FlutterSecureStorage>(),
+    gh.lazySingleton<_i53.ModelDownloadService>(
+        () => _i53.ModelDownloadService());
+    gh.lazySingleton<_i54.NfcSharingService>(() => _i54.NfcSharingService());
+    gh.lazySingleton<_i55.NodeDiscoveryService>(
+        () => _i55.NodeDiscoveryService());
+    gh.lazySingleton<_i56.OAuthRepository>(() => _i56.OAuthRepositoryImpl(
+          appAuth: gh<_i57.FlutterAppAuth>(),
+          secureStorage: gh<_i58.FlutterSecureStorage>(),
           clientId: gh<String>(),
           redirectUrl: gh<String>(),
           discoveryUrl: gh<String>(),
@@ -387,247 +393,249 @@ extension GetItInjectableX on _i1.GetIt {
           idTokenKey: gh<String>(),
           refreshTokenKey: gh<String>(),
         ));
-    gh.lazySingleton<_i57.OcrService>(() => _i57.MlKitOcrService());
-    gh.factory<_i58.OnboardingCubit>(() => _i58.OnboardingCubit());
-    gh.lazySingleton<_i59.PromptScrubber>(
-        () => _i59.PromptScrubber(gh<_i22.Isar>()));
-    gh.lazySingleton<_i60.RatingRepository>(
-        () => _i61.IsarRatingRepository(gh<_i22.Isar>()));
-    gh.lazySingleton<_i62.ReportRepository>(
-        () => _i63.IsarReportRepository(gh<_i22.Isar>()));
-    gh.factory<_i64.RiskCalculator>(() => _i64.RiskCalculator());
-    gh.factory<_i65.RiskCalculatorService>(() =>
-        _i65.RiskCalculatorService(calculator: gh<_i64.RiskCalculator>()));
-    gh.factory<_i66.SharingCubit>(() => _i66.SharingCubit(
+    gh.lazySingleton<_i59.OcrService>(() => _i59.MlKitOcrService());
+    gh.factory<_i60.OnboardingCubit>(() => _i60.OnboardingCubit());
+    gh.lazySingleton<_i61.PromptScrubber>(
+        () => _i61.PromptScrubber(gh<_i24.Isar>()));
+    gh.lazySingleton<_i62.RatingRepository>(
+        () => _i63.IsarRatingRepository(gh<_i24.Isar>()));
+    gh.lazySingleton<_i64.ReportRepository>(
+        () => _i65.IsarReportRepository(gh<_i24.Isar>()));
+    gh.factory<_i66.RiskCalculator>(() => _i66.RiskCalculator());
+    gh.factory<_i67.RiskCalculatorService>(() =>
+        _i67.RiskCalculatorService(calculator: gh<_i66.RiskCalculator>()));
+    gh.factory<_i68.SharingCubit>(() => _i68.SharingCubit(
           bleService: gh<_i6.BleSharingService>(),
-          nfcService: gh<_i52.NfcSharingService>(),
-          wifiService: gh<_i67.WifiDirectService>(),
+          nfcService: gh<_i54.NfcSharingService>(),
+          wifiService: gh<_i69.WifiDirectService>(),
         ));
-    gh.lazySingleton<_i68.SidetreeAnchorClient>(
-        () => _i68.SidetreeAnchorClient.create());
-    gh.lazySingleton<_i69.SsiRepository>(
-        () => _i70.IsarSsiRepository(gh<_i22.Isar>()));
-    gh.lazySingleton<_i71.SsiService>(() => _i72.SsiServiceImpl(
-          gh<_i69.SsiRepository>(),
-          gh<_i68.SidetreeAnchorClient>(),
+    gh.lazySingleton<_i70.SidetreeAnchorClient>(
+        () => _i70.SidetreeAnchorClient.create());
+    gh.lazySingleton<_i71.SsiRepository>(
+        () => _i72.IsarSsiRepository(gh<_i24.Isar>()));
+    gh.lazySingleton<_i73.SsiService>(() => _i74.SsiServiceImpl(
+          gh<_i71.SsiRepository>(),
+          gh<_i70.SidetreeAnchorClient>(),
         ));
-    gh.factory<_i73.SymptomAnalysisStrategy>(
-        () => _i73.SymptomAnalysisStrategy());
-    gh.lazySingleton<_i74.SyncRepository>(() => _i75.SyncRepositoryImpl(
+    gh.factory<_i75.SymptomAnalysisStrategy>(
+        () => _i75.SymptomAnalysisStrategy());
+    gh.lazySingleton<_i76.SyncRepository>(() => _i77.SyncRepositoryImpl(
           gh<_i18.FhirClient>(),
-          gh<_i22.Isar>(),
-          gh<_i56.FlutterSecureStorage>(),
-          gh<_i53.NodeDiscoveryService>(),
+          gh<_i24.Isar>(),
+          gh<_i58.FlutterSecureStorage>(),
+          gh<_i55.NodeDiscoveryService>(),
         ));
-    gh.lazySingleton<_i35.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i76.UserProfileRepository>(
-        () => _i77.UserProfileRepositoryImpl(gh<_i22.Isar>()));
-    gh.lazySingleton<_i78.UserProfileService>(
-        () => _i78.UserProfileService(gh<_i76.UserProfileRepository>()));
-    gh.lazySingleton<_i79.VectorStoreService>(() => _i80.IsarVectorStoreService(
+    gh.lazySingleton<_i37.SyncService>(() => networkModule.syncService);
+    gh.lazySingleton<_i78.UserProfileRepository>(
+        () => _i79.UserProfileRepositoryImpl(gh<_i24.Isar>()));
+    gh.lazySingleton<_i80.UserProfileService>(
+        () => _i80.UserProfileService(gh<_i78.UserProfileRepository>()));
+    gh.lazySingleton<_i81.VectorStoreService>(() => _i82.IsarVectorStoreService(
           gh<_i16.MemoryGraph>(),
-          gh<_i37.MedicalKnowledgeRepository>(),
+          gh<_i39.MedicalKnowledgeRepository>(),
         ));
-    gh.factory<_i81.VitalAnalysisStrategy>(() => _i81.VitalAnalysisStrategy());
-    gh.factory<_i82.VitalSignAnalyzer>(() => _i82.VitalSignAnalyzer());
-    gh.lazySingleton<_i83.VitalSignRepository>(
-        () => _i84.VitalSignRepositoryImpl(gh<_i22.Isar>()));
-    gh.factory<_i85.VitalsCubit>(
-        () => _i85.VitalsCubit(gh<_i83.VitalSignRepository>()));
-    gh.lazySingleton<_i67.WifiDirectService>(() => _i67.WifiDirectService());
-    gh.lazySingleton<_i86.AllergyRepository>(
-        () => _i87.IsarAllergyRepository(gh<_i22.Isar>()));
-    gh.lazySingleton<_i88.AnonCredsService>(
-        () => _i89.AnonCredsServiceImpl(gh<_i69.SsiRepository>()));
-    gh.lazySingleton<_i90.AppointmentRepository>(
-        () => _i91.IsarAppointmentRepository(gh<_i22.Isar>()));
-    gh.factory<_i92.AppointmentsCubit>(
-        () => _i92.AppointmentsCubit(gh<_i90.AppointmentRepository>()));
-    gh.lazySingleton<_i93.AuthRepository>(
-        () => _i94.AuthRepositoryImpl(gh<_i22.Isar>()));
-    gh.lazySingleton<_i95.AuthService>(
-        () => _i95.AuthServiceImpl(gh<_i17.EncryptionService>()));
-    gh.lazySingleton<_i96.BleMedicalSharingService>(
-        () => _i96.BleMedicalSharingService(
+    gh.factory<_i83.VitalAnalysisStrategy>(() => _i83.VitalAnalysisStrategy());
+    gh.factory<_i84.VitalSignAnalyzer>(() => _i84.VitalSignAnalyzer());
+    gh.lazySingleton<_i85.VitalSignRepository>(
+        () => _i86.VitalSignRepositoryImpl(gh<_i24.Isar>()));
+    gh.factory<_i87.VitalsCubit>(
+        () => _i87.VitalsCubit(gh<_i85.VitalSignRepository>()));
+    gh.lazySingleton<_i69.WifiDirectService>(() => _i69.WifiDirectService());
+    gh.factory<_i88.AboutCubit>(
+        () => _i88.AboutCubit(gh<_i21.IAboutRepository>()));
+    gh.lazySingleton<_i89.AllergyRepository>(
+        () => _i90.IsarAllergyRepository(gh<_i24.Isar>()));
+    gh.lazySingleton<_i91.AnonCredsService>(
+        () => _i92.AnonCredsServiceImpl(gh<_i71.SsiRepository>()));
+    gh.lazySingleton<_i93.AppointmentRepository>(
+        () => _i94.IsarAppointmentRepository(gh<_i24.Isar>()));
+    gh.factory<_i95.AppointmentsCubit>(
+        () => _i95.AppointmentsCubit(gh<_i93.AppointmentRepository>()));
+    gh.lazySingleton<_i96.AuthRepository>(
+        () => _i97.AuthRepositoryImpl(gh<_i24.Isar>()));
+    gh.lazySingleton<_i98.AuthService>(
+        () => _i98.AuthServiceImpl(gh<_i17.EncryptionService>()));
+    gh.lazySingleton<_i99.BleMedicalSharingService>(
+        () => _i99.BleMedicalSharingService(
               gh<_i6.BleSharingService>(),
               gh<_i17.EncryptionService>(),
-              gh<_i71.SsiService>(),
+              gh<_i73.SsiService>(),
             ));
-    gh.factory<_i97.CalendarImportCubit>(() => _i97.CalendarImportCubit(
+    gh.factory<_i100.CalendarImportCubit>(() => _i100.CalendarImportCubit(
           gh<_i9.CalendarRepository>(),
-          gh<_i90.AppointmentRepository>(),
-          gh<_i76.UserProfileRepository>(),
+          gh<_i93.AppointmentRepository>(),
+          gh<_i78.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i98.ClinicalReasonerService>(
-        () => _i99.SymphonyClinicalReasonerService(
-              gh<_i37.MedicalKnowledgeRepository>(),
-              gh<_i59.PromptScrubber>(),
+    gh.lazySingleton<_i101.ClinicalReasonerService>(
+        () => _i102.SymphonyClinicalReasonerService(
+              gh<_i39.MedicalKnowledgeRepository>(),
+              gh<_i61.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i100.DashboardRepository>(
-        () => _i101.DashboardRepositoryImpl(
-              gh<_i83.VitalSignRepository>(),
-              gh<_i47.MedicationRepository>(),
-              gh<_i62.ReportRepository>(),
+    gh.lazySingleton<_i103.DashboardRepository>(
+        () => _i104.DashboardRepositoryImpl(
+              gh<_i85.VitalSignRepository>(),
+              gh<_i49.MedicationRepository>(),
+              gh<_i64.ReportRepository>(),
             ));
-    gh.lazySingleton<_i102.DoctorProfileRepository>(
-        () => _i103.IsarDoctorProfileRepository(gh<_i22.Isar>()));
-    gh.factoryAsync<_i104.DoctorVerificationCubit>(
-        () async => _i104.DoctorVerificationCubit(
-              gh<_i102.DoctorProfileRepository>(),
-              gh<_i60.RatingRepository>(),
-              await getAsync<_i26.LicenseVerifier>(),
+    gh.lazySingleton<_i105.DoctorProfileRepository>(
+        () => _i106.IsarDoctorProfileRepository(gh<_i24.Isar>()));
+    gh.factoryAsync<_i107.DoctorVerificationCubit>(
+        () async => _i107.DoctorVerificationCubit(
+              gh<_i105.DoctorProfileRepository>(),
+              gh<_i62.RatingRepository>(),
+              await getAsync<_i28.LicenseVerifier>(),
             ));
-    gh.factory<_i105.EmailCitasCubit>(() => _i105.EmailCitasCubit(
+    gh.factory<_i108.EmailCitasCubit>(() => _i108.EmailCitasCubit(
           gh<_i14.EmailRepository>(),
-          gh<_i90.AppointmentRepository>(),
+          gh<_i93.AppointmentRepository>(),
         ));
-    gh.factory<_i106.EpsConnectionCubit>(() => _i106.EpsConnectionCubit(
-          gh<_i54.OAuthRepository>(),
-          gh<_i76.UserProfileRepository>(),
+    gh.factory<_i109.EpsConnectionCubit>(() => _i109.EpsConnectionCubit(
+          gh<_i56.OAuthRepository>(),
+          gh<_i78.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i107.HealthContextService>(
-        () => _i108.IsarHealthContextService(
-              gh<_i83.VitalSignRepository>(),
-              gh<_i47.MedicationRepository>(),
-              gh<_i76.UserProfileRepository>(),
+    gh.lazySingleton<_i110.HealthContextService>(
+        () => _i111.IsarHealthContextService(
+              gh<_i85.VitalSignRepository>(),
+              gh<_i49.MedicationRepository>(),
+              gh<_i78.UserProfileRepository>(),
               gh<_i16.MemoryGraph>(),
             ));
-    gh.factory<_i109.HealthImportCubit>(() => _i109.HealthImportCubit(
+    gh.factory<_i112.HealthImportCubit>(() => _i112.HealthImportCubit(
           gh<_i20.HealthDataImportService>(),
-          gh<_i83.VitalSignRepository>(),
+          gh<_i85.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i110.HealthRecordRepository>(
-        () => _i111.HealthRecordRepositoryImpl(gh<_i22.Isar>()));
-    gh.lazySingleton<_i27.LlmAdapter>(
-      () => _i112.GeminiLlmAdapter(
-        scrubber: gh<_i59.PromptScrubber>(),
-        userProfileRepository: gh<_i76.UserProfileRepository>(),
-        modelWrapper: gh<_i113.GeminiModelWrapper>(),
+    gh.lazySingleton<_i113.HealthRecordRepository>(
+        () => _i114.HealthRecordRepositoryImpl(gh<_i24.Isar>()));
+    gh.factory<_i29.LlmAdapter>(
+      () => _i115.MockLlmAdapter(gh<_i61.PromptScrubber>()),
+      instanceName: 'mock',
+    );
+    gh.lazySingleton<_i29.LlmAdapter>(
+      () => _i116.GeminiLlmAdapter(
+        scrubber: gh<_i61.PromptScrubber>(),
+        userProfileRepository: gh<_i78.UserProfileRepository>(),
+        modelWrapper: gh<_i117.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
     );
-    gh.factory<_i27.LlmAdapter>(
-      () => _i114.MockLlmAdapter(gh<_i59.PromptScrubber>()),
-      instanceName: 'mock',
-    );
-    gh.lazySingleton<_i115.LlmAdapterFactory>(
-        () => _i115.LlmAdapterFactory(gh<_i31.LlmSettingsRepository>()));
-    gh.lazySingleton<_i116.LlmService>(() => _i117.GemmaLlmService(
-          gh<_i79.VectorStoreService>(),
-          gh<_i76.UserProfileRepository>(),
-          gh<_i27.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i118.LlmAdapterFactory>(
+        () => _i118.LlmAdapterFactory(gh<_i33.LlmSettingsRepository>()));
+    gh.lazySingleton<_i119.LlmService>(() => _i120.GemmaLlmService(
+          gh<_i81.VectorStoreService>(),
+          gh<_i78.UserProfileRepository>(),
+          gh<_i29.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i118.LlmSettingsCubit>(() => _i118.LlmSettingsCubit(
-          gh<_i31.LlmSettingsRepository>(),
-          gh<_i11.DeviceCapabilityService>(),
-          gh<_i27.LlmAdapter>(instanceName: 'gemma'),
+    gh.factory<_i121.LlmSettingsCubit>(() => _i121.LlmSettingsCubit(
+          gh<_i33.LlmSettingsRepository>(),
+          gh<_i12.DeviceCapabilityService>(),
+          gh<_i29.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i119.MedicalAssistantCubit>(() => _i119.MedicalAssistantCubit(
-          llmAdapter: gh<_i40.MedicalLlmAdapter>(),
-          analysisService: gh<_i34.MedicalAnalysisService>(),
-          healthContextService: gh<_i107.HealthContextService>(),
+    gh.factory<_i122.MedicalAssistantCubit>(() => _i122.MedicalAssistantCubit(
+          llmAdapter: gh<_i42.MedicalLlmAdapter>(),
+          analysisService: gh<_i36.MedicalAnalysisService>(),
+          healthContextService: gh<_i110.HealthContextService>(),
         ));
-    gh.lazySingleton<_i120.MedicalResearchService>(
-        () => _i120.MedicalResearchService(
-              gh<_i45.MedicalWebSearchService>(),
-              gh<_i41.MedicalScraperService>(),
+    gh.lazySingleton<_i123.MedicalResearchService>(
+        () => _i123.MedicalResearchService(
+              gh<_i47.MedicalWebSearchService>(),
+              gh<_i43.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i121.OnboardingRepository>(
-        () => _i122.OnboardingRepositoryImpl(gh<_i76.UserProfileRepository>()));
-    gh.lazySingleton<_i123.PatientContextIndexer>(
-      () => _i123.PatientContextIndexer(
-        gh<_i22.Isar>(),
-        gh<_i79.VectorStoreService>(),
-        gh<_i110.HealthRecordRepository>(),
-        gh<_i47.MedicationRepository>(),
-        gh<_i86.AllergyRepository>(),
-        gh<_i83.VitalSignRepository>(),
-        gh<_i90.AppointmentRepository>(),
+    gh.lazySingleton<_i124.OnboardingRepository>(
+        () => _i125.OnboardingRepositoryImpl(gh<_i78.UserProfileRepository>()));
+    gh.lazySingleton<_i126.PatientContextIndexer>(
+      () => _i126.PatientContextIndexer(
+        gh<_i24.Isar>(),
+        gh<_i81.VectorStoreService>(),
+        gh<_i113.HealthRecordRepository>(),
+        gh<_i49.MedicationRepository>(),
+        gh<_i89.AllergyRepository>(),
+        gh<_i85.VitalSignRepository>(),
+        gh<_i93.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i124.ReportGenerationService>(
-        () => _i125.GemmaReportGenerationService(
-              gh<_i27.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i79.VectorStoreService>(),
-              gh<_i76.UserProfileRepository>(),
-              gh<_i59.PromptScrubber>(),
+    gh.lazySingleton<_i127.ReportGenerationService>(
+        () => _i128.GemmaReportGenerationService(
+              gh<_i29.LlmAdapter>(instanceName: 'gemma'),
+              gh<_i81.VectorStoreService>(),
+              gh<_i78.UserProfileRepository>(),
+              gh<_i61.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i126.SmartSearchUseCase>(
-        () => _i126.SmartSearchUseCase(gh<_i79.VectorStoreService>()));
-    gh.factory<_i127.SsiCubit>(() => _i127.SsiCubit(gh<_i69.SsiRepository>()));
-    gh.factory<_i128.SyncCubit>(() => _i128.SyncCubit(
-          gh<_i35.SyncService>(),
-          gh<_i79.VectorStoreService>(),
+    gh.lazySingleton<_i129.SmartSearchUseCase>(
+        () => _i129.SmartSearchUseCase(gh<_i81.VectorStoreService>()));
+    gh.factory<_i130.SsiCubit>(() => _i130.SsiCubit(gh<_i71.SsiRepository>()));
+    gh.factory<_i131.SyncCubit>(() => _i131.SyncCubit(
+          gh<_i37.SyncService>(),
+          gh<_i81.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i129.SyncService>(() => _i129.SyncService(
-          gh<_i74.SyncRepository>(),
-          gh<_i76.UserProfileRepository>(),
+    gh.lazySingleton<_i132.SyncService>(() => _i132.SyncService(
+          gh<_i76.SyncRepository>(),
+          gh<_i78.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i130.SyncService>(() => _i131.SyncServiceImpl(
-          gh<_i132.SyncRepository>(),
-          gh<_i35.SyncService>(),
+    gh.lazySingleton<_i133.SyncService>(() => _i134.SyncServiceImpl(
+          gh<_i135.SyncRepository>(),
+          gh<_i37.SyncService>(),
         ));
-    gh.factory<_i133.UserProfileCubit>(
-        () => _i133.UserProfileCubit(gh<_i76.UserProfileRepository>()));
-    gh.factory<_i134.AllergiesCubit>(
-        () => _i134.AllergiesCubit(gh<_i86.AllergyRepository>()));
-    gh.factory<_i135.AuthCubit>(() => _i135.AuthCubit(gh<_i95.AuthService>()));
-    gh.factory<_i136.AuthCubit>(() => _i136.AuthCubit(
-          gh<_i93.AuthRepository>(),
+    gh.factory<_i136.UserProfileCubit>(
+        () => _i136.UserProfileCubit(gh<_i78.UserProfileRepository>()));
+    gh.factory<_i137.AllergiesCubit>(
+        () => _i137.AllergiesCubit(gh<_i89.AllergyRepository>()));
+    gh.factory<_i138.AuthCubit>(() => _i138.AuthCubit(
+          gh<_i96.AuthRepository>(),
           gh<_i17.EncryptionService>(),
           gh<_i5.BiometricService>(),
         ));
-    gh.factory<_i137.DashboardCubit>(
-        () => _i137.DashboardCubit(gh<_i100.DashboardRepository>()));
-    gh.factory<_i138.FhirSyncCubit>(
-        () => _i138.FhirSyncCubit(gh<_i130.SyncService>()));
-    gh.factory<_i139.FhirSyncCubit>(
-        () => _i139.FhirSyncCubit(gh<_i129.SyncService>()));
-    gh.factory<_i140.HealthRecordCubit>(() => _i140.HealthRecordCubit(
-          gh<_i110.HealthRecordRepository>(),
+    gh.factory<_i139.AuthCubit>(() => _i139.AuthCubit(gh<_i98.AuthService>()));
+    gh.factory<_i140.DashboardCubit>(
+        () => _i140.DashboardCubit(gh<_i103.DashboardRepository>()));
+    gh.factory<_i141.FhirSyncCubit>(
+        () => _i141.FhirSyncCubit(gh<_i132.SyncService>()));
+    gh.factory<_i142.FhirSyncCubit>(
+        () => _i142.FhirSyncCubit(gh<_i133.SyncService>()));
+    gh.factory<_i143.HealthRecordCubit>(() => _i143.HealthRecordCubit(
+          gh<_i113.HealthRecordRepository>(),
           gh<_i19.FilePickerService>(),
-          gh<_i21.ImagePickerService>(),
-          gh<_i57.OcrService>(),
-          gh<_i79.VectorStoreService>(),
+          gh<_i23.ImagePickerService>(),
+          gh<_i59.OcrService>(),
+          gh<_i81.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i116.LlmService>(
-      () => _i141.RagLlmService(
-        gh<_i79.VectorStoreService>(),
-        gh<_i120.MedicalResearchService>(),
-        gh<_i76.UserProfileRepository>(),
-        gh<_i27.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i119.LlmService>(
+      () => _i144.RagLlmService(
+        gh<_i81.VectorStoreService>(),
+        gh<_i123.MedicalResearchService>(),
+        gh<_i78.UserProfileRepository>(),
+        gh<_i29.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
-    gh.lazySingleton<_i142.MedicalIndexingService>(
-        () => _i142.MedicalIndexingService(
-              gh<_i37.MedicalKnowledgeRepository>(),
-              gh<_i79.VectorStoreService>(),
-              gh<_i123.PatientContextIndexer>(),
+    gh.lazySingleton<_i145.MedicalIndexingService>(
+        () => _i145.MedicalIndexingService(
+              gh<_i39.MedicalKnowledgeRepository>(),
+              gh<_i81.VectorStoreService>(),
+              gh<_i126.PatientContextIndexer>(),
             ));
-    gh.factory<_i143.MedicalResearchCubit>(() => _i143.MedicalResearchCubit(
-          gh<_i120.MedicalResearchService>(),
-          gh<_i43.MedicalStandardsService>(),
+    gh.factory<_i146.MedicalResearchCubit>(() => _i146.MedicalResearchCubit(
+          gh<_i123.MedicalResearchService>(),
+          gh<_i45.MedicalStandardsService>(),
         ));
-    gh.factory<_i144.ReportBloc>(() => _i144.ReportBloc(
-          gh<_i62.ReportRepository>(),
-          gh<_i124.ReportGenerationService>(),
+    gh.factory<_i147.ReportBloc>(() => _i147.ReportBloc(
+          gh<_i64.ReportRepository>(),
+          gh<_i127.ReportGenerationService>(),
         ));
-    gh.lazySingleton<_i145.HomeRepository>(() => _i146.HomeRepositoryImpl(
-          gh<_i83.VitalSignRepository>(),
-          gh<_i142.MedicalIndexingService>(),
-          gh<_i34.MedicalAnalysisService>(),
-          gh<_i76.UserProfileRepository>(),
+    gh.lazySingleton<_i148.HomeRepository>(() => _i149.HomeRepositoryImpl(
+          gh<_i85.VitalSignRepository>(),
+          gh<_i145.MedicalIndexingService>(),
+          gh<_i36.MedicalAnalysisService>(),
+          gh<_i78.UserProfileRepository>(),
         ));
     return this;
   }
 }
 
-class _$FhirModule extends _i147.FhirModule {}
+class _$FhirModule extends _i150.FhirModule {}
 
-class _$NetworkModule extends _i148.NetworkModule {}
+class _$NetworkModule extends _i151.NetworkModule {}
 
-class _$MemoryModule extends _i149.MemoryModule {}
+class _$MemoryModule extends _i152.MemoryModule {}
 
-class _$DatabaseModule extends _i150.DatabaseModule {}
+class _$DatabaseModule extends _i153.DatabaseModule {}

--- a/lib/features/about/application/about_cubit.dart
+++ b/lib/features/about/application/about_cubit.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:injectable/injectable.dart';
+import '../domain/entities/about_info.dart';
+import '../domain/repositories/i_about_repository.dart';
+
+abstract class AboutState extends Equatable {
+  const AboutState();
+
+  @override
+  List<Object?> get props => [];
+}
+
+class AboutInitial extends AboutState {}
+
+class AboutLoading extends AboutState {}
+
+class AboutLoaded extends AboutState {
+  final AboutInfo aboutInfo;
+
+  const AboutLoaded(this.aboutInfo);
+
+  @override
+  List<Object?> get props => [aboutInfo];
+}
+
+class AboutError extends AboutState {
+  final String message;
+
+  const AboutError(this.message);
+
+  @override
+  List<Object?> get props => [message];
+}
+
+@injectable
+class AboutCubit extends Cubit<AboutState> {
+  final IAboutRepository _repository;
+
+  AboutCubit(this._repository) : super(AboutInitial());
+
+  Future<void> loadAboutInfo() async {
+    emit(AboutLoading());
+    try {
+      final info = await _repository.getAboutInfo();
+      emit(AboutLoaded(info));
+    } catch (e) {
+      emit(AboutError(e.toString()));
+    }
+  }
+}

--- a/lib/features/about/domain/entities/about_info.dart
+++ b/lib/features/about/domain/entities/about_info.dart
@@ -1,0 +1,35 @@
+import 'package:equatable/equatable.dart';
+
+class BlogPost extends Equatable {
+  final String title;
+  final String content;
+  final String date;
+  final String category;
+
+  const BlogPost({
+    required this.title,
+    required this.content,
+    required this.date,
+    required this.category,
+  });
+
+  @override
+  List<Object?> get props => [title, content, date, category];
+}
+
+class AboutInfo extends Equatable {
+  final List<BlogPost> blogPosts;
+  final String missionStatement;
+  final List<String> values;
+  final List<String> activities;
+
+  const AboutInfo({
+    required this.blogPosts,
+    required this.missionStatement,
+    required this.values,
+    required this.activities,
+  });
+
+  @override
+  List<Object?> get props => [blogPosts, missionStatement, values, activities];
+}

--- a/lib/features/about/domain/repositories/i_about_repository.dart
+++ b/lib/features/about/domain/repositories/i_about_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/about_info.dart';
+
+abstract class IAboutRepository {
+  Future<AboutInfo> getAboutInfo();
+}

--- a/lib/features/about/infrastructure/repositories/about_repository_impl.dart
+++ b/lib/features/about/infrastructure/repositories/about_repository_impl.dart
@@ -1,18 +1,33 @@
-class BlogPost {
-  final String title;
-  final String content;
-  final String date;
-  final String category;
+import 'package:injectable/injectable.dart';
+import '../../domain/entities/about_info.dart';
+import '../../domain/repositories/i_about_repository.dart';
 
-  const BlogPost({
-    required this.title,
-    required this.content,
-    required this.date,
-    required this.category,
-  });
+@LazySingleton(as: IAboutRepository)
+class AboutRepositoryImpl implements IAboutRepository {
+  @override
+  Future<AboutInfo> getAboutInfo() async {
+    // In a real app, this might come from an API or local DB.
+    // For now, we use the static data moved from the legacy data folder.
+    return const AboutInfo(
+      blogPosts: _staticBlogPosts,
+      missionStatement: 'Creemos que la salud es el activo más valioso de la humanidad. OrionHealth nace con la visión de poner la tecnología más avanzada al servicio del bienestar individual, garantizando la privacidad y el empoderamiento del paciente.',
+      values: [
+        'Cada persona merece acceso a su historial médico completo',
+        'La privacidad médica es un derecho fundamental',
+        'La IA médica debe estar al servicio de la salud, no de corporaciones',
+        'Los datos de salud empoderan a las personas para tomar mejores decisiones',
+      ],
+      activities: [
+        'Almacenamos datos médicos de forma segura y encriptada en tu dispositivo',
+        'Permitimos que modelos de IA analicen tu información para ayudarte',
+        'Buscamos información médica actualizada de fuentes científicas confiables',
+        'Conectamos personas con estándares de medicina mundial',
+      ],
+    );
+  }
 }
 
-const List<BlogPost> staticBlogPosts = [
+const List<BlogPost> _staticBlogPosts = [
   BlogPost(
     title: 'Avances médicos que impactan tu salud',
     content: 'La medicina personalizada está avanzando a pasos agigantados. Gracias al análisis de datos a gran escala, ahora es posible adaptar los tratamientos a la genética y el historial único de cada paciente. En OrionHealth, te preparamos para esta revolución permitiéndote ser el dueño de tu propia información médica.',

--- a/lib/features/about/presentation/pages/about_page.dart
+++ b/lib/features/about/presentation/pages/about_page.dart
@@ -1,32 +1,59 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import '../../../../core/di/injection.dart';
 import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
 import '../widgets/mission_section.dart';
-import '../../data/blog_posts.dart';
+import '../../application/about_cubit.dart';
+import '../../domain/entities/about_info.dart';
 
 class AboutPage extends StatelessWidget {
   const AboutPage({super.key});
 
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      body: CustomScrollView(
-        slivers: [
-          _buildAppBar(),
-          SliverPadding(
-            padding: const EdgeInsets.all(16.0),
-            sliver: SliverList(
-              delegate: SliverChildListDelegate([
-                const MissionSection(),
-                const SizedBox(height: 40),
-                _buildBlogHeader(),
-                const SizedBox(height: 16),
-                ...staticBlogPosts.map((post) => _BlogTile(post: post)),
-                const SizedBox(height: 40),
-              ]),
-            ),
-          ),
-        ],
+    return BlocProvider(
+      create: (context) => getIt<AboutCubit>()..loadAboutInfo(),
+      child: Scaffold(
+        body: BlocBuilder<AboutCubit, AboutState>(
+          builder: (context, state) {
+            if (state is AboutLoading || state is AboutInitial) {
+              return const Center(child: CircularProgressIndicator());
+            }
+
+            if (state is AboutError) {
+              return Center(child: Text('Error: ${state.message}'));
+            }
+
+            if (state is AboutLoaded) {
+              final info = state.aboutInfo;
+              return CustomScrollView(
+                slivers: [
+                  _buildAppBar(),
+                  SliverPadding(
+                    padding: const EdgeInsets.all(16.0),
+                    sliver: SliverList(
+                      delegate: SliverChildListDelegate([
+                        MissionSection(
+                          missionStatement: info.missionStatement,
+                          values: info.values,
+                          activities: info.activities,
+                        ),
+                        const SizedBox(height: 40),
+                        _buildBlogHeader(),
+                        const SizedBox(height: 16),
+                        ...info.blogPosts.map((post) => _BlogTile(post: post)),
+                        const SizedBox(height: 40),
+                      ]),
+                    ),
+                  ),
+                ],
+              );
+            }
+
+            return const SizedBox.shrink();
+          },
+        ),
       ),
     );
   }
@@ -48,7 +75,7 @@ class AboutPage extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
+        const Text(
           'COMUNIDAD Y NOTICIAS',
           style: TextStyle(
             color: AppColors.secondary,

--- a/lib/features/about/presentation/widgets/mission_section.dart
+++ b/lib/features/about/presentation/widgets/mission_section.dart
@@ -3,7 +3,16 @@ import '../../../../core/theme/app_colors.dart';
 import '../../../../core/widgets/glassmorphic_card.dart';
 
 class MissionSection extends StatelessWidget {
-  const MissionSection({super.key});
+  final String missionStatement;
+  final List<String> values;
+  final List<String> activities;
+
+  const MissionSection({
+    super.key,
+    required this.missionStatement,
+    required this.values,
+    required this.activities,
+  });
 
   @override
   Widget build(BuildContext context) {
@@ -25,7 +34,7 @@ class MissionSection extends StatelessWidget {
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
-        Text(
+        const Text(
           'NUESTRA MISIÓN',
           style: TextStyle(
             color: AppColors.primary,
@@ -35,7 +44,7 @@ class MissionSection extends StatelessWidget {
           ),
         ),
         const SizedBox(height: 8),
-        Text(
+        const Text(
           'SALUD HUMANA COMO PRIORIDAD NÚMERO UNO',
           style: TextStyle(
             fontSize: 24,
@@ -52,7 +61,7 @@ class MissionSection extends StatelessWidget {
       child: Padding(
         padding: const EdgeInsets.all(16.0),
         child: Text(
-          'Creemos que la salud es el activo más valioso de la humanidad. OrionHealth nace con la visión de poner la tecnología más avanzada al servicio del bienestar individual, garantizando la privacidad y el empoderamiento del paciente.',
+          missionStatement,
           style: TextStyle(
             fontSize: 16,
             height: 1.5,
@@ -64,13 +73,6 @@ class MissionSection extends StatelessWidget {
   }
 
   Widget _buildValuesSection() {
-    final values = [
-      'Cada persona merece acceso a su historial médico completo',
-      'La privacidad médica es un derecho fundamental',
-      'La IA médica debe estar al servicio de la salud, no de corporaciones',
-      'Los datos de salud empoderan a las personas para tomar mejores decisiones',
-    ];
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [
@@ -100,13 +102,6 @@ class MissionSection extends StatelessWidget {
   }
 
   Widget _buildWhatWeDoSection() {
-    final activities = [
-      'Almacenamos datos médicos de forma segura y encriptada en tu dispositivo',
-      'Permitimos que modelos de IA analicen tu información para ayudarte',
-      'Buscamos información médica actualizada de fuentes científicas confiables',
-      'Conectamos personas con estándares de medicina mundial',
-    ];
-
     return Column(
       crossAxisAlignment: CrossAxisAlignment.start,
       children: [

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -245,10 +245,10 @@ packages:
     dependency: transitive
     description:
       name: characters
-      sha256: f71061c654a3380576a52b451dd5532377954cf9dbd272a78fc8479606670803
+      sha256: faf38497bda5ead2a8c7615f4f7939df04333478bf32e4173fcb06d428b5716b
       url: "https://pub.dev"
     source: hosted
-    version: "1.4.0"
+    version: "1.4.1"
   checked_yaml:
     dependency: transitive
     description:
@@ -1166,18 +1166,18 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc58c723c3c24bf8d3e2d3ad3f2f9d7bd9cf43ec6feaa64181775e60190153f2
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.17"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
       name: material_color_utilities
-      sha256: f7142bb1154231d7ea5f96bc7bde4bda2a0945d2806bb11670e30b850d56bdec
+      sha256: "9c337007e82b1889149c82ed242ed1cb24a66044e30979c44912381e9be4c48b"
       url: "https://pub.dev"
     source: hosted
-    version: "0.11.1"
+    version: "0.13.0"
   medical_standards:
     dependency: "direct main"
     description:
@@ -1634,10 +1634,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.7"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/about/presentation/pages/about_page_test.dart
+++ b/test/features/about/presentation/pages/about_page_test.dart
@@ -1,11 +1,48 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/about/presentation/pages/about_page.dart';
 import 'package:orionhealth_health/features/about/presentation/widgets/mission_section.dart';
+import 'package:orionhealth_health/features/about/application/about_cubit.dart';
+import 'package:orionhealth_health/features/about/domain/entities/about_info.dart';
+
+class MockAboutCubit extends Mock implements AboutCubit {}
 
 void main() {
+  late MockAboutCubit mockAboutCubit;
+
+  setUpAll(() {
+    mockAboutCubit = MockAboutCubit();
+    final getIt = GetIt.instance;
+    getIt.registerLazySingleton<AboutCubit>(() => mockAboutCubit);
+  });
+
+  tearDownAll(() async {
+    await GetIt.instance.reset();
+  });
+
   testWidgets('AboutPage displays mission section and blog posts', (WidgetTester tester) async {
-    // Set a larger surface size to ensure all widgets are laid out and potentially visible if needed by finders
+    const aboutInfo = AboutInfo(
+      blogPosts: [
+        BlogPost(
+          title: 'Test Blog Post',
+          content: 'Test Content',
+          date: '2024-05-10',
+          category: 'Test Category',
+        ),
+      ],
+      missionStatement: 'Test Mission',
+      values: ['Value 1'],
+      activities: ['Activity 1'],
+    );
+
+    when(() => mockAboutCubit.state).thenReturn(const AboutLoaded(aboutInfo));
+    when(() => mockAboutCubit.loadAboutInfo()).thenAnswer((_) async {});
+    when(() => mockAboutCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockAboutCubit.close()).thenAnswer((_) async {});
+
+    // Set a larger surface size
     tester.view.physicalSize = const Size(1080, 2400);
     tester.view.devicePixelRatio = 1.0;
 
@@ -15,11 +52,16 @@ void main() {
       ),
     );
 
+    await tester.pump();
+
     // Check if the title is present
     expect(find.text('Sobre OrionHealth'), findsOneWidget);
 
     // Check if MissionSection is present
     expect(find.byType(MissionSection), findsOneWidget);
+
+    // Check if mission statement is displayed
+    expect(find.text('Test Mission'), findsOneWidget);
 
     // Scroll down to find the blog section if it's not in view
     await tester.scrollUntilVisible(find.text('Nuestro Blog de Salud'), 500.0);
@@ -27,8 +69,8 @@ void main() {
     // Check if blog section header is present
     expect(find.text('Nuestro Blog de Salud'), findsOneWidget);
 
-    // Check if at least one blog post title is present
-    expect(find.text('Avances médicos que impactan tu salud'), findsOneWidget);
+    // Check if the mock blog post title is present
+    expect(find.text('Test Blog Post'), findsOneWidget);
 
     // Reset view
     addTearDown(tester.view.resetPhysicalSize);


### PR DESCRIPTION
This PR migrates the `about` feature to Clean Architecture. 

Key changes:
1. **Domain Layer**: Added `AboutInfo` entity and `IAboutRepository` interface to define the business logic and data contracts.
2. **Application Layer**: Introduced `AboutCubit` and `AboutState` for reactive state management.
3. **Infrastructure Layer**: Created `AboutRepositoryImpl` to provide the static information previously stored in the legacy `data/` folder.
4. **Presentation Layer**: Refactored `AboutPage` and `MissionSection` to use `BlocProvider` and `BlocBuilder`, decoupling the UI from data sources.
5. **Data Migration**: Successfully removed the non-compliant `lib/features/about/data/` directory.
6. **Testing**: Updated existing widget tests to work with the new Cubit-based architecture using `mocktail` for dependency mocking.

The changes improve maintainability, follow project standards, and prepare the feature for future dynamic data integration. All relevant tests pass and `dart analyze` reports no issues in the modified feature.

Fixes #529

---
*PR created automatically by Jules for task [1475683994528168861](https://jules.google.com/task/1475683994528168861) started by @iberi22*