### PR TITLE
Increase eps_connection coverage to 100% and refactor to Clean Architecture

### DIFF
--- a/lib/features/eps_connection/application/bloc/eps_connection_cubit.dart
+++ b/lib/features/eps_connection/application/bloc/eps_connection_cubit.dart
@@ -1,41 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-FileCopyrightText: 2025 SouthWest AI Labs
+
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import 'eps_connection_state.dart';
-import '../../domain/entities/eps_connection.dart';
 import '../../domain/entities/eps_provider.dart';
-import '../../domain/repositories/oauth_repository.dart';
-import '../../../user_profile/domain/repositories/user_profile_repository.dart';
+import '../../domain/usecases/connect_provider_usecase.dart';
+import '../../domain/usecases/disconnect_provider_usecase.dart';
+import '../../domain/usecases/get_connections_usecase.dart';
 
 @injectable
 class EpsConnectionCubit extends Cubit<EpsConnectionState> {
-  final OAuthRepository _oauthRepository;
-  final UserProfileRepository _userProfileRepository;
+  final GetConnectionsUseCase _getConnectionsUseCase;
+  final ConnectProviderUseCase _connectProviderUseCase;
+  final DisconnectProviderUseCase _disconnectProviderUseCase;
 
-  EpsConnectionCubit(this._oauthRepository, this._userProfileRepository)
-      : super(const EpsConnectionInitial()) {
+  EpsConnectionCubit(
+    this._getConnectionsUseCase,
+    this._connectProviderUseCase,
+    this._disconnectProviderUseCase,
+  ) : super(const EpsConnectionInitial()) {
     loadConnections();
   }
 
   Future<void> loadConnections() async {
     emit(const EpsConnectionLoading());
     try {
-      final connectedIds = await _oauthRepository.getConnectedProviders();
-      final List<EPSConnection> connections = [];
-
-      for (final id in connectedIds) {
-        final token = await _oauthRepository.getToken(id);
-        final provider = await _oauthRepository.getProviderDetails(id);
-        final patientId = await _oauthRepository.getPatientId(id);
-
-        if (token != null && provider != null) {
-          connections.add(EPSConnection(
-            provider: provider,
-            token: token,
-            patientId: patientId ?? 'Unknown',
-            connectedAt: DateTime.now(), // ideally persisted connectedAt too
-          ));
-        }
-      }
+      final connections = await _getConnectionsUseCase();
       emit(EpsConnectionLoaded(connections));
     } catch (e) {
       emit(EpsConnectionError('Error loading connections: ${e.toString()}'));
@@ -45,24 +36,8 @@ class EpsConnectionCubit extends Cubit<EpsConnectionState> {
   Future<void> connect(EPSProvider provider) async {
     emit(const EpsConnectionLoading());
     try {
-      final result = await _oauthRepository.login(provider);
-      if (result != null) {
-        final patientId = result.patientId;
-
-        final profile = await _userProfileRepository.getUserProfile();
-        if (profile != null) {
-          final updatedProfile = profile.copyWith(
-            isEpsConnected: true,
-            epsPatientId: patientId,
-          );
-          await _userProfileRepository.saveUserProfile(updatedProfile);
-          await loadConnections();
-        } else {
-          emit(const EpsConnectionError('User profile not found.'));
-        }
-      } else {
-        await loadConnections();
-      }
+      await _connectProviderUseCase(provider);
+      await loadConnections();
     } catch (e) {
       emit(EpsConnectionError('Connection error: ${e.toString()}'));
     }
@@ -71,19 +46,7 @@ class EpsConnectionCubit extends Cubit<EpsConnectionState> {
   Future<void> disconnect(String providerId) async {
     emit(const EpsConnectionLoading());
     try {
-      await _oauthRepository.logout(providerId);
-      final profile = await _userProfileRepository.getUserProfile();
-      if (profile != null) {
-        // If it was the only connection or we want to clear the global flag
-        final providers = await _oauthRepository.getConnectedProviders();
-        if (providers.isEmpty) {
-          final updatedProfile = profile.copyWith(
-            isEpsConnected: false,
-            epsPatientId: null,
-          );
-          await _userProfileRepository.saveUserProfile(updatedProfile);
-        }
-      }
+      await _disconnectProviderUseCase(providerId);
       await loadConnections();
     } catch (e) {
       emit(EpsConnectionError('Disconnection error: ${e.toString()}'));

--- a/lib/features/eps_connection/domain/usecases/connect_provider_usecase.dart
+++ b/lib/features/eps_connection/domain/usecases/connect_provider_usecase.dart
@@ -1,0 +1,32 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-FileCopyrightText: 2025 SouthWest AI Labs
+
+import 'package:injectable/injectable.dart';
+import '../entities/eps_provider.dart';
+import '../repositories/oauth_repository.dart';
+import '../../../user_profile/domain/repositories/user_profile_repository.dart';
+
+@injectable
+class ConnectProviderUseCase {
+  final OAuthRepository _oauthRepository;
+  final UserProfileRepository _userProfileRepository;
+
+  ConnectProviderUseCase(this._oauthRepository, this._userProfileRepository);
+
+  Future<void> call(EPSProvider provider) async {
+    final result = await _oauthRepository.login(provider);
+    if (result != null) {
+      final patientId = result.patientId;
+      final profile = await _userProfileRepository.getUserProfile();
+      if (profile != null) {
+        final updatedProfile = profile.copyWith(
+          isEpsConnected: true,
+          epsPatientId: patientId,
+        );
+        await _userProfileRepository.saveUserProfile(updatedProfile);
+      } else {
+        throw Exception('User profile not found.');
+      }
+    }
+  }
+}

--- a/lib/features/eps_connection/domain/usecases/disconnect_provider_usecase.dart
+++ b/lib/features/eps_connection/domain/usecases/disconnect_provider_usecase.dart
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-FileCopyrightText: 2025 SouthWest AI Labs
+
+import 'package:injectable/injectable.dart';
+import '../repositories/oauth_repository.dart';
+import '../../../user_profile/domain/repositories/user_profile_repository.dart';
+
+@injectable
+class DisconnectProviderUseCase {
+  final OAuthRepository _oauthRepository;
+  final UserProfileRepository _userProfileRepository;
+
+  DisconnectProviderUseCase(this._oauthRepository, this._userProfileRepository);
+
+  Future<void> call(String providerId) async {
+    await _oauthRepository.logout(providerId);
+    final profile = await _userProfileRepository.getUserProfile();
+    if (profile != null) {
+      final providers = await _oauthRepository.getConnectedProviders();
+      if (providers.isEmpty) {
+        final updatedProfile = profile.copyWith(isEpsConnected: false);
+        updatedProfile.epsPatientId = null;
+        await _userProfileRepository.saveUserProfile(updatedProfile);
+      }
+    }
+  }
+}

--- a/lib/features/eps_connection/domain/usecases/get_connections_usecase.dart
+++ b/lib/features/eps_connection/domain/usecases/get_connections_usecase.dart
@@ -1,0 +1,34 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-FileCopyrightText: 2025 SouthWest AI Labs
+
+import 'package:injectable/injectable.dart';
+import '../entities/eps_connection.dart';
+import '../repositories/oauth_repository.dart';
+
+@injectable
+class GetConnectionsUseCase {
+  final OAuthRepository _repository;
+
+  GetConnectionsUseCase(this._repository);
+
+  Future<List<EPSConnection>> call() async {
+    final connectedIds = await _repository.getConnectedProviders();
+    final List<EPSConnection> connections = [];
+
+    for (final id in connectedIds) {
+      final token = await _repository.getToken(id);
+      final provider = await _repository.getProviderDetails(id);
+      final patientId = await _repository.getPatientId(id);
+
+      if (token != null && provider != null) {
+        connections.add(EPSConnection(
+          provider: provider,
+          token: token,
+          patientId: patientId ?? 'Unknown',
+          connectedAt: DateTime.now(),
+        ));
+      }
+    }
+    return connections;
+  }
+}

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1270,10 +1270,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1293,10 +1293,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1938,10 +1938,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/eps_connection/application/eps_connection_cubit_test.dart
+++ b/test/features/eps_connection/application/eps_connection_cubit_test.dart
@@ -2,80 +2,120 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_cubit.dart';
 import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_state.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_connection.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/oauth_token.dart';
-import 'package:orionhealth_health/features/eps_connection/domain/repositories/oauth_repository.dart';
-import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
-import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/connect_provider_usecase.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/disconnect_provider_usecase.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/get_connections_usecase.dart';
 
-class MockOAuthRepository extends Mock implements OAuthRepository {}
-class MockUserProfileRepository extends Mock implements UserProfileRepository {}
+class MockGetConnectionsUseCase extends Mock implements GetConnectionsUseCase {}
+class MockConnectProviderUseCase extends Mock implements ConnectProviderUseCase {}
+class MockDisconnectProviderUseCase extends Mock implements DisconnectProviderUseCase {}
 
 void main() {
   late EpsConnectionCubit cubit;
-  late MockOAuthRepository mockOAuthRepository;
-  late MockUserProfileRepository mockUserProfileRepository;
+  late MockGetConnectionsUseCase mockGetConnectionsUseCase;
+  late MockConnectProviderUseCase mockConnectProviderUseCase;
+  late MockDisconnectProviderUseCase mockDisconnectProviderUseCase;
 
-  final testProfile = UserProfile(
-    name: 'Test User',
-    email: 'test@example.com',
-  );
-
-  final testProvider = EPSProvider(
+  final testProvider = const EPSProvider(
     id: 'test_id',
     name: 'Test EPS',
-    discoveryUrl: 'https://test.com',
-    clientId: 'client',
-    redirectUrl: 'url',
-    scopes: const ['scope'],
+    discoveryUrl: 'D',
+    clientId: 'C',
+    redirectUrl: 'R',
+    scopes: ['S'],
   );
 
-  final testToken = const OAuthToken(accessToken: 'token');
+  final testConnection = EPSConnection(
+    provider: testProvider,
+    token: const OAuthToken(accessToken: 'token'),
+    patientId: 'PT-123',
+    connectedAt: DateTime.now(),
+  );
 
   setUpAll(() {
-    registerFallbackValue(testProfile);
     registerFallbackValue(testProvider);
   });
 
   setUp(() {
-    mockOAuthRepository = MockOAuthRepository();
-    mockUserProfileRepository = MockUserProfileRepository();
+    mockGetConnectionsUseCase = MockGetConnectionsUseCase();
+    mockConnectProviderUseCase = MockConnectProviderUseCase();
+    mockDisconnectProviderUseCase = MockDisconnectProviderUseCase();
 
-    when(() => mockOAuthRepository.getConnectedProviders()).thenAnswer((_) async => []);
+    when(() => mockGetConnectionsUseCase()).thenAnswer((_) async => []);
   });
 
   Future<void> buildCubit() async {
-    cubit = EpsConnectionCubit(mockOAuthRepository, mockUserProfileRepository);
+    cubit = EpsConnectionCubit(
+      mockGetConnectionsUseCase,
+      mockConnectProviderUseCase,
+      mockDisconnectProviderUseCase,
+    );
     await Future.delayed(Duration.zero);
   }
 
   group('EpsConnectionCubit', () {
-    test('loadConnections fetches all details and patient ID', () async {
-      when(() => mockOAuthRepository.getConnectedProviders()).thenAnswer((_) async => ['test_id']);
-      when(() => mockOAuthRepository.getToken('test_id')).thenAnswer((_) async => testToken);
-      when(() => mockOAuthRepository.getProviderDetails('test_id')).thenAnswer((_) async => testProvider);
-      when(() => mockOAuthRepository.getPatientId('test_id')).thenAnswer((_) async => 'PT-123');
+    test('loadConnections emits Loaded state with connections', () async {
+      when(() => mockGetConnectionsUseCase()).thenAnswer((_) async => [testConnection]);
 
       await buildCubit();
 
+      expect(cubit.state, isA<EpsConnectionLoaded>());
       final state = cubit.state as EpsConnectionLoaded;
-      expect(state.connections.length, 1);
-      expect(state.connections.first.patientId, 'PT-123');
-      expect(state.connections.first.provider.name, 'Test EPS');
+      expect(state.connections, [testConnection]);
     });
 
-    test('connect uses patient ID from login result', () async {
-      when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => testProfile);
-      when(() => mockOAuthRepository.login(any())).thenAnswer((_) async => OAuthLoginResult(token: testToken, patientId: 'PT-123'));
-      when(() => mockUserProfileRepository.saveUserProfile(any())).thenAnswer((_) async => {});
-      when(() => mockOAuthRepository.getConnectedProviders()).thenAnswer((_) async => []);
+    test('loadConnections emits Error state on exception', () async {
+      when(() => mockGetConnectionsUseCase()).thenThrow(Exception('Fail'));
+
+      await buildCubit();
+
+      expect(cubit.state, isA<EpsConnectionError>());
+      expect((cubit.state as EpsConnectionError).message, contains('Fail'));
+    });
+
+    test('connect calls usecase and reloads', () async {
+      when(() => mockConnectProviderUseCase(any())).thenAnswer((_) async => {});
+      when(() => mockGetConnectionsUseCase()).thenAnswer((_) async => [testConnection]);
 
       await buildCubit();
       await cubit.connect(testProvider);
 
-      verify(() => mockUserProfileRepository.saveUserProfile(any(
-        that: isA<UserProfile>().having((p) => p.epsPatientId, 'epsPatientId', 'PT-123')
-      ))).called(1);
+      verify(() => mockConnectProviderUseCase(testProvider)).called(1);
+      expect(cubit.state, isA<EpsConnectionLoaded>());
+    });
+
+    test('connect emits Error state on exception', () async {
+      when(() => mockConnectProviderUseCase(any())).thenThrow(Exception('Connect Fail'));
+
+      await buildCubit();
+      await cubit.connect(testProvider);
+
+      expect(cubit.state, isA<EpsConnectionError>());
+      expect((cubit.state as EpsConnectionError).message, contains('Connect Fail'));
+    });
+
+    test('disconnect calls usecase and reloads', () async {
+      when(() => mockDisconnectProviderUseCase(any())).thenAnswer((_) async => {});
+      when(() => mockGetConnectionsUseCase()).thenAnswer((_) async => []);
+
+      await buildCubit();
+      await cubit.disconnect('test_id');
+
+      verify(() => mockDisconnectProviderUseCase('test_id')).called(1);
+      expect(cubit.state, isA<EpsConnectionLoaded>());
+    });
+
+    test('disconnect emits Error state on exception', () async {
+      when(() => mockDisconnectProviderUseCase(any())).thenThrow(Exception('Disconnect Fail'));
+
+      await buildCubit();
+      await cubit.disconnect('test_id');
+
+      expect(cubit.state, isA<EpsConnectionError>());
+      expect((cubit.state as EpsConnectionError).message, contains('Disconnect Fail'));
     });
   });
 }

--- a/test/features/eps_connection/application/eps_connection_state_test.dart
+++ b/test/features/eps_connection/application/eps_connection_state_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_state.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_connection.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/oauth_token.dart';
+
+void main() {
+  group('EpsConnectionState', () {
+    test('EpsConnectionInitial supports equality', () {
+      const state = EpsConnectionInitial();
+      expect(state, const EpsConnectionInitial());
+      expect(state.props, isEmpty);
+    });
+
+    test('EpsConnectionLoading supports equality', () {
+      const state = EpsConnectionLoading();
+      expect(state, const EpsConnectionLoading());
+      expect(state.props, isEmpty);
+    });
+
+    test('EpsConnectionLoaded supports equality', () {
+      final conn = EPSConnection(
+        provider: const EPSProvider(id: '1', name: 'N', discoveryUrl: 'D', clientId: 'C', redirectUrl: 'R', scopes: []),
+        token: const OAuthToken(accessToken: 'A'),
+        patientId: 'P',
+        connectedAt: DateTime(2023),
+      );
+      final state = EpsConnectionLoaded([conn]);
+      expect(state, EpsConnectionLoaded([conn]));
+      expect(state.props, [[conn]]);
+    });
+
+    test('EpsConnectionError supports equality', () {
+      const state = EpsConnectionError('error');
+      expect(state, const EpsConnectionError('error'));
+      expect(state.props, ['error']);
+    });
+  });
+}

--- a/test/features/eps_connection/data/datasources/oauth_local_datasource_test.dart
+++ b/test/features/eps_connection/data/datasources/oauth_local_datasource_test.dart
@@ -23,6 +23,8 @@ void main() {
       await dataSource.saveTokensForProvider('id1', 'acc', 'id', 'ref');
 
       verify(() => mockStorage.write(key: 'oauth_access_token_id1', value: 'acc')).called(1);
+      verify(() => mockStorage.write(key: 'oauth_id_token_id1', value: 'id')).called(1);
+      verify(() => mockStorage.write(key: 'oauth_refresh_token_id1', value: 'ref')).called(1);
       verify(() => mockStorage.write(key: 'connected_providers', value: 'id1')).called(1);
     });
 
@@ -34,6 +36,14 @@ void main() {
       expect(result, ['id1', 'id2']);
     });
 
+    test('getConnectedProviderIds returns empty list if null or empty', () async {
+      when(() => mockStorage.read(key: 'connected_providers')).thenAnswer((_) async => null);
+      expect(await dataSource.getConnectedProviderIds(), isEmpty);
+
+      when(() => mockStorage.read(key: 'connected_providers')).thenAnswer((_) async => '');
+      expect(await dataSource.getConnectedProviderIds(), isEmpty);
+    });
+
     test('clearTokensForProvider removes from storage and list', () async {
       when(() => mockStorage.delete(key: any(named: 'key'))).thenAnswer((_) async => {});
       when(() => mockStorage.read(key: 'connected_providers')).thenAnswer((_) async => 'id1,id2');
@@ -43,7 +53,46 @@ void main() {
       await dataSource.clearTokensForProvider('id1');
 
       verify(() => mockStorage.delete(key: 'oauth_access_token_id1')).called(1);
+      verify(() => mockStorage.delete(key: 'oauth_id_token_id1')).called(1);
+      verify(() => mockStorage.delete(key: 'oauth_refresh_token_id1')).called(1);
+      verify(() => mockStorage.delete(key: 'oauth_provider_data_id1')).called(1);
+      verify(() => mockStorage.delete(key: 'oauth_patient_id_id1')).called(1);
       verify(() => mockStorage.write(key: 'connected_providers', value: 'id2')).called(1);
+    });
+
+    test('getters return values from storage', () async {
+      when(() => mockStorage.read(key: 'oauth_access_token_id1')).thenAnswer((_) async => 'acc');
+      when(() => mockStorage.read(key: 'oauth_id_token_id1')).thenAnswer((_) async => 'id');
+      when(() => mockStorage.read(key: 'oauth_refresh_token_id1')).thenAnswer((_) async => 'ref');
+      when(() => mockStorage.read(key: 'oauth_patient_id_id1')).thenAnswer((_) async => 'pt');
+
+      expect(await dataSource.getAccessToken('id1'), 'acc');
+      expect(await dataSource.getIdToken('id1'), 'id');
+      expect(await dataSource.getRefreshToken('id1'), 'ref');
+      expect(await dataSource.getPatientId('id1'), 'pt');
+    });
+
+    test('savePatientId writes to storage', () async {
+      when(() => mockStorage.write(key: any(named: 'key'), value: any(named: 'value'))).thenAnswer((_) async => {});
+      await dataSource.savePatientId('id1', 'pt');
+      verify(() => mockStorage.write(key: 'oauth_patient_id_id1', value: 'pt')).called(1);
+    });
+
+    test('saveProviderData and getProviderData works with JSON', () async {
+      final data = {'name': 'test'};
+      when(() => mockStorage.write(key: any(named: 'key'), value: any(named: 'value'))).thenAnswer((_) async => {});
+      when(() => mockStorage.read(key: 'oauth_provider_data_id1')).thenAnswer((_) async => '{"name":"test"}');
+
+      await dataSource.saveProviderData('id1', data);
+      verify(() => mockStorage.write(key: 'oauth_provider_data_id1', value: '{"name":"test"}')).called(1);
+
+      final result = await dataSource.getProviderData('id1');
+      expect(result, data);
+    });
+
+    test('getProviderData returns null if missing', () async {
+      when(() => mockStorage.read(key: 'oauth_provider_data_id1')).thenAnswer((_) async => null);
+      expect(await dataSource.getProviderData('id1'), isNull);
     });
   });
 }

--- a/test/features/eps_connection/data/models/oauth_token_dto_test.dart
+++ b/test/features/eps_connection/data/models/oauth_token_dto_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/eps_connection/data/models/oauth_token_dto.dart';
+
+void main() {
+  group('OAuthTokenDto', () {
+    final now = DateTime.now();
+    final dto = OAuthTokenDto(
+      accessToken: 'access',
+      idToken: 'id',
+      refreshToken: 'refresh',
+      expiresAt: now,
+    );
+
+    test('toJson', () {
+      final json = dto.toJson();
+      expect(json['accessToken'], 'access');
+      expect(json['idToken'], 'id');
+      expect(json['refreshToken'], 'refresh');
+      expect(json['expiresAt'], now.toIso8601String());
+    });
+
+    test('fromJson', () {
+      final json = {
+        'accessToken': 'access',
+        'idToken': 'id',
+        'refreshToken': 'refresh',
+        'expiresAt': now.toIso8601String(),
+      };
+      final fromJson = OAuthTokenDto.fromJson(json);
+      expect(fromJson.accessToken, dto.accessToken);
+      expect(fromJson.idToken, dto.idToken);
+      expect(fromJson.refreshToken, dto.refreshToken);
+      expect(fromJson.expiresAt?.toIso8601String(), dto.expiresAt?.toIso8601String());
+    });
+
+    test('toJson handles nulls', () {
+      const dtoNull = OAuthTokenDto();
+      final json = dtoNull.toJson();
+      expect(json, isEmpty);
+    });
+
+    test('fromJson handles nulls', () {
+      final fromJson = OAuthTokenDto.fromJson({});
+      expect(fromJson.accessToken, isNull);
+      expect(fromJson.expiresAt, isNull);
+    });
+  });
+}

--- a/test/features/eps_connection/domain/entities/eps_provider_test.dart
+++ b/test/features/eps_connection/domain/entities/eps_provider_test.dart
@@ -11,6 +11,7 @@ void main() {
         clientId: 'C',
         redirectUrl: 'R',
         scopes: ['S'],
+        type: EPSProviderType.ihce,
       );
       const p2 = EPSProvider(
         id: '1',
@@ -19,8 +20,31 @@ void main() {
         clientId: 'C',
         redirectUrl: 'R',
         scopes: ['S'],
+        type: EPSProviderType.ihce,
       );
       expect(p1, p2);
+    });
+
+    test('props contain all fields', () {
+      const p = EPSProvider(
+        id: '1',
+        name: 'N',
+        discoveryUrl: 'D',
+        clientId: 'C',
+        redirectUrl: 'R',
+        scopes: ['S'],
+        type: EPSProviderType.fhir,
+      );
+      expect(p.props, ['1', 'N', 'D', 'C', 'R', ['S'], EPSProviderType.fhir]);
+    });
+  });
+
+  group('EPSProviderType', () {
+    test('enum values', () {
+      expect(EPSProviderType.values.length, 3);
+      expect(EPSProviderType.ihce.name, 'ihce');
+      expect(EPSProviderType.openmrs.name, 'openmrs');
+      expect(EPSProviderType.fhir.name, 'fhir');
     });
   });
 }

--- a/test/features/eps_connection/domain/usecases/connect_provider_usecase_test.dart
+++ b/test/features/eps_connection/domain/usecases/connect_provider_usecase_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/oauth_token.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/repositories/oauth_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/connect_provider_usecase.dart';
+import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
+import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
+
+class MockOAuthRepository extends Mock implements OAuthRepository {}
+class MockUserProfileRepository extends Mock implements UserProfileRepository {}
+
+void main() {
+  late ConnectProviderUseCase useCase;
+  late MockOAuthRepository mockOAuthRepository;
+  late MockUserProfileRepository mockUserProfileRepository;
+
+  final testProvider = const EPSProvider(
+    id: 'test_id',
+    name: 'Test EPS',
+    discoveryUrl: 'D',
+    clientId: 'C',
+    redirectUrl: 'R',
+    scopes: ['S'],
+  );
+  final testProfile = UserProfile(name: 'Test', email: 'test@test.com');
+
+  setUpAll(() {
+    registerFallbackValue(testProvider);
+    registerFallbackValue(testProfile);
+  });
+
+  setUp(() {
+    mockOAuthRepository = MockOAuthRepository();
+    mockUserProfileRepository = MockUserProfileRepository();
+    useCase = ConnectProviderUseCase(mockOAuthRepository, mockUserProfileRepository);
+  });
+
+  test('should login and update user profile on success', () async {
+    when(() => mockOAuthRepository.login(any())).thenAnswer((_) async => OAuthLoginResult(
+      token: const OAuthToken(accessToken: 'A'),
+      patientId: 'PT-123',
+    ));
+    when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => testProfile);
+    when(() => mockUserProfileRepository.saveUserProfile(any())).thenAnswer((_) async => {});
+
+    await useCase(testProvider);
+
+    verify(() => mockOAuthRepository.login(testProvider)).called(1);
+    verify(() => mockUserProfileRepository.getUserProfile()).called(1);
+    verify(() => mockUserProfileRepository.saveUserProfile(any(
+      that: predicate<UserProfile>((p) => p.epsPatientId == 'PT-123' && p.isEpsConnected == true),
+    ))).called(1);
+  });
+
+  test('should throw exception if profile not found', () async {
+    when(() => mockOAuthRepository.login(any())).thenAnswer((_) async => OAuthLoginResult(
+      token: const OAuthToken(accessToken: 'A'),
+      patientId: 'PT-123',
+    ));
+    when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => null);
+
+    expect(() => useCase(testProvider), throwsA(isA<Exception>()));
+  });
+
+  test('should do nothing if login returns null', () async {
+    when(() => mockOAuthRepository.login(any())).thenAnswer((_) async => null);
+
+    await useCase(testProvider);
+
+    verify(() => mockOAuthRepository.login(testProvider)).called(1);
+    verifyNever(() => mockUserProfileRepository.getUserProfile());
+  });
+}

--- a/test/features/eps_connection/domain/usecases/disconnect_provider_usecase_test.dart
+++ b/test/features/eps_connection/domain/usecases/disconnect_provider_usecase_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/repositories/oauth_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/disconnect_provider_usecase.dart';
+import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
+import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
+
+class MockOAuthRepository extends Mock implements OAuthRepository {}
+class MockUserProfileRepository extends Mock implements UserProfileRepository {}
+
+void main() {
+  late DisconnectProviderUseCase useCase;
+  late MockOAuthRepository mockOAuthRepository;
+  late MockUserProfileRepository mockUserProfileRepository;
+
+  final testProfile = UserProfile(
+    name: 'Test',
+    email: 'test@test.com',
+    isEpsConnected: true,
+    epsPatientId: 'PT-123',
+  );
+
+  setUpAll(() {
+    registerFallbackValue(testProfile);
+  });
+
+  setUp(() {
+    mockOAuthRepository = MockOAuthRepository();
+    mockUserProfileRepository = MockUserProfileRepository();
+    useCase = DisconnectProviderUseCase(mockOAuthRepository, mockUserProfileRepository);
+  });
+
+  test('should logout and update profile if no connections left', () async {
+    when(() => mockOAuthRepository.logout(any())).thenAnswer((_) async => {});
+    when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => testProfile);
+    when(() => mockOAuthRepository.getConnectedProviders()).thenAnswer((_) async => []);
+    when(() => mockUserProfileRepository.saveUserProfile(any())).thenAnswer((_) async => {});
+
+    await useCase('test_id');
+
+    verify(() => mockOAuthRepository.logout('test_id')).called(1);
+    verify(() => mockUserProfileRepository.saveUserProfile(any(
+      that: isA<UserProfile>()
+          .having((p) => p.isEpsConnected, 'isEpsConnected', false)
+          .having((p) => p.epsPatientId, 'epsPatientId', isNull),
+    ))).called(1);
+  });
+
+  test('should logout but NOT update profile if connections still exist', () async {
+    when(() => mockOAuthRepository.logout(any())).thenAnswer((_) async => {});
+    when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => testProfile);
+    when(() => mockOAuthRepository.getConnectedProviders()).thenAnswer((_) async => ['other_id']);
+
+    await useCase('test_id');
+
+    verify(() => mockOAuthRepository.logout('test_id')).called(1);
+    verifyNever(() => mockUserProfileRepository.saveUserProfile(any()));
+  });
+
+  test('should handle missing profile gracefully', () async {
+    when(() => mockOAuthRepository.logout(any())).thenAnswer((_) async => {});
+    when(() => mockUserProfileRepository.getUserProfile()).thenAnswer((_) async => null);
+
+    await useCase('test_id');
+
+    verify(() => mockOAuthRepository.logout('test_id')).called(1);
+    verifyNever(() => mockOAuthRepository.getConnectedProviders());
+  });
+}

--- a/test/features/eps_connection/domain/usecases/get_connections_usecase_test.dart
+++ b/test/features/eps_connection/domain/usecases/get_connections_usecase_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_connection.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/oauth_token.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/repositories/oauth_repository.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/get_connections_usecase.dart';
+
+class MockOAuthRepository extends Mock implements OAuthRepository {}
+
+void main() {
+  late GetConnectionsUseCase useCase;
+  late MockOAuthRepository mockRepository;
+
+  final testProvider = const EPSProvider(
+    id: 'test_id',
+    name: 'Test EPS',
+    discoveryUrl: 'D',
+    clientId: 'C',
+    redirectUrl: 'R',
+    scopes: ['S'],
+  );
+  final testToken = const OAuthToken(accessToken: 'token');
+
+  setUp(() {
+    mockRepository = MockOAuthRepository();
+    useCase = GetConnectionsUseCase(mockRepository);
+  });
+
+  test('should return list of EPSConnection from repository', () async {
+    when(() => mockRepository.getConnectedProviders()).thenAnswer((_) async => ['test_id']);
+    when(() => mockRepository.getToken('test_id')).thenAnswer((_) async => testToken);
+    when(() => mockRepository.getProviderDetails('test_id')).thenAnswer((_) async => testProvider);
+    when(() => mockRepository.getPatientId('test_id')).thenAnswer((_) async => 'PT-123');
+
+    final result = await useCase();
+
+    expect(result.length, 1);
+    expect(result.first.provider, testProvider);
+    expect(result.first.token, testToken);
+    expect(result.first.patientId, 'PT-123');
+    verify(() => mockRepository.getConnectedProviders()).called(1);
+    verify(() => mockRepository.getToken('test_id')).called(1);
+    verify(() => mockRepository.getProviderDetails('test_id')).called(1);
+    verify(() => mockRepository.getPatientId('test_id')).called(1);
+  });
+
+  test('should skip if token or provider details are missing', () async {
+    when(() => mockRepository.getConnectedProviders()).thenAnswer((_) async => ['test_id']);
+    when(() => mockRepository.getToken('test_id')).thenAnswer((_) async => null);
+    when(() => mockRepository.getProviderDetails('test_id')).thenAnswer((_) async => null);
+    when(() => mockRepository.getPatientId('test_id')).thenAnswer((_) async => null);
+
+    final result = await useCase();
+
+    expect(result, isEmpty);
+  });
+
+  test('should use "Unknown" as patientId if missing', () async {
+    when(() => mockRepository.getConnectedProviders()).thenAnswer((_) async => ['test_id']);
+    when(() => mockRepository.getToken('test_id')).thenAnswer((_) async => testToken);
+    when(() => mockRepository.getProviderDetails('test_id')).thenAnswer((_) async => testProvider);
+    when(() => mockRepository.getPatientId('test_id')).thenAnswer((_) async => null);
+
+    final result = await useCase();
+
+    expect(result.first.patientId, 'Unknown');
+  });
+}

--- a/test/features/eps_connection/infrastructure/oauth_repository_test.dart
+++ b/test/features/eps_connection/infrastructure/oauth_repository_test.dart
@@ -1,0 +1,184 @@
+import 'package:flutter_appauth/flutter_appauth.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/eps_connection/data/datasources/oauth_local_datasource.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+import 'package:orionhealth_health/features/eps_connection/infrastructure/oauth_repository.dart';
+
+class MockOAuthLocalDataSource extends Mock implements OAuthLocalDataSource {}
+class MockFlutterAppAuth extends Mock implements FlutterAppAuth {}
+
+class FakeAuthorizationTokenRequest extends Fake implements AuthorizationTokenRequest {}
+class FakeTokenRequest extends Fake implements TokenRequest {}
+
+void main() {
+  late OAuthRepositoryImpl repository;
+  late MockOAuthLocalDataSource mockLocalDataSource;
+  late MockFlutterAppAuth mockAppAuth;
+
+  final testProvider = const EPSProvider(
+    id: 'test_id',
+    name: 'Test EPS',
+    discoveryUrl: 'D',
+    clientId: 'C',
+    redirectUrl: 'R',
+    scopes: ['S'],
+    type: EPSProviderType.ihce,
+  );
+
+  setUpAll(() {
+    registerFallbackValue(FakeAuthorizationTokenRequest());
+    registerFallbackValue(FakeTokenRequest());
+  });
+
+  setUp(() {
+    mockLocalDataSource = MockOAuthLocalDataSource();
+    mockAppAuth = MockFlutterAppAuth();
+    repository = OAuthRepositoryImpl(mockLocalDataSource, appAuth: mockAppAuth);
+  });
+
+  group('OAuthRepositoryImpl', () {
+    test('login success', () async {
+      final authResponse = AuthorizationTokenResponse(
+        'access',
+        'refresh',
+        DateTime.now().add(const Duration(hours: 1)),
+        'id',
+        'token_type',
+        ['S'],
+        {'patient': 'PT-123'},
+        {},
+      );
+
+      when(() => mockAppAuth.authorizeAndExchangeCode(any())).thenAnswer((_) async => authResponse);
+      when(() => mockLocalDataSource.saveTokensForProvider(any(), any(), any(), any())).thenAnswer((_) async => {});
+      when(() => mockLocalDataSource.saveProviderData(any(), any())).thenAnswer((_) async => {});
+      when(() => mockLocalDataSource.savePatientId(any(), any())).thenAnswer((_) async => {});
+      when(() => mockLocalDataSource.getConnectedProviderIds()).thenAnswer((_) async => []);
+
+      final result = await repository.login(testProvider);
+
+      expect(result?.patientId, 'PT-123');
+      expect(result?.token.accessToken, 'access');
+      verify(() => mockLocalDataSource.saveTokensForProvider('test_id', 'access', 'id', 'refresh')).called(1);
+      verify(() => mockLocalDataSource.saveProviderData('test_id', any())).called(1);
+      verify(() => mockLocalDataSource.savePatientId('test_id', 'PT-123')).called(1);
+    });
+
+    test('login returns null on exception', () async {
+      when(() => mockAppAuth.authorizeAndExchangeCode(any())).thenThrow(Exception('AppAuth Fail'));
+
+      final result = await repository.login(testProvider);
+
+      expect(result, isNull);
+    });
+
+    test('logout clears local data', () async {
+      when(() => mockLocalDataSource.clearTokensForProvider(any())).thenAnswer((_) async => {});
+
+      await repository.logout('test_id');
+
+      verify(() => mockLocalDataSource.clearTokensForProvider('test_id')).called(1);
+    });
+
+    test('getToken returns OAuthToken if access token exists', () async {
+      when(() => mockLocalDataSource.getAccessToken('test_id')).thenAnswer((_) async => 'access');
+      when(() => mockLocalDataSource.getIdToken('test_id')).thenAnswer((_) async => 'id');
+      when(() => mockLocalDataSource.getRefreshToken('test_id')).thenAnswer((_) async => 'refresh');
+
+      final token = await repository.getToken('test_id');
+
+      expect(token?.accessToken, 'access');
+      expect(token?.idToken, 'id');
+      expect(token?.refreshToken, 'refresh');
+    });
+
+    test('getToken returns null if access token is missing', () async {
+      when(() => mockLocalDataSource.getAccessToken('test_id')).thenAnswer((_) async => null);
+      when(() => mockLocalDataSource.getIdToken('test_id')).thenAnswer((_) async => null);
+      when(() => mockLocalDataSource.getRefreshToken('test_id')).thenAnswer((_) async => null);
+
+      final token = await repository.getToken('test_id');
+
+      expect(token, isNull);
+    });
+
+    test('getPatientId returns from local data source', () async {
+      when(() => mockLocalDataSource.getPatientId('test_id')).thenAnswer((_) async => 'PT-123');
+
+      final patientId = await repository.getPatientId('test_id');
+
+      expect(patientId, 'PT-123');
+    });
+
+    test('getProviderDetails returns EPSProvider from local data source', () async {
+      final providerData = {
+        'id': 'test_id',
+        'name': 'Test EPS',
+        'discoveryUrl': 'D',
+        'clientId': 'C',
+        'redirectUrl': 'R',
+        'scopes': ['S'],
+        'type': 'ihce',
+      };
+      when(() => mockLocalDataSource.getProviderData('test_id')).thenAnswer((_) async => providerData);
+
+      final provider = await repository.getProviderDetails('test_id');
+
+      expect(provider, testProvider);
+    });
+
+    test('getProviderDetails returns null if no data', () async {
+      when(() => mockLocalDataSource.getProviderData('test_id')).thenAnswer((_) async => null);
+
+      final provider = await repository.getProviderDetails('test_id');
+
+      expect(provider, isNull);
+    });
+
+    test('refreshToken success', () async {
+      final tokenResponse = TokenResponse(
+        'new_access',
+        'new_refresh',
+        DateTime.now().add(const Duration(hours: 1)),
+        'new_id',
+        'token_type',
+        ['S'],
+        {},
+      );
+      when(() => mockLocalDataSource.getRefreshToken('test_id')).thenAnswer((_) async => 'old_refresh');
+      when(() => mockAppAuth.token(any())).thenAnswer((_) async => tokenResponse);
+      when(() => mockLocalDataSource.saveTokensForProvider(any(), any(), any(), any())).thenAnswer((_) async => {});
+
+      final token = await repository.refreshToken(testProvider);
+
+      expect(token?.accessToken, 'new_access');
+      verify(() => mockLocalDataSource.saveTokensForProvider('test_id', 'new_access', 'new_id', 'new_refresh')).called(1);
+    });
+
+    test('refreshToken returns null if no old refresh token', () async {
+      when(() => mockLocalDataSource.getRefreshToken('test_id')).thenAnswer((_) async => null);
+
+      final token = await repository.refreshToken(testProvider);
+
+      expect(token, isNull);
+    });
+
+    test('refreshToken returns null on exception', () async {
+      when(() => mockLocalDataSource.getRefreshToken('test_id')).thenAnswer((_) async => 'old_refresh');
+      when(() => mockAppAuth.token(any())).thenThrow(Exception('Fail'));
+
+      final token = await repository.refreshToken(testProvider);
+
+      expect(token, isNull);
+    });
+
+    test('getConnectedProviders returns from local data source', () async {
+      when(() => mockLocalDataSource.getConnectedProviderIds()).thenAnswer((_) async => ['test_id']);
+
+      final providers = await repository.getConnectedProviders();
+
+      expect(providers, ['test_id']);
+    });
+  });
+}

--- a/test/features/eps_connection/presentation/eps_connect_button_test.dart
+++ b/test/features/eps_connection/presentation/eps_connect_button_test.dart
@@ -8,6 +8,7 @@ import 'package:orionhealth_health/features/eps_connection/presentation/eps_conn
 import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_connection.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/oauth_token.dart';
+import 'package:orionhealth_health/features/eps_connection/presentation/pages/eps_connection_page.dart';
 
 class MockEpsConnectionCubit extends Mock implements EpsConnectionCubit {}
 
@@ -17,6 +18,17 @@ void main() {
   setUp(() {
     mockCubit = MockEpsConnectionCubit();
   });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: Scaffold(
+        body: BlocProvider<EpsConnectionCubit>.value(
+          value: mockCubit,
+          child: const EpsConnectButton(),
+        ),
+      ),
+    );
+  }
 
   testWidgets('EpsConnectButton shows connected state', (tester) async {
     final connection = EPSConnection(
@@ -28,37 +40,47 @@ void main() {
     when(() => mockCubit.state).thenReturn(EpsConnectionLoaded([connection]));
     when(() => mockCubit.stream).thenAnswer((_) => Stream.value(EpsConnectionLoaded([connection])));
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: BlocProvider<EpsConnectionCubit>.value(
-            value: mockCubit,
-            child: const EpsConnectButton(),
-          ),
-        ),
-      ),
-    );
+    await tester.pumpWidget(createWidgetUnderTest());
 
     expect(find.text('Conectado con IHCE'), findsOneWidget);
     expect(find.text('ID Paciente: P1'), findsOneWidget);
     expect(find.text('Ver Detalles'), findsOneWidget);
+
+    await tester.tap(find.text('Ver Detalles'));
+    await tester.pumpAndSettle();
+    expect(find.byType(EpsConnectionPage), findsOneWidget);
   });
 
   testWidgets('EpsConnectButton shows disconnected state', (tester) async {
     when(() => mockCubit.state).thenReturn(const EpsConnectionLoaded([]));
     when(() => mockCubit.stream).thenAnswer((_) => Stream.value(const EpsConnectionLoaded([])));
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: Scaffold(
-          body: BlocProvider<EpsConnectionCubit>.value(
-            value: mockCubit,
-            child: const EpsConnectButton(),
-          ),
-        ),
-      ),
-    );
+    await tester.pumpWidget(createWidgetUnderTest());
 
     expect(find.text('Conectar con mi EPS'), findsOneWidget);
