### PR TITLE
Add domain and application layers to AI Assistant feature

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -18,115 +18,117 @@ import 'package:isar/isar.dart' as _i22;
 import 'package:isar_agent_memory/isar_agent_memory.dart' as _i16;
 import 'package:medical_standards/medical_standards.dart' as _i35;
 
-import '../../features/allergies/application/allergies_cubit.dart' as _i136;
+import '../../features/ai_assistant/application/ai_assistant_cubit.dart'
+    as _i147;
+import '../../features/ai_assistant/domain/repositories/i_ai_repository.dart'
+    as _i141;
+import '../../features/ai_assistant/infrastructure/repositories/ai_repository_impl.dart'
+    as _i142;
+import '../../features/allergies/application/allergies_cubit.dart' as _i135;
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i87;
+    as _i89;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i3;
 import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
-    as _i88;
+    as _i90;
 import '../../features/appointments/application/appointments_cubit.dart'
-    as _i93;
+    as _i95;
 import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i91;
+    as _i93;
 import '../../features/appointments/domain/services/appointment_service.dart'
     as _i4;
 import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
-    as _i92;
+    as _i94;
 import '../../features/auth/application/auth_cubit.dart' as _i137;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i138;
-import '../../features/auth/domain/auth_service.dart' as _i96;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i94;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i136;
+import '../../features/auth/domain/auth_service.dart' as _i98;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i96;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
-    as _i95;
+    as _i97;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i5;
 import '../../features/auth/infrastructure/services/ble_medical_sharing_service.dart'
-    as _i97;
+    as _i99;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
     as _i17;
 import '../../features/calendar_import/data/calendar_repository.dart' as _i9;
 import '../../features/calendar_import/domain/calendar_import_cubit.dart'
-    as _i98;
-import '../../features/dashboard/application/dashboard_cubit.dart' as _i139;
+    as _i100;
+import '../../features/dashboard/application/dashboard_cubit.dart' as _i138;
 import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
-    as _i101;
+    as _i103;
 import '../../features/dashboard/infrastructure/repositories/dashboard_repository_impl.dart'
-    as _i102;
+    as _i104;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
-    as _i105;
+    as _i107;
 import '../../features/doctor_verification/data/datasources/license_registry_local.dart'
     as _i25;
 import '../../features/doctor_verification/data/repositories/isar_doctor_profile_repository.dart'
-    as _i104;
+    as _i106;
 import '../../features/doctor_verification/data/repositories/isar_rating_repository.dart'
     as _i61;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
-    as _i103;
+    as _i105;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
     as _i60;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
     as _i26;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i106;
+import '../../features/email-citas/application/email_citas_cubit.dart' as _i108;
 import '../../features/email-citas/domain/repositories/email_repository.dart'
     as _i14;
 import '../../features/email-citas/infrastructure/repositories/email_repository_impl.dart'
     as _i15;
 import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
-    as _i107;
+    as _i109;
 import '../../features/eps_connection/infrastructure/oauth_repository.dart'
     as _i54;
 import '../../features/health_data_import/application/health_import_cubit.dart'
-    as _i111;
+    as _i113;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i20;
-import '../../features/health_data_import/infrastructure/data_source.dart'
-    as _i66;
-import '../../features/health_data_import/infrastructure/health_data_repository_impl.dart'
-    as _i110;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i142;
+    as _i140;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i112;
+    as _i114;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i113;
+    as _i115;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i19;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
     as _i21;
 import '../../features/health_record/infrastructure/services/ocr_service.dart'
     as _i57;
-import '../../features/health_sharing/application/sharing_cubit.dart' as _i67;
+import '../../features/health_sharing/application/sharing_cubit.dart' as _i66;
 import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
     as _i6;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i7;
 import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
     as _i52;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i68;
-import '../../features/home/domain/repositories/home_repository.dart' as _i147;
-import '../../features/home/infrastructure/home_repository_impl.dart' as _i148;
+    as _i67;
+import '../../features/home/domain/repositories/home_repository.dart' as _i148;
+import '../../features/home/infrastructure/home_repository_impl.dart' as _i149;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i128;
+    as _i130;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i37;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i27;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i80;
+    as _i82;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
     as _i29;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i30;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i115;
-import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i116;
+import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
+    as _i117;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i114;
+    as _i118;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
     as _i28;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i119;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i118;
+    as _i121;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i120;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
     as _i143;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
@@ -134,9 +136,9 @@ import '../../features/local_agent/infrastructure/repositories/asset_medical_kno
 import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i39;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i81;
+    as _i83;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i117;
+    as _i119;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i33;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
@@ -144,19 +146,19 @@ import '../../features/local_agent/infrastructure/services/medical_indexing_serv
 import '../../features/local_agent/infrastructure/services/model_download_service.dart'
     as _i51;
 import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i125;
+    as _i127;
 import '../../features/medical_assistant/application/medical_assistant_cubit.dart'
-    as _i121;
+    as _i123;
 import '../../features/medical_assistant/domain/services/analysis/lab_analysis_strategy.dart'
     as _i23;
 import '../../features/medical_assistant/domain/services/analysis/symptom_analysis_strategy.dart'
-    as _i74;
+    as _i73;
 import '../../features/medical_assistant/domain/services/analysis/vital_analysis_strategy.dart'
-    as _i82;
+    as _i84;
 import '../../features/medical_assistant/domain/services/clinical_reasoner_service.dart'
-    as _i99;
+    as _i101;
 import '../../features/medical_assistant/domain/services/health_context_service.dart'
-    as _i108;
+    as _i111;
 import '../../features/medical_assistant/domain/services/medical_analysis_service.dart'
     as _i34;
 import '../../features/medical_assistant/domain/services/medical_guidelines_service.dart'
@@ -168,13 +170,13 @@ import '../../features/medical_assistant/infrastructure/analysis/lab_interpreter
 import '../../features/medical_assistant/infrastructure/analysis/risk_calculator.dart'
     as _i64;
 import '../../features/medical_assistant/infrastructure/analysis/vital_sign_analyzer.dart'
