### PR TITLE
Add unit tests for health_record domain models and repository

### DIFF
--- a/test/features/health_record/domain/entities/timeline_entry_test.dart
+++ b/test/features/health_record/domain/entities/timeline_entry_test.dart
@@ -1,0 +1,71 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/timeline_entry.dart';
+
+void main() {
+  group('TimelineEntry', () {
+    final testDate = DateTime(2025, 1, 1);
+
+    test('should create TimelineEntry with provided values', () {
+      final entry = TimelineEntry(
+        id: '1',
+        title: 'Lab Result',
+        description: 'Blood test',
+        date: testDate,
+        type: TimelineEntryType.labResult,
+        metadata: const {'key': 'value'},
+      );
+
+      expect(entry.id, '1');
+      expect(entry.title, 'Lab Result');
+      expect(entry.description, 'Blood test');
+      expect(entry.date, testDate);
+      expect(entry.type, TimelineEntryType.labResult);
+      expect(entry.metadata, const {'key': 'value'});
+    });
+
+    test('should support value equality', () {
+      final entry1 = TimelineEntry(
+        id: '1',
+        title: 'Lab Result',
+        date: testDate,
+        type: TimelineEntryType.labResult,
+      );
+      final entry2 = TimelineEntry(
+        id: '1',
+        title: 'Lab Result',
+        date: testDate,
+        type: TimelineEntryType.labResult,
+      );
+      final entry3 = TimelineEntry(
+        id: '2',
+        title: 'Lab Result',
+        date: testDate,
+        type: TimelineEntryType.labResult,
+      );
+
+      expect(entry1, equals(entry2));
+      expect(entry1, isNot(equals(entry3)));
+      expect(entry1.hashCode, equals(entry2.hashCode));
+    });
+
+    test('should have correct props', () {
+      final entry = TimelineEntry(
+        id: '1',
+        title: 'Lab Result',
+        description: 'Blood test',
+        date: testDate,
+        type: TimelineEntryType.labResult,
+        metadata: const {'key': 'value'},
+      );
+
+      expect(entry.props, [
+        '1',
+        'Lab Result',
+        'Blood test',
+        testDate,
+        TimelineEntryType.labResult,
+        {'key': 'value'},
+      ]);
+    });
+  });
+}

--- a/test/features/health_record/infrastructure/health_record_repository_test.dart
+++ b/test/features/health_record/infrastructure/health_record_repository_test.dart
@@ -12,7 +12,7 @@ void main() {
   late String testDir;
 
   setUpAll(() async {
-    testDir = p.join(Directory.current.path, 'test_db_health_records');
+    testDir = p.join(Directory.systemTemp.path, 'test_db_health_records');
     await Directory(testDir).create(recursive: true);
 
     await Isar.initializeIsarCore(download: true);
@@ -34,45 +34,63 @@ void main() {
     await isar.writeTxn(() => isar.medicalRecords.clear());
   });
 
-  test('Should save and retrieve a health record', () async {
-    final attachment = MedicalAttachment(
-      localPath: 'test.pdf',
-      mimeType: 'application/pdf',
-      extractedText: 'Extracted text content',
-    );
+  group('HealthRecordRepositoryImpl', () {
+    test('Should save and retrieve a health record', () async {
+      final attachment = MedicalAttachment(
+        localPath: 'test.pdf',
+        mimeType: 'application/pdf',
+        extractedText: 'Extracted text content',
+      );
 
-    final record = MedicalRecord(
-      date: DateTime.now(),
-      type: RecordType.labResult,
-      summary: 'Test summary',
-      attachments: [attachment],
-    );
+      final record = MedicalRecord(
+        date: DateTime(2025, 1, 1),
+        type: RecordType.labResult,
+        summary: 'Test summary',
+        attachments: [attachment],
+      );
 
-    await repository.saveRecord(record);
+      await repository.saveRecord(record);
 
-    final records = await repository.getAllRecords();
-    expect(records.length, 1);
-    expect(records.first.summary, 'Test summary');
-    expect(records.first.type, RecordType.labResult);
-    expect(records.first.attachments.length, 1);
-    expect(records.first.attachments.first.extractedText, 'Extracted text content');
-  });
+      final records = await repository.getAllRecords();
+      expect(records.length, 1);
+      expect(records.first.summary, 'Test summary');
+      expect(records.first.type, RecordType.labResult);
+      expect(records.first.attachments.length, 1);
+      expect(records.first.attachments.first.extractedText, 'Extracted text content');
+    });
 
-  test('Should return multiple records sorted by Isar (default)', () async {
-    final record1 = MedicalRecord(summary: 'Record 1');
-    final record2 = MedicalRecord(summary: 'Record 2');
+    test('Should overwrite existing record when saving with same ID', () async {
+      final record = MedicalRecord(summary: 'Original');
+      await repository.saveRecord(record);
 
-    await repository.saveRecord(record1);
-    await repository.saveRecord(record2);
+      final savedRecords = await repository.getAllRecords();
+      final id = savedRecords.first.id;
 
-    final records = await repository.getAllRecords();
-    expect(records.length, 2);
-    final summaries = records.map((r) => r.summary).toList();
-    expect(summaries, containsAll(['Record 1', 'Record 2']));
-  });
+      final updatedRecord = MedicalRecord(summary: 'Updated')..id = id;
+      await repository.saveRecord(updatedRecord);
 
-  test('Should handle empty records', () async {
-    final records = await repository.getAllRecords();
-    expect(records, isEmpty);
+      final finalRecords = await repository.getAllRecords();
+      expect(finalRecords.length, 1);
+      expect(finalRecords.first.summary, 'Updated');
+      expect(finalRecords.first.id, id);
+    });
+
+    test('Should return multiple records', () async {
+      final record1 = MedicalRecord(summary: 'Record 1');
+      final record2 = MedicalRecord(summary: 'Record 2');
+
+      await repository.saveRecord(record1);
+      await repository.saveRecord(record2);
+
+      final records = await repository.getAllRecords();
+      expect(records.length, 2);
+      final summaries = records.map((r) => r.summary).toList();
+      expect(summaries, containsAll(['Record 1', 'Record 2']));
+    });
+
+    test('Should return an empty list when no records exist', () async {
+      final records = await repository.getAllRecords();
+      expect(records, isEmpty);
+    });
   });
 }


### PR DESCRIPTION
This PR adds unit tests for the `health_record` feature to improve coverage.
- Added `test/features/health_record/domain/entities/timeline_entry_test.dart` to cover the `TimelineEntry` model.
- Updated `test/features/health_record/infrastructure/health_record_repository_test.dart` to include specific test cases for `saveRecord` (overwriting records) and `getAllRecords` (multiple records and empty database).
- Improved repository test isolation by using `Directory.systemTemp` for the Isar database.

Fixes #660

---
*PR created automatically by Jules for task [15882568014670275979](https://jules.google.com/task/15882568014670275979) started by @iberi22*