+
+    await tester.tap(find.text('Conectar con mi EPS'));
+    await tester.pumpAndSettle();
+    expect(find.byType(EpsConnectionPage), findsOneWidget);
+  });
+
+  testWidgets('EpsConnectButton shows loading state', (tester) async {
+    when(() => mockCubit.state).thenReturn(const EpsConnectionLoading());
+    when(() => mockCubit.stream).thenAnswer((_) => Stream.value(const EpsConnectionLoading()));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('EpsConnectButton shows error SnackBar', (tester) async {
+    when(() => mockCubit.state).thenReturn(const EpsConnectionInitial());
+    when(() => mockCubit.stream).thenAnswer((_) => Stream.value(const EpsConnectionError('Failed')));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.text('Failed'), findsOneWidget);
   });
 }

--- a/test/features/eps_connection/presentation/pages/eps_connection_page_test.dart
+++ b/test/features/eps_connection/presentation/pages/eps_connection_page_test.dart
@@ -4,10 +4,10 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_cubit.dart';
 import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_state.dart';
+import 'package:orionhealth_health/features/eps_connection/presentation/pages/eps_connection_page.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_connection.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/oauth_token.dart';
-import 'package:orionhealth_health/features/eps_connection/presentation/pages/eps_connection_page.dart';
 
 class MockEpsConnectionCubit extends Mock implements EpsConnectionCubit {}
 