-    as _i83;
+    as _i85;
 import '../../features/medical_assistant/infrastructure/llm/medical_llm_adapter.dart'
     as _i40;
 import '../../features/medical_assistant/infrastructure/services/clinical_reasoner_service.dart'
-    as _i100;
+    as _i102;
 import '../../features/medical_assistant/infrastructure/services/health_context_service_impl.dart'
-    as _i109;
+    as _i112;
 import '../../features/medical_research/application/medical_research_cubit.dart'
     as _i145;
 import '../../features/medical_research/domain/services/medical_scraper_service.dart'
@@ -186,7 +188,7 @@ import '../../features/medical_research/domain/services/medical_web_search_servi
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i8;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i122;
+    as _i124;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i42;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
@@ -199,75 +201,75 @@ import '../../features/medications/domain/repositories/medication_repository.dar
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
     as _i48;
 import '../../features/onboarding/application/onboarding_cubit.dart' as _i58;
-import '../../features/onboarding/application/sync_cubit.dart' as _i130;
+import '../../features/onboarding/application/sync_cubit.dart' as _i132;
 import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i123;
+    as _i125;
 import '../../features/onboarding/infrastructure/onboarding_repository_impl.dart'
-    as _i124;
+    as _i126;
 import '../../features/reports/application/bloc/report_bloc.dart' as _i146;
 import '../../features/reports/domain/repositories/report_repository.dart'
     as _i62;
 import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i126;
+    as _i128;
 import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i63;
 import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i127;
+    as _i129;
 import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i50;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i120;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i122;
 import '../../features/settings/domain/repositories/llm_settings_repository.dart'
     as _i31;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i12;
+    as _i11;
 import '../../features/settings/infrastructure/repositories/llm_settings_repository_impl.dart'
     as _i32;
-import '../../features/ssi/application/ssi_cubit.dart' as _i129;
-import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i70;
-import '../../features/ssi/domain/services/anoncreds_service.dart' as _i89;
-import '../../features/ssi/domain/services/ssi_service.dart' as _i72;
+import '../../features/ssi/application/ssi_cubit.dart' as _i131;
+import '../../features/ssi/domain/repositories/ssi_repository.dart' as _i69;
+import '../../features/ssi/domain/services/anoncreds_service.dart' as _i91;
+import '../../features/ssi/domain/services/ssi_service.dart' as _i71;
 import '../../features/ssi/infrastructure/repositories/isar_ssi_repository.dart'
-    as _i71;
+    as _i70;
 import '../../features/ssi/infrastructure/services/anoncreds_service_impl.dart'
-    as _i90;
+    as _i92;
 import '../../features/ssi/infrastructure/services/sidetree_anchor_client.dart'
-    as _i69;
+    as _i68;
 import '../../features/ssi/infrastructure/services/ssi_service_impl.dart'
-    as _i73;
-import '../../features/sync/application/sync_cubit.dart' as _i141;
+    as _i72;
+import '../../features/sync/application/sync_cubit.dart' as _i110;
 import '../../features/sync/data/fhir_client.dart' as _i18;
 import '../../features/sync/data/node_discovery_service.dart' as _i53;
-import '../../features/sync/data/sync_repository.dart' as _i76;
-import '../../features/sync/domain/repositories/sync_repository.dart' as _i134;
-import '../../features/sync/domain/services/sync_service.dart' as _i132;
-import '../../features/sync/domain/sync_cubit.dart' as _i140;
-import '../../features/sync/domain/sync_repository.dart' as _i75;
-import '../../features/sync/domain/sync_service.dart' as _i131;
+import '../../features/sync/data/sync_repository.dart' as _i75;
+import '../../features/sync/domain/repositories/sync_repository.dart' as _i78;
+import '../../features/sync/domain/services/sync_service.dart' as _i76;
+import '../../features/sync/domain/sync_cubit.dart' as _i139;
+import '../../features/sync/domain/sync_repository.dart' as _i74;
+import '../../features/sync/domain/sync_service.dart' as _i133;
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
-    as _i133;
-import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i135;
-import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
     as _i77;
-import '../../features/user_profile/domain/services/user_profile_service.dart'
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i134;
+import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
     as _i79;
+import '../../features/user_profile/domain/services/user_profile_service.dart'
+    as _i81;
 import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
-    as _i78;
-import '../../features/vitals/application/vitals_cubit.dart' as _i86;
+    as _i80;
+import '../../features/vitals/application/vitals_cubit.dart' as _i88;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i84;
+    as _i86;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
-    as _i85;
-import '../services/device_capability_service.dart' as _i11;
+    as _i87;
+import '../services/device_capability_service.dart' as _i12;
 import '../services/privacy_anonymizer.dart' as _i59;
-import 'database_module.dart' as _i152;
-import 'fhir_module.dart' as _i149;
-import 'memory_module.dart' as _i151;
-import 'network_module.dart' as _i150;
+import 'database_module.dart' as _i153;
+import 'fhir_module.dart' as _i150;
+import 'memory_module.dart' as _i152;
+import 'network_module.dart' as _i151;
 
+const String _mobile = 'mobile';
 const String _desktop = 'desktop';
 const String _test = 'test';
