### PR TITLE
feat(calendar_import): add infrastructure layer with real calendar API integration

### DIFF
--- a/lib/core/di/calendar_module.dart
+++ b/lib/core/di/calendar_module.dart
@@ -1,0 +1,8 @@
+import 'package:device_calendar/device_calendar.dart';
+import 'package:injectable/injectable.dart';
+
+@module
+abstract class CalendarModule {
+  @lazySingleton
+  DeviceCalendarPlugin get deviceCalendarPlugin => DeviceCalendarPlugin();
+}

--- a/lib/features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart
+++ b/lib/features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart
@@ -1,0 +1,53 @@
+import 'package:device_calendar/device_calendar.dart';
+import 'package:injectable/injectable.dart';
+
+/// Data source that interacts with the device's native calendar API.
+/// Wraps [DeviceCalendarPlugin] to provide a cleaner interface for the repository.
+@injectable
+class CalendarApiDatasource {
+  final DeviceCalendarPlugin _deviceCalendarPlugin;
+
+  CalendarApiDatasource({DeviceCalendarPlugin? deviceCalendarPlugin})
+      : _deviceCalendarPlugin = deviceCalendarPlugin ?? DeviceCalendarPlugin();
+
+  /// Checks if calendar permissions have been granted.
+  Future<bool> hasPermissions() async {
+    final permissionsGranted = await _deviceCalendarPlugin.hasPermissions();
+    return permissionsGranted.isSuccess && (permissionsGranted.data ?? false);
+  }
+
+  /// Requests calendar permissions from the user.
+  Future<bool> requestPermissions() async {
+    final permissionsGranted = await _deviceCalendarPlugin.requestPermissions();
+    return permissionsGranted.isSuccess && (permissionsGranted.data ?? false);
+  }
+
+  /// Retrieves all available calendars on the device.
+  Future<List<Calendar>> getCalendars() async {
+    final calendarsResult = await _deviceCalendarPlugin.retrieveCalendars();
+    if (calendarsResult.isSuccess && calendarsResult.data != null) {
+      return calendarsResult.data!;
+    }
+    return [];
+  }
+
+  /// Retrieves events from a specific calendar within a date range.
+  Future<List<Event>> getEvents(
+    String calendarId, {
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    final retrieveEventsParams = RetrieveEventsParams(
+      startDate: startDate,
+      endDate: endDate,
+    );
+    final eventsResult = await _deviceCalendarPlugin.retrieveEvents(
+      calendarId,
+      retrieveEventsParams,
+    );
+    if (eventsResult.isSuccess && eventsResult.data != null) {
+      return eventsResult.data!;
+    }
+    return [];
+  }
+}

--- a/lib/features/calendar_import/infrastructure/models/calendar_event_dto.dart
+++ b/lib/features/calendar_import/infrastructure/models/calendar_event_dto.dart
@@ -1,0 +1,62 @@
+import 'package:device_calendar/device_calendar.dart';
+import '../../domain/entities/calendar_event.dart';
+
+class CalendarEventDto {
+  final String title;
+  final DateTime startDateTime;
+  final DateTime? endDateTime;
+  final String? description;
+  final String? location;
+
+  const CalendarEventDto({
+    required this.title,
+    required this.startDateTime,
+    this.endDateTime,
+    this.description,
+    this.location,
+  });
+
+  factory CalendarEventDto.fromDeviceCalendar(Event event) {
+    return CalendarEventDto(
+      title: event.title ?? '',
+      startDateTime: event.start != null
+          ? DateTime.fromMillisecondsSinceEpoch(event.start!.millisecondsSinceEpoch)
+          : DateTime.now(),
+      endDateTime: event.end != null
+          ? DateTime.fromMillisecondsSinceEpoch(event.end!.millisecondsSinceEpoch)
+          : null,
+      description: event.description,
+      location: event.location,
+    );
+  }
+
+  CalendarEvent toEntity({CalendarEventSource source = CalendarEventSource.deviceCalendar}) {
+    return CalendarEvent(
+      title: title,
+      startDateTime: startDateTime,
+      endDateTime: endDateTime,
+      description: description,
+      location: location,
+      source: source,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'title': title,
+        'startDateTime': startDateTime.toIso8601String(),
+        'endDateTime': endDateTime?.toIso8601String(),
+        'description': description,
+        'location': location,
+      };
+
+  factory CalendarEventDto.fromJson(Map<String, dynamic> json) =>
+      CalendarEventDto(
+        title: json['title'] as String,
+        startDateTime: DateTime.parse(json['startDateTime'] as String),
+        endDateTime: json['endDateTime'] != null
+            ? DateTime.parse(json['endDateTime'] as String)
+            : null,
+        description: json['description'] as String?,
+        location: json['location'] as String?,
+      );
+}

--- a/lib/features/calendar_import/infrastructure/models/calendar_source_dto.dart
+++ b/lib/features/calendar_import/infrastructure/models/calendar_source_dto.dart
@@ -1,0 +1,49 @@
+import 'package:device_calendar/device_calendar.dart';
+import '../../domain/entities/calendar_source.dart';
+
+class CalendarSourceDto {
+  final String id;
+  final String name;
+  final bool isReadOnly;
+  final bool isPrimary;
+
+  const CalendarSourceDto({
+    required this.id,
+    required this.name,
+    this.isReadOnly = false,
+    this.isPrimary = false,
+  });
+
+  factory CalendarSourceDto.fromDeviceCalendar(Calendar calendar) {
+    return CalendarSourceDto(
+      id: calendar.id ?? '',
+      name: calendar.name ?? '',
+      isReadOnly: calendar.isReadOnly ?? false,
+      isPrimary: false, // device_calendar 4.3.3 might not have isPrimary
+    );
+  }
+
+  CalendarSource toEntity() {
+    return CalendarSource(
+      id: id,
+      name: name,
+      isReadOnly: isReadOnly,
+      isPrimary: isPrimary,
+    );
+  }
+
+  Map<String, dynamic> toJson() => {
+        'id': id,
+        'name': name,
+        'isReadOnly': isReadOnly,
+        'isPrimary': isPrimary,
+      };
+
+  factory CalendarSourceDto.fromJson(Map<String, dynamic> json) =>
+      CalendarSourceDto(
+        id: json['id'] as String,
+        name: json['name'] as String,
+        isReadOnly: json['isReadOnly'] as bool? ?? false,
+        isPrimary: json['isPrimary'] as bool? ?? false,
+      );
+}

--- a/lib/features/calendar_import/infrastructure/repositories/calendar_repository_impl.dart
+++ b/lib/features/calendar_import/infrastructure/repositories/calendar_repository_impl.dart
@@ -1,0 +1,97 @@
+import 'package:injectable/injectable.dart';
+import '../../domain/entities/calendar_event.dart';
+import '../../domain/entities/calendar_source.dart';
+import '../../domain/repositories/calendar_repository.dart';
+import '../datasources/calendar_api_datasource.dart';
+import '../models/calendar_event_dto.dart';
+import '../models/calendar_source_dto.dart';
+
+@LazySingleton(as: CalendarRepository)
+class CalendarRepositoryImpl implements CalendarRepository {
+  final CalendarApiDatasource _datasource;
+
+  CalendarRepositoryImpl(this._datasource);
+
+  @override
+  Future<bool> hasPermissions() async {
+    return await _datasource.hasPermissions();
+  }
+
+  @override
+  Future<bool> requestPermissions() async {
+    return await _datasource.requestPermissions();
+  }
+
+  @override
+  Future<List<CalendarSource>> getCalendarSources() async {
+    final calendars = await _datasource.getCalendars();
+    return calendars
+        .map((c) => CalendarSourceDto.fromDeviceCalendar(c).toEntity())
+        .toList();
+  }
+
+  @override
+  Future<List<CalendarEvent>> fetchMedicalEvents({
+    DateTime? startDate,
+    DateTime? endDate,
+  }) async {
+    final calendars = await _datasource.getCalendars();
+    final List<CalendarEvent> allMedicalEvents = [];
+
+    // Default range if not provided: 3 months back to 6 months forward
+    final start = startDate ?? DateTime.now().subtract(const Duration(days: 90));
+    final end = endDate ?? DateTime.now().add(const Duration(days: 180));
+
+    for (final calendar in calendars) {
+      if (calendar.id == null) continue;
+
+      final events = await _datasource.getEvents(
+        calendar.id!,
+        startDate: start,
+        endDate: end,
+      );
+
+      for (final event in events) {
+        if (_isMedicalEvent(event.title ?? '', event.description ?? '')) {
+          allMedicalEvents.add(
+            CalendarEventDto.fromDeviceCalendar(event).toEntity(
+              source: CalendarEventSource.deviceCalendar,
+            ),
+          );
+        }
+      }
+    }
+
+    return allMedicalEvents;
+  }
+
+  bool _isMedicalEvent(String title, String description) {
+    final text = '$title $description'.toLowerCase();
+    const keywords = [
+      'cita',
+      'médico',
+      'consulta',
+      'eps',
+      'sura',
+      'comfama',
+      'sanitas',
+      'doctor',
+      'especialista',
+      'control',
+      'examen',
+      'procedimiento',
+      'odontología',
+      'terapia',
+      'laboratorio',
+      'vacuna',
+      'hospital',
+      'clínica',
+      'salud',
+      'pediatría',
+      'ginecología',
+      'cardiología',
+    ];
+
+    return keywords.any((keyword) => text.contains(keyword));
+  }
+}

--- a/lib/features/calendar_import/infrastructure/utils/calendar_parser.dart
+++ b/lib/features/calendar_import/infrastructure/utils/calendar_parser.dart
@@ -1,0 +1,127 @@
+import '../../domain/entities/calendar_event.dart';
+
+/// Utility to parse calendar events from ICS and CSV formats.
+///
+/// Implements basic medical filtering to only import relevant appointments.
+class CalendarParser {
+  /// Keywords used to identify medical events.
+  static const List<String> _medicalKeywords = [
+    'cita', 'médico', 'consulta', 'eps', 'sura', 'comfama',
+    'sanitas', 'doctor', 'especialista', 'control', 'examen',
+    'procedimiento', 'odontología', 'terapia', 'laboratorio', 'vacuna',
+    'hospital', 'clínica', 'salud', 'dra.', 'dr.',
+  ];
+
+  /// Parses an ICS (iCalendar) string and returns medical events.
+  List<CalendarEvent> parseIcs(String icsContent) {
+    final List<CalendarEvent> events = [];
+    final lines = icsContent.split('\n');
+
+    String? currentSummary;
+    DateTime? currentStart;
+    String? currentDescription;
+
+    for (var line in lines) {
+      line = line.trim();
+      if (line.startsWith('BEGIN:VEVENT')) {
+        currentSummary = null;
+        currentStart = null;
+        currentDescription = null;
+      } else if (line.startsWith('SUMMARY:')) {
+        currentSummary = line.substring(8);
+      } else if (line.startsWith('DTSTART:')) {
+        currentStart = _parseIcsDateTime(line.substring(8));
+      } else if (line.startsWith('DESCRIPTION:')) {
+        currentDescription = line.substring(12);
+      } else if (line.startsWith('END:VEVENT')) {
+        if (currentSummary != null && currentStart != null) {
+          if (_isMedical(currentSummary, currentDescription ?? '')) {
+            events.add(CalendarEvent(
+              title: currentSummary,
+              startDateTime: currentStart,
+              description: currentDescription,
+              source: CalendarEventSource.icsFile,
+            ));
+          }
+        }
+      }
+    }
+
+    return _deduplicate(events);
+  }
+
+  /// Parses a CSV string and returns medical events.
+  /// Expected format: Subject,Start Date,Start Time,Description
+  List<CalendarEvent> parseCsv(String csvContent) {
+    final List<CalendarEvent> events = [];
+    final lines = csvContent.split('\n');
+
+    // Skip header if present
+    int startIndex = 0;
+    if (lines.isNotEmpty && lines[0].toLowerCase().contains('subject')) {
+      startIndex = 1;
+    }
+
+    for (int i = startIndex; i < lines.length; i++) {
+      final line = lines[i].trim();
+      if (line.isEmpty) continue;
+
+      final parts = line.split(',');
+      if (parts.length < 3) continue;
+
+      final title = parts[0].trim();
+      final dateStr = parts[1].trim();
+      final timeStr = parts[2].trim();
+      final description = parts.length > 3 ? parts[3].trim() : null;
+
+      try {
+        final start = DateTime.parse('$dateStr $timeStr');
+        if (_isMedical(title, description ?? '')) {
+          events.add(CalendarEvent(
+            title: title,
+            startDateTime: start,
+            description: description,
+            source: CalendarEventSource.csvFile,
+          ));
+        }
+      } catch (_) {
+        // Skip malformed rows
+      }
+    }
+
+    return _deduplicate(events);
+  }
+
+  bool _isMedical(String title, String description) {
+    final text = '$title $description'.toLowerCase();
+    return _medicalKeywords.any((kw) => text.contains(kw));
+  }
+
+  List<CalendarEvent> _deduplicate(List<CalendarEvent> events) {
+    final Map<String, CalendarEvent> unique = {};
+    for (var e in events) {
+      unique[e.dedupKey] = e;
+    }
+    return unique.values.toList();
+  }
+
+  DateTime? _parseIcsDateTime(String value) {
+    // Format: 20231027T100000Z
+    try {
+      final year = int.parse(value.substring(0, 4));
+      final month = int.parse(value.substring(4, 6));
+      final day = int.parse(value.substring(6, 8));
+      final hour = int.parse(value.substring(9, 11));
+      final minute = int.parse(value.substring(11, 13));
+      final second = int.parse(value.substring(13, 15));
+
+      final isUtc = value.endsWith('Z');
+      if (isUtc) {
+        return DateTime.utc(year, month, day, hour, minute, second).toLocal();
+      }
+      return DateTime(year, month, day, hour, minute, second);
+    } catch (_) {
+      return null;
+    }
+  }
+}

--- a/test/features/calendar_import/infrastructure/calendar_parser_test.dart
+++ b/test/features/calendar_import/infrastructure/calendar_parser_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:orionhealth_health/features/calendar_import/infrastructure/calendar_parser.dart';
+import 'package:orionhealth_health/features/calendar_import/infrastructure/utils/calendar_parser.dart';
 import 'package:orionhealth_health/features/calendar_import/domain/entities/calendar_event.dart';
 
 void main() {


### PR DESCRIPTION
This PR adds the infrastructure layer to the calendar_import feature. It includes a real integration with the device calendar API via the `device_calendar` package, repository implementations, DTOs for data mapping, and a utility for parsing medical events from ICS and CSV files. All components are registered in the dependency injection system.

Fixes #581

---
*PR created automatically by Jules for task [16230921354407322806](https://jules.google.com/task/16230921354407322806) started by @iberi22*