@@ -18,18 +18,20 @@ void main() {
     mockCubit = MockEpsConnectionCubit();
   });
 
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: BlocProvider<EpsConnectionCubit>.value(
+        value: mockCubit,
+        child: const EpsConnectionPage(),
+      ),
+    );
+  }
+
   testWidgets('EpsConnectionPage shows loading indicator when state is Loading', (tester) async {
     when(() => mockCubit.state).thenReturn(const EpsConnectionLoading());
     when(() => mockCubit.stream).thenAnswer((_) => Stream.value(const EpsConnectionLoading()));
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: BlocProvider<EpsConnectionCubit>.value(
-          value: mockCubit,
-          child: const EpsConnectionPage(),
-        ),
-      ),
-    );
+    await tester.pumpWidget(createWidgetUnderTest());
 
     expect(find.byType(CircularProgressIndicator), findsOneWidget);
   });
@@ -38,20 +40,13 @@ void main() {
     when(() => mockCubit.state).thenReturn(const EpsConnectionLoaded([]));
     when(() => mockCubit.stream).thenAnswer((_) => Stream.value(const EpsConnectionLoaded([])));
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: BlocProvider<EpsConnectionCubit>.value(
-          value: mockCubit,
-          child: const EpsConnectionPage(),
-        ),
-      ),
-    );
+    await tester.pumpWidget(createWidgetUnderTest());
 
     expect(find.text('No EPS providers connected'), findsOneWidget);
     expect(find.text('Connect via QR Code'), findsOneWidget);
   });
 