-const String _mobile = 'mobile';
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -402,216 +404,206 @@ extension GetItInjectableX on _i1.GetIt {
     gh.factory<_i64.RiskCalculator>(() => _i64.RiskCalculator());
     gh.factory<_i65.RiskCalculatorService>(() =>
         _i65.RiskCalculatorService(calculator: gh<_i64.RiskCalculator>()));
-    gh.lazySingleton<_i66.SensorHealthDataSource>(
-        () => _i66.SensorHealthDataSourceImpl());
-    gh.factory<_i67.SharingCubit>(() => _i67.SharingCubit(
+    gh.factory<_i66.SharingCubit>(() => _i66.SharingCubit(
           bleService: gh<_i6.BleSharingService>(),
           nfcService: gh<_i52.NfcSharingService>(),
-          wifiService: gh<_i68.WifiDirectService>(),
+          wifiService: gh<_i67.WifiDirectService>(),
         ));
-    gh.lazySingleton<_i69.SidetreeAnchorClient>(
-        () => _i69.SidetreeAnchorClient.create());
-    gh.lazySingleton<_i70.SsiRepository>(
-        () => _i71.IsarSsiRepository(gh<_i22.Isar>()));
-    gh.lazySingleton<_i72.SsiService>(() => _i73.SsiServiceImpl(
-          gh<_i70.SsiRepository>(),
-          gh<_i69.SidetreeAnchorClient>(),
+    gh.lazySingleton<_i68.SidetreeAnchorClient>(
+        () => _i68.SidetreeAnchorClient.create());
+    gh.lazySingleton<_i69.SsiRepository>(
+        () => _i70.IsarSsiRepository(gh<_i22.Isar>()));
+    gh.lazySingleton<_i71.SsiService>(() => _i72.SsiServiceImpl(
+          gh<_i69.SsiRepository>(),
+          gh<_i68.SidetreeAnchorClient>(),
         ));
-    gh.factory<_i74.SymptomAnalysisStrategy>(
-        () => _i74.SymptomAnalysisStrategy());
-    gh.lazySingleton<_i75.SyncRepository>(() => _i76.SyncRepositoryImpl(
+    gh.factory<_i73.SymptomAnalysisStrategy>(
+        () => _i73.SymptomAnalysisStrategy());
+    gh.lazySingleton<_i74.SyncRepository>(() => _i75.SyncRepositoryImpl(
           gh<_i18.FhirClient>(),
           gh<_i22.Isar>(),
           gh<_i56.FlutterSecureStorage>(),
           gh<_i53.NodeDiscoveryService>(),
         ));
     gh.lazySingleton<_i35.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i77.UserProfileRepository>(
-        () => _i78.UserProfileRepositoryImpl(gh<_i22.Isar>()));
-    gh.lazySingleton<_i79.UserProfileService>(
-        () => _i79.UserProfileService(gh<_i77.UserProfileRepository>()));
-    gh.lazySingleton<_i80.VectorStoreService>(() => _i81.IsarVectorStoreService(
+    gh.lazySingleton<_i76.SyncService>(() => _i77.SyncServiceImpl(
+          gh<_i78.SyncRepository>(),
+          gh<_i35.SyncService>(),
+        ));
+    gh.lazySingleton<_i79.UserProfileRepository>(
+        () => _i80.UserProfileRepositoryImpl(gh<_i22.Isar>()));
+    gh.lazySingleton<_i81.UserProfileService>(
+        () => _i81.UserProfileService(gh<_i79.UserProfileRepository>()));
+    gh.lazySingleton<_i82.VectorStoreService>(() => _i83.IsarVectorStoreService(
           gh<_i16.MemoryGraph>(),
           gh<_i37.MedicalKnowledgeRepository>(),
         ));
-    gh.factory<_i82.VitalAnalysisStrategy>(() => _i82.VitalAnalysisStrategy());
-    gh.factory<_i83.VitalSignAnalyzer>(() => _i83.VitalSignAnalyzer());
-    gh.lazySingleton<_i84.VitalSignRepository>(
-        () => _i85.VitalSignRepositoryImpl(gh<_i22.Isar>()));
-    gh.factory<_i86.VitalsCubit>(
-        () => _i86.VitalsCubit(gh<_i84.VitalSignRepository>()));
-    gh.lazySingleton<_i68.WifiDirectService>(() => _i68.WifiDirectService());
-    gh.lazySingleton<_i87.AllergyRepository>(
-        () => _i88.IsarAllergyRepository(gh<_i22.Isar>()));
-    gh.lazySingleton<_i89.AnonCredsService>(
-        () => _i90.AnonCredsServiceImpl(gh<_i70.SsiRepository>()));
-    gh.lazySingleton<_i91.AppointmentRepository>(
-        () => _i92.IsarAppointmentRepository(gh<_i22.Isar>()));
-    gh.factory<_i93.AppointmentsCubit>(
-        () => _i93.AppointmentsCubit(gh<_i91.AppointmentRepository>()));
-    gh.lazySingleton<_i94.AuthRepository>(
-        () => _i95.AuthRepositoryImpl(gh<_i22.Isar>()));
-    gh.lazySingleton<_i96.AuthService>(
-        () => _i96.AuthServiceImpl(gh<_i17.EncryptionService>()));
-    gh.lazySingleton<_i97.BleMedicalSharingService>(
-        () => _i97.BleMedicalSharingService(
+    gh.factory<_i84.VitalAnalysisStrategy>(() => _i84.VitalAnalysisStrategy());
+    gh.factory<_i85.VitalSignAnalyzer>(() => _i85.VitalSignAnalyzer());
+    gh.lazySingleton<_i86.VitalSignRepository>(
+        () => _i87.VitalSignRepositoryImpl(gh<_i22.Isar>()));
+    gh.factory<_i88.VitalsCubit>(
+        () => _i88.VitalsCubit(gh<_i86.VitalSignRepository>()));
+    gh.lazySingleton<_i67.WifiDirectService>(() => _i67.WifiDirectService());
+    gh.lazySingleton<_i89.AllergyRepository>(
+        () => _i90.IsarAllergyRepository(gh<_i22.Isar>()));
+    gh.lazySingleton<_i91.AnonCredsService>(
+        () => _i92.AnonCredsServiceImpl(gh<_i69.SsiRepository>()));
+    gh.lazySingleton<_i93.AppointmentRepository>(
+        () => _i94.IsarAppointmentRepository(gh<_i22.Isar>()));
+    gh.factory<_i95.AppointmentsCubit>(
+        () => _i95.AppointmentsCubit(gh<_i93.AppointmentRepository>()));
+    gh.lazySingleton<_i96.AuthRepository>(
+        () => _i97.AuthRepositoryImpl(gh<_i22.Isar>()));
+    gh.lazySingleton<_i98.AuthService>(
+        () => _i98.AuthServiceImpl(gh<_i17.EncryptionService>()));
+    gh.lazySingleton<_i99.BleMedicalSharingService>(
+        () => _i99.BleMedicalSharingService(
               gh<_i6.BleSharingService>(),
               gh<_i17.EncryptionService>(),
-              gh<_i72.SsiService>(),
+              gh<_i71.SsiService>(),
             ));
-    gh.factory<_i98.CalendarImportCubit>(() => _i98.CalendarImportCubit(
+    gh.factory<_i100.CalendarImportCubit>(() => _i100.CalendarImportCubit(
           gh<_i9.CalendarRepository>(),
-          gh<_i91.AppointmentRepository>(),
-          gh<_i77.UserProfileRepository>(),
+          gh<_i93.AppointmentRepository>(),
+          gh<_i79.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i99.ClinicalReasonerService>(
-        () => _i100.SymphonyClinicalReasonerService(
+    gh.lazySingleton<_i101.ClinicalReasonerService>(
+        () => _i102.SymphonyClinicalReasonerService(
               gh<_i37.MedicalKnowledgeRepository>(),
               gh<_i59.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i101.DashboardRepository>(
-        () => _i102.DashboardRepositoryImpl(
-              gh<_i84.VitalSignRepository>(),
+    gh.lazySingleton<_i103.DashboardRepository>(
+        () => _i104.DashboardRepositoryImpl(
+              gh<_i86.VitalSignRepository>(),
               gh<_i47.MedicationRepository>(),
               gh<_i62.ReportRepository>(),
             ));
-    gh.lazySingleton<_i103.DoctorProfileRepository>(
-        () => _i104.IsarDoctorProfileRepository(gh<_i22.Isar>()));
-    gh.factoryAsync<_i105.DoctorVerificationCubit>(
-        () async => _i105.DoctorVerificationCubit(
-              gh<_i103.DoctorProfileRepository>(),
+    gh.lazySingleton<_i105.DoctorProfileRepository>(
+        () => _i106.IsarDoctorProfileRepository(gh<_i22.Isar>()));
+    gh.factoryAsync<_i107.DoctorVerificationCubit>(
+        () async => _i107.DoctorVerificationCubit(
+              gh<_i105.DoctorProfileRepository>(),
               gh<_i60.RatingRepository>(),
               await getAsync<_i26.LicenseVerifier>(),
             ));
-    gh.factory<_i106.EmailCitasCubit>(() => _i106.EmailCitasCubit(
+    gh.factory<_i108.EmailCitasCubit>(() => _i108.EmailCitasCubit(
           gh<_i14.EmailRepository>(),
-          gh<_i91.AppointmentRepository>(),
+          gh<_i93.AppointmentRepository>(),
         ));
-    gh.factory<_i107.EpsConnectionCubit>(() => _i107.EpsConnectionCubit(
+    gh.factory<_i109.EpsConnectionCubit>(() => _i109.EpsConnectionCubit(
           gh<_i54.OAuthRepository>(),
-          gh<_i77.UserProfileRepository>(),
+          gh<_i79.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i66.FileHealthDataSource>(
-        () => _i66.FileHealthDataSourceImpl(
-              gh<_i19.FilePickerService>(),
-              gh<_i57.OcrService>(),
-            ));
-    gh.lazySingleton<_i108.HealthContextService>(
-        () => _i109.IsarHealthContextService(
-              gh<_i84.VitalSignRepository>(),
+    gh.factory<_i110.FhirSyncCubit>(
+        () => _i110.FhirSyncCubit(gh<_i76.SyncService>()));
+    gh.lazySingleton<_i111.HealthContextService>(
+        () => _i112.IsarHealthContextService(
+              gh<_i86.VitalSignRepository>(),
               gh<_i47.MedicationRepository>(),
-              gh<_i77.UserProfileRepository>(),
+              gh<_i79.UserProfileRepository>(),
               gh<_i16.MemoryGraph>(),
             ));
-    gh.lazySingleton<_i110.HealthDataRepository>(
-        () => _i110.HealthDataRepositoryImpl(
-              gh<_i66.SensorHealthDataSource>(),
-              gh<_i66.FileHealthDataSource>(),
-            ));
-    gh.factory<_i111.HealthImportCubit>(() => _i111.HealthImportCubit(
+    gh.factory<_i113.HealthImportCubit>(() => _i113.HealthImportCubit(
           gh<_i20.HealthDataImportService>(),
-          gh<_i84.VitalSignRepository>(),
+          gh<_i86.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i112.HealthRecordRepository>(
-        () => _i113.HealthRecordRepositoryImpl(gh<_i22.Isar>()));
-    gh.factory<_i27.LlmAdapter>(
-      () => _i114.MockLlmAdapter(gh<_i59.PromptScrubber>()),
-      instanceName: 'mock',
-    );
+    gh.lazySingleton<_i114.HealthRecordRepository>(
+        () => _i115.HealthRecordRepositoryImpl(gh<_i22.Isar>()));
     gh.lazySingleton<_i27.LlmAdapter>(
-      () => _i115.GeminiLlmAdapter(
+      () => _i116.GeminiLlmAdapter(
         scrubber: gh<_i59.PromptScrubber>(),
-        userProfileRepository: gh<_i77.UserProfileRepository>(),
-        modelWrapper: gh<_i116.GeminiModelWrapper>(),
+        userProfileRepository: gh<_i79.UserProfileRepository>(),
+        modelWrapper: gh<_i117.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
     );
-    gh.lazySingleton<_i117.LlmAdapterFactory>(
-        () => _i117.LlmAdapterFactory(gh<_i31.LlmSettingsRepository>()));
-    gh.lazySingleton<_i118.LlmService>(() => _i119.GemmaLlmService(
-          gh<_i80.VectorStoreService>(),
-          gh<_i77.UserProfileRepository>(),
+    gh.factory<_i27.LlmAdapter>(
+      () => _i118.MockLlmAdapter(gh<_i59.PromptScrubber>()),
+      instanceName: 'mock',
+    );
+    gh.lazySingleton<_i119.LlmAdapterFactory>(
+        () => _i119.LlmAdapterFactory(gh<_i31.LlmSettingsRepository>()));
+    gh.lazySingleton<_i120.LlmService>(() => _i121.GemmaLlmService(
+          gh<_i82.VectorStoreService>(),
+          gh<_i79.UserProfileRepository>(),
           gh<_i27.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i120.LlmSettingsCubit>(() => _i120.LlmSettingsCubit(
+    gh.factory<_i122.LlmSettingsCubit>(() => _i122.LlmSettingsCubit(
           gh<_i31.LlmSettingsRepository>(),
-          gh<_i12.DeviceCapabilityService>(),
+          gh<_i11.DeviceCapabilityService>(),
           gh<_i27.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i121.MedicalAssistantCubit>(() => _i121.MedicalAssistantCubit(
+    gh.factory<_i123.MedicalAssistantCubit>(() => _i123.MedicalAssistantCubit(
           llmAdapter: gh<_i40.MedicalLlmAdapter>(),
           analysisService: gh<_i34.MedicalAnalysisService>(),
-          healthContextService: gh<_i108.HealthContextService>(),
+          healthContextService: gh<_i111.HealthContextService>(),
         ));
-    gh.lazySingleton<_i122.MedicalResearchService>(
-        () => _i122.MedicalResearchService(
+    gh.lazySingleton<_i124.MedicalResearchService>(
+        () => _i124.MedicalResearchService(
               gh<_i45.MedicalWebSearchService>(),
               gh<_i41.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i123.OnboardingRepository>(
-        () => _i124.OnboardingRepositoryImpl(gh<_i77.UserProfileRepository>()));
-    gh.lazySingleton<_i125.PatientContextIndexer>(
-      () => _i125.PatientContextIndexer(
+    gh.lazySingleton<_i125.OnboardingRepository>(
+        () => _i126.OnboardingRepositoryImpl(gh<_i79.UserProfileRepository>()));
+    gh.lazySingleton<_i127.PatientContextIndexer>(
+      () => _i127.PatientContextIndexer(
         gh<_i22.Isar>(),
-        gh<_i80.VectorStoreService>(),
-        gh<_i112.HealthRecordRepository>(),
+        gh<_i82.VectorStoreService>(),
+        gh<_i114.HealthRecordRepository>(),
         gh<_i47.MedicationRepository>(),
-        gh<_i87.AllergyRepository>(),
-        gh<_i84.VitalSignRepository>(),
-        gh<_i91.AppointmentRepository>(),
+        gh<_i89.AllergyRepository>(),
+        gh<_i86.VitalSignRepository>(),
+        gh<_i93.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i126.ReportGenerationService>(
-        () => _i127.GemmaReportGenerationService(
+    gh.lazySingleton<_i128.ReportGenerationService>(
+        () => _i129.GemmaReportGenerationService(
               gh<_i27.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i80.VectorStoreService>(),
-              gh<_i77.UserProfileRepository>(),
+              gh<_i82.VectorStoreService>(),
+              gh<_i79.UserProfileRepository>(),
               gh<_i59.PromptScrubber>(),
             ));
-    gh.lazySingleton<_i128.SmartSearchUseCase>(
-        () => _i128.SmartSearchUseCase(gh<_i80.VectorStoreService>()));
-    gh.factory<_i129.SsiCubit>(() => _i129.SsiCubit(gh<_i70.SsiRepository>()));
-    gh.factory<_i130.SyncCubit>(() => _i130.SyncCubit(
+    gh.lazySingleton<_i130.SmartSearchUseCase>(
+        () => _i130.SmartSearchUseCase(gh<_i82.VectorStoreService>()));
+    gh.factory<_i131.SsiCubit>(() => _i131.SsiCubit(gh<_i69.SsiRepository>()));
+    gh.factory<_i132.SyncCubit>(() => _i132.SyncCubit(
           gh<_i35.SyncService>(),
-          gh<_i80.VectorStoreService>(),
+          gh<_i82.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i131.SyncService>(() => _i131.SyncService(
-          gh<_i75.SyncRepository>(),
-          gh<_i77.UserProfileRepository>(),
+    gh.lazySingleton<_i133.SyncService>(() => _i133.SyncService(
+          gh<_i74.SyncRepository>(),
+          gh<_i79.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i132.SyncService>(() => _i133.SyncServiceImpl(
-          gh<_i134.SyncRepository>(),
-          gh<_i35.SyncService>(),
-        ));
-    gh.factory<_i135.UserProfileCubit>(
-        () => _i135.UserProfileCubit(gh<_i77.UserProfileRepository>()));
-    gh.factory<_i136.AllergiesCubit>(
-        () => _i136.AllergiesCubit(gh<_i87.AllergyRepository>()));
-    gh.factory<_i137.AuthCubit>(() => _i137.AuthCubit(gh<_i96.AuthService>()));
-    gh.factory<_i138.AuthCubit>(() => _i138.AuthCubit(
-          gh<_i94.AuthRepository>(),
+    gh.factory<_i134.UserProfileCubit>(
+        () => _i134.UserProfileCubit(gh<_i79.UserProfileRepository>()));
+    gh.factory<_i135.AllergiesCubit>(
+        () => _i135.AllergiesCubit(gh<_i89.AllergyRepository>()));
+    gh.factory<_i136.AuthCubit>(() => _i136.AuthCubit(
+          gh<_i96.AuthRepository>(),
           gh<_i17.EncryptionService>(),
           gh<_i5.BiometricService>(),
         ));
-    gh.factory<_i139.DashboardCubit>(
-        () => _i139.DashboardCubit(gh<_i101.DashboardRepository>()));
-    gh.factory<_i140.FhirSyncCubit>(
-        () => _i140.FhirSyncCubit(gh<_i131.SyncService>()));
-    gh.factory<_i141.FhirSyncCubit>(
-        () => _i141.FhirSyncCubit(gh<_i132.SyncService>()));
-    gh.factory<_i142.HealthRecordCubit>(() => _i142.HealthRecordCubit(
-          gh<_i112.HealthRecordRepository>(),
+    gh.factory<_i137.AuthCubit>(() => _i137.AuthCubit(gh<_i98.AuthService>()));
+    gh.factory<_i138.DashboardCubit>(
+        () => _i138.DashboardCubit(gh<_i103.DashboardRepository>()));
+    gh.factory<_i139.FhirSyncCubit>(
+        () => _i139.FhirSyncCubit(gh<_i133.SyncService>()));
+    gh.factory<_i140.HealthRecordCubit>(() => _i140.HealthRecordCubit(
+          gh<_i114.HealthRecordRepository>(),
           gh<_i19.FilePickerService>(),
           gh<_i21.ImagePickerService>(),
           gh<_i57.OcrService>(),
-          gh<_i80.VectorStoreService>(),
+          gh<_i82.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i118.LlmService>(
+    gh.factory<_i141.IAiRepository>(
+        () => _i142.AiRepositoryImpl(gh<_i120.LlmService>()));
+    gh.lazySingleton<_i120.LlmService>(
       () => _i143.RagLlmService(
-        gh<_i80.VectorStoreService>(),
-        gh<_i122.MedicalResearchService>(),
-        gh<_i77.UserProfileRepository>(),
+        gh<_i82.VectorStoreService>(),
+        gh<_i124.MedicalResearchService>(),
+        gh<_i79.UserProfileRepository>(),
         gh<_i27.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
@@ -619,31 +611,33 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i144.MedicalIndexingService>(
         () => _i144.MedicalIndexingService(
               gh<_i37.MedicalKnowledgeRepository>(),
-              gh<_i80.VectorStoreService>(),
-              gh<_i125.PatientContextIndexer>(),
+              gh<_i82.VectorStoreService>(),
+              gh<_i127.PatientContextIndexer>(),
             ));
     gh.factory<_i145.MedicalResearchCubit>(() => _i145.MedicalResearchCubit(
-          gh<_i122.MedicalResearchService>(),
+          gh<_i124.MedicalResearchService>(),
           gh<_i43.MedicalStandardsService>(),
         ));
     gh.factory<_i146.ReportBloc>(() => _i146.ReportBloc(
           gh<_i62.ReportRepository>(),
-          gh<_i126.ReportGenerationService>(),
+          gh<_i128.ReportGenerationService>(),
         ));
-    gh.lazySingleton<_i147.HomeRepository>(() => _i148.HomeRepositoryImpl(
-          gh<_i84.VitalSignRepository>(),
+    gh.factory<_i147.AiAssistantCubit>(
+        () => _i147.AiAssistantCubit(gh<_i141.IAiRepository>()));
+    gh.lazySingleton<_i148.HomeRepository>(() => _i149.HomeRepositoryImpl(
+          gh<_i86.VitalSignRepository>(),
           gh<_i144.MedicalIndexingService>(),
           gh<_i34.MedicalAnalysisService>(),
-          gh<_i77.UserProfileRepository>(),
+          gh<_i79.UserProfileRepository>(),
         ));
     return this;
   }
 }
 
-class _$FhirModule extends _i149.FhirModule {}
+class _$FhirModule extends _i150.FhirModule {}
 
-class _$NetworkModule extends _i150.NetworkModule {}
+class _$NetworkModule extends _i151.NetworkModule {}
 
-class _$MemoryModule extends _i151.MemoryModule {}
+class _$MemoryModule extends _i152.MemoryModule {}
 
-class _$DatabaseModule extends _i152.DatabaseModule {}
+class _$DatabaseModule extends _i153.DatabaseModule {}

--- a/lib/features/ai_assistant/application/ai_assistant_cubit.dart
+++ b/lib/features/ai_assistant/application/ai_assistant_cubit.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:equatable/equatable.dart';
+import 'package:injectable/injectable.dart';
+import '../../local_agent/domain/chat_message.dart';
+import '../domain/entities/ai_query.dart';
+import '../domain/repositories/i_ai_repository.dart';
+
+enum AiAssistantStatus { idle, thinking, responding, error }
+
+class AiAssistantState extends Equatable {
+  final List<ChatMessage> messages;
+  final AiAssistantStatus status;
+  final String? errorMessage;
+
+  const AiAssistantState({
+    required this.messages,
+    this.status = AiAssistantStatus.idle,
+    this.errorMessage,
+  });
+
+  factory AiAssistantState.initial() {
+    return AiAssistantState(
+      messages: [
+        ChatMessage(
+          role: ChatRole.assistant,
+          content: "Welcome to OrionHealth. How can I assist you with your health data today?",
+          timestamp: DateTime.now(),
+        ),
+      ],
+    );
+  }
+
+  AiAssistantState copyWith({
+    List<ChatMessage>? messages,
+    AiAssistantStatus? status,
+    String? errorMessage,
+  }) {
+    return AiAssistantState(
+      messages: messages ?? this.messages,
+      status: status ?? this.status,
+      errorMessage: errorMessage ?? this.errorMessage,
+    );
+  }
+
+  @override
+  List<Object?> get props => [messages, status, errorMessage];
+}
+
+@injectable
+class AiAssistantCubit extends Cubit<AiAssistantState> {
+  final IAiRepository _repository;
+  StreamSubscription? _subscription;
+
+  AiAssistantCubit(this._repository) : super(AiAssistantState.initial());
+
+  Future<void> sendMessage(String text) async {
+    if (text.trim().isEmpty) return;
+
+    final userMessage = ChatMessage(
+      role: ChatRole.user,
+      content: text,
+      timestamp: DateTime.now(),
+    );
+
+    final assistantMessage = ChatMessage(
+      role: ChatRole.assistant,
+      content: '',
+      timestamp: DateTime.now(),
+    );
+
+    final updatedMessages = List<ChatMessage>.from(state.messages)
+      ..add(userMessage)
+      ..add(assistantMessage);
+
+    emit(state.copyWith(
+      messages: updatedMessages,
+      status: AiAssistantStatus.thinking,
+    ));
+
+    await _subscription?.cancel();
+
+    final query = AiQuery(text: text, timestamp: userMessage.timestamp);
+    bool firstChunk = true;
+
+    _subscription = _repository.askStreaming(query).listen(
+      (chunk) {
+        if (firstChunk) {
+          emit(state.copyWith(status: AiAssistantStatus.responding));
+          firstChunk = false;
+        }
+
+        final lastMessage = state.messages.last;
+        final updatedLastMessage = ChatMessage(
+          id: lastMessage.id,
+          role: lastMessage.role,
+          content: lastMessage.content + chunk,
+          timestamp: lastMessage.timestamp,
+          citations: lastMessage.citations,
+        );
+
+        final newMessages = List<ChatMessage>.from(state.messages)
+          ..[state.messages.length - 1] = updatedLastMessage;
+
+        emit(state.copyWith(messages: newMessages));
+      },
+      onDone: () {
+        emit(state.copyWith(status: AiAssistantStatus.idle));
+      },
+      onError: (error) {
+        final lastMessage = state.messages.last;
+        final updatedLastMessage = ChatMessage(
+          id: lastMessage.id,
+          role: lastMessage.role,
+          content: '${lastMessage.content}\nError: $error',
+          timestamp: lastMessage.timestamp,
+          citations: lastMessage.citations,
+        );
+
+        final newMessages = List<ChatMessage>.from(state.messages)
+          ..[state.messages.length - 1] = updatedLastMessage;
+
+        emit(state.copyWith(
+          messages: newMessages,
+          status: AiAssistantStatus.error,
+          errorMessage: error.toString(),
+        ));
+      },
+    );
+  }
+
+  @override
+  Future<void> close() {
+    _subscription?.cancel();
+    return super.close();
+  }
+}

--- a/lib/features/ai_assistant/domain/entities/ai_query.dart
+++ b/lib/features/ai_assistant/domain/entities/ai_query.dart
@@ -1,0 +1,14 @@
+import 'package:equatable/equatable.dart';
+
+class AiQuery extends Equatable {
+  final String text;
+  final DateTime timestamp;
+
+  const AiQuery({
+    required this.text,
+    required this.timestamp,
+  });
+
+  @override
+  List<Object?> get props => [text, timestamp];
+}

--- a/lib/features/ai_assistant/domain/repositories/i_ai_repository.dart
+++ b/lib/features/ai_assistant/domain/repositories/i_ai_repository.dart
@@ -1,0 +1,5 @@
+import '../entities/ai_query.dart';
+
+abstract class IAiRepository {
+  Stream<String> askStreaming(AiQuery query);
+}

--- a/lib/features/ai_assistant/infrastructure/repositories/ai_repository_impl.dart
+++ b/lib/features/ai_assistant/infrastructure/repositories/ai_repository_impl.dart
@@ -1,0 +1,16 @@
+import 'package:injectable/injectable.dart';
+import '../../../../features/local_agent/infrastructure/llm_service.dart';
+import '../../domain/entities/ai_query.dart';
+import '../../domain/repositories/i_ai_repository.dart';
+
+@Injectable(as: IAiRepository)
+class AiRepositoryImpl implements IAiRepository {
+  final LlmService _llmService;
+
+  AiRepositoryImpl(this._llmService);
+
+  @override
+  Stream<String> askStreaming(AiQuery query) {
+    return _llmService.generate(query.text);
+  }
+}

--- a/lib/features/ai_assistant/presentation/pages/chat_page.dart
+++ b/lib/features/ai_assistant/presentation/pages/chat_page.dart
@@ -1,18 +1,19 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:intl/intl.dart';
 
+import '../../../../core/di/injection.dart';
 import '../../../local_agent/domain/chat_message.dart';
 import '../../../local_agent/infrastructure/llm_service.dart';
+import '../../application/ai_assistant_cubit.dart';
+import '../../infrastructure/repositories/ai_repository_impl.dart';
 import '../widgets/message_composer.dart';
 import '../../../../../core/theme/app_colors.dart';
 
-
-enum AssistantState { idle, thinking, responding }
-
 class ChatPage extends StatefulWidget {
-  final LlmService llmService;
-  const ChatPage({super.key, required this.llmService});
+  final LlmService? llmService;
+  const ChatPage({super.key, this.llmService});
 
   @override
   State<ChatPage> createState() => _ChatPageState();
@@ -21,19 +22,6 @@ class ChatPage extends StatefulWidget {
 class _ChatPageState extends State<ChatPage> {
   final TextEditingController _textController = TextEditingController();
   final ScrollController _scrollController = ScrollController();
-  final List<ChatMessage> _messages = [];
-  AssistantState _assistantState = AssistantState.idle;
-
-  @override
-  void initState() {
-    super.initState();
-    // Add initial AI message
-    _messages.add(ChatMessage(
-      role: ChatRole.assistant,
-      content: "Welcome to OrionHealth. How can I assist you with your health data today?",
-      timestamp: DateTime.now(),
-    ));
-  }
 
   @override
   void dispose() {
@@ -54,93 +42,64 @@ class _ChatPageState extends State<ChatPage> {
     });
   }
 
-  void _sendMessage([String? text]) {
-    final messageText = text ?? _textController.text.trim();
-    if (messageText.isEmpty) return;
-
-    HapticFeedback.lightImpact();
-
-    final userMessage = ChatMessage(
-      role: ChatRole.user,
-      content: messageText,
-      timestamp: DateTime.now(),
-    );
-
-    setState(() {
-      _messages.add(userMessage);
-      _assistantState = AssistantState.thinking;
-    });
-
-    if (text == null) _textController.clear();
-    _scrollToBottom();
-
-    final assistantMessage = ChatMessage(
-      role: ChatRole.assistant,
-      content: '',
-      timestamp: DateTime.now(),
-    );
-
-    setState(() => _messages.add(assistantMessage));
-
-    bool firstChunk = true;
-    widget.llmService.generate(messageText).listen(
-      (chunk) {
-        if (firstChunk) {
-          setState(() {
-            _assistantState = AssistantState.responding;
-            firstChunk = false;
-          });
-        }
-        setState(() {
-          _messages.last.content += chunk;
-        });
-        _scrollToBottom();
-      },
-      onDone: () {
-        setState(() => _assistantState = AssistantState.idle);
-        _scrollToBottom();
-      },
-      onError: (error) {
-        setState(() {
-          _messages.last.content = 'Error: ${error.toString()}';
-          _assistantState = AssistantState.idle;
-        });
-        _scrollToBottom();
-      },
-    );
-  }
-
   @override
   Widget build(BuildContext context) {
-    return Scaffold(
-      appBar: _buildAppBar(),
-      body: Column(
-        children: [
-          Expanded(
-            child: ListView.builder(
-              controller: _scrollController,
-              padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 20.0),
-              itemCount: _messages.length,
-              itemBuilder: (context, index) {
-                final message = _messages[index];
-                return _ChatMessageWidget(message: message);
-              },
+    return BlocProvider(
+      create: (context) {
+        if (widget.llmService != null) {
+          return AiAssistantCubit(AiRepositoryImpl(widget.llmService!));
+        }
+        return getIt<AiAssistantCubit>();
+      },
+      child: BlocConsumer<AiAssistantCubit, AiAssistantState>(
+        listener: (context, state) {
+          _scrollToBottom();
+        },
+        builder: (context, state) {
+          return Scaffold(
+            appBar: _buildAppBar(state.status),
+            body: Column(
+              children: [
+                Expanded(
+                  child: ListView.builder(
+                    controller: _scrollController,
+                    padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 20.0),
+                    itemCount: state.messages.length,
+                    itemBuilder: (context, index) {
+                      final message = state.messages[index];
+                      return _ChatMessageWidget(message: message);
+                    },
+                  ),
+                ),
+                if (state.status == AiAssistantStatus.thinking ||
+                    state.status == AiAssistantStatus.responding)
+                  _TypingIndicator(status: state.status),
+                MessageComposer(
+                  controller: _textController,
+                  onSend: () {
+                    final messageText = _textController.text.trim();
+                    if (messageText.isEmpty) return;
+                    HapticFeedback.lightImpact();
+                    context.read<AiAssistantCubit>().sendMessage(messageText);
+                    _textController.clear();
+                  },
+                  onQuickPrompt: (prompt) {
+                    HapticFeedback.lightImpact();
+                    context.read<AiAssistantCubit>().sendMessage(prompt);
+                  },
+                  isEnabled: state.status == AiAssistantStatus.idle ||
+                      state.status == AiAssistantStatus.error,
+                ),
+              ],
             ),
-          ),
-          if (_assistantState != AssistantState.idle)
-            _TypingIndicator(state: _assistantState),
-          MessageComposer(
-            controller: _textController,
-            onSend: _sendMessage,
-            onQuickPrompt: (prompt) => _sendMessage(prompt),
-            isEnabled: _assistantState == AssistantState.idle,
-          ),
-        ],
+          );
+        },
       ),
     );
   }
 
-  AppBar _buildAppBar() {
+  AppBar _buildAppBar(AiAssistantStatus status) {
+    final isProcessing = status == AiAssistantStatus.thinking || status == AiAssistantStatus.responding;
     return AppBar(
       title: Column(
         children: [
@@ -149,15 +108,15 @@ class _ChatPageState extends State<ChatPage> {
             mainAxisSize: MainAxisSize.min,
             children: [
               Icon(Icons.circle,
-                color: _assistantState == AssistantState.idle ? AppColors.primary : Colors.orange,
+                color: !isProcessing ? AppColors.primary : Colors.orange,
                 size: 8
               ),
               const SizedBox(width: 4),
               Text(
-                _assistantState == AssistantState.idle ? 'Online' : 'Processing...',
+                !isProcessing ? 'Online' : 'Processing...',
                 style: TextStyle(
                   fontSize: 12,
-                  color: _assistantState == AssistantState.idle ? AppColors.primary : Colors.orange
+                  color: !isProcessing ? AppColors.primary : Colors.orange
                 )
               ),
             ],
@@ -236,8 +195,8 @@ class _ChatMessageWidget extends StatelessWidget {
 }
 
 class _TypingIndicator extends StatefulWidget {
-  final AssistantState state;
-  const _TypingIndicator({required this.state});
+  final AiAssistantStatus status;
+  const _TypingIndicator({required this.status});
 
   @override
   State<_TypingIndicator> createState() => _TypingIndicatorState();
@@ -267,7 +226,7 @@ class _TypingIndicatorState extends State<_TypingIndicator> with SingleTickerPro
 
   @override
   Widget build(BuildContext context) {
-    final statusText = widget.state == AssistantState.thinking
+    final statusText = widget.status == AiAssistantStatus.thinking
         ? 'Orion is thinking...'
         : 'Orion is responding...';
 
@@ -281,7 +240,7 @@ class _TypingIndicatorState extends State<_TypingIndicator> with SingleTickerPro
             child: CircularProgressIndicator(
               strokeWidth: 2,
               valueColor: AlwaysStoppedAnimation<Color>(
-                widget.state == AssistantState.thinking ? AppColors.secondary : AppColors.primary
+                widget.status == AiAssistantStatus.thinking ? AppColors.secondary : AppColors.primary
               ),
             ),
           ),


### PR DESCRIPTION
This PR implements the domain and application layers for the AI Assistant feature, following Clean Architecture principles. It introduces entities, repository interfaces, and a Cubit for state management, while wiring them to the existing presentation layer. It also ensures proper separation of concerns by placing the repository implementation in the infrastructure layer.

Fixes #527

---
*PR created automatically by Jules for task [12019630508021137516](https://jules.google.com/task/12019630508021137516) started by @iberi22*