### PR TITLE
fix: #550 VoiceChatControls.onSendTextMessage type mismatch

### DIFF
--- a/lib/features/voice_chat/voice_chat_screen.dart
+++ b/lib/features/voice_chat/voice_chat_screen.dart
@@ -66,7 +66,7 @@ class VoiceChatControls extends StatelessWidget {
   final TextEditingController textController;
   final VoidCallback onRecordPressed;
   final VoidCallback onStopRecording;
-  final void Function(String) onSendTextMessage;
+  final Future<void> Function(String) onSendTextMessage;
   final VoidCallback onInterrupt;
 
   const VoiceChatControls({

--- a/windows/flutter/generated_plugins.cmake
+++ b/windows/flutter/generated_plugins.cmake
@@ -23,6 +23,7 @@ list(APPEND FLUTTER_PLUGIN_LIST
 )
 
 list(APPEND FLUTTER_FFI_PLUGIN_LIST
+  jni
   onnxruntime
   sherpa_onnx_windows
 )


### PR DESCRIPTION
Closes #550

Changed onSendTextMessage callback type from \oid Function(String)\ to \Future<void> Function(String)\ to match the actual async implementation.