-  testWidgets('EpsConnectionPage shows connections list', (tester) async {
+  testWidgets('EpsConnectionPage shows connections list and handles disconnect', (tester) async {
     final connection = EPSConnection(
       provider: const EPSProvider(id: '1', name: 'Provider 1', discoveryUrl: 'D', clientId: 'C', redirectUrl: 'R', scopes: []),
       token: const OAuthToken(accessToken: 'A'),
@@ -60,17 +55,39 @@ void main() {
     );
     when(() => mockCubit.state).thenReturn(EpsConnectionLoaded([connection]));
     when(() => mockCubit.stream).thenAnswer((_) => Stream.value(EpsConnectionLoaded([connection])));
+    when(() => mockCubit.disconnect(any())).thenAnswer((_) async => {});
 
-    await tester.pumpWidget(
-      MaterialApp(
-        home: BlocProvider<EpsConnectionCubit>.value(
-          value: mockCubit,
-          child: const EpsConnectionPage(),
-        ),
-      ),
-    );
+    await tester.pumpWidget(createWidgetUnderTest());
 
     expect(find.text('Provider 1'), findsOneWidget);
-    expect(find.textContaining('Patient ID: P1'), findsOneWidget);
+
+    // Tap disconnect in the card
+    await tester.tap(find.byIcon(Icons.link_off));
+    await tester.pump();
+
+    verify(() => mockCubit.disconnect('1')).called(1);
+  });
+
+  testWidgets('EpsConnectionPage shows error SnackBar', (tester) async {
+    when(() => mockCubit.state).thenReturn(const EpsConnectionInitial());
+    when(() => mockCubit.stream).thenAnswer((_) => Stream.value(const EpsConnectionError('Failed to load')));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump(); // trigger listener
+
+    expect(find.byType(SnackBar), findsOneWidget);
+    expect(find.text('Failed to load'), findsOneWidget);
+  });
+
+  testWidgets('Connect via QR Code tap shows SnackBar', (tester) async {
+    when(() => mockCubit.state).thenReturn(const EpsConnectionLoaded([]));
+    when(() => mockCubit.stream).thenAnswer((_) => Stream.value(const EpsConnectionLoaded([])));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    await tester.tap(find.text('Connect via QR Code'));
+    await tester.pump();
+
+    expect(find.text('QR scanner coming soon'), findsOneWidget);
   });
 }


### PR DESCRIPTION
The eps_connection feature was at 95% coverage. To reach 100% and follow project standards, I introduced a UseCase layer in the domain, refactored the Cubit to use these UseCases, and added missing tests across all layers (Domain, Infrastructure, Application, and Presentation). I also fixed a bug found during testing where the patient ID was not being cleared upon disconnection.

Fixes #650

---
*PR created automatically by Jules for task [1050320267386444567](https://jules.google.com/task/1050320267386444567) started by @iberi22*