### PR TITLE
Add unit tests for meditation domain models and session tracking

### DIFF
--- a/test/features/meditation/application/meditation_cubit_test.dart
+++ b/test/features/meditation/application/meditation_cubit_test.dart
@@ -1,0 +1,362 @@
+import 'dart:async';
+import 'package:fake_async/fake_async.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/core/services/audio/audio_player_service.dart';
+import 'package:orionhealth_health/features/meditation/application/meditation_cubit.dart';
+import 'package:orionhealth_health/features/meditation/application/meditation_state.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_progress.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_script.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_session.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/complete_session_usecase.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/get_progress_usecase.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/recommend_script_usecase.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/start_session_usecase.dart';
+
+class MockRecommendScriptUseCase extends Mock implements RecommendScriptUseCase {}
+
+class MockStartSessionUseCase extends Mock implements StartSessionUseCase {}
+
+class MockCompleteSessionUseCase extends Mock implements CompleteSessionUseCase {}
+
+class MockGetProgressUseCase extends Mock implements GetProgressUseCase {}
+
+class MockAudioService extends Mock implements AudioService {}
+
+class FakeMeditationScript extends Fake implements MeditationScript {}
+
+class FakeMeditationSession extends Fake implements MeditationSession {}
+
+void main() {
+  late MeditationCubit cubit;
+  late MockRecommendScriptUseCase mockRecommendScriptUseCase;
+  late MockStartSessionUseCase mockStartSessionUseCase;
+  late MockCompleteSessionUseCase mockCompleteSessionUseCase;
+  late MockGetProgressUseCase mockGetProgressUseCase;
+  late MockAudioService mockAudioService;
+
+  setUpAll(() {
+    registerFallbackValue(FakeMeditationScript());
+    registerFallbackValue(FakeMeditationSession());
+  });
+
+  setUp(() {
+    mockRecommendScriptUseCase = MockRecommendScriptUseCase();
+    mockStartSessionUseCase = MockStartSessionUseCase();
+    mockCompleteSessionUseCase = MockCompleteSessionUseCase();
+    mockGetProgressUseCase = MockGetProgressUseCase();
+    mockAudioService = MockAudioService();
+    when(() => mockAudioService.stopAll()).thenAnswer((_) async => {});
+
+    cubit = MeditationCubit(
+      mockRecommendScriptUseCase,
+      mockStartSessionUseCase,
+      mockCompleteSessionUseCase,
+      mockGetProgressUseCase,
+      mockAudioService,
+    );
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  const tScript = MeditationScript(
+    id: '1',
+    title: 'Calm',
+    category: MeditationCategory.calm,
+    durationMinutes: 5,
+    steps: ['Step 1', 'Step 2'],
+  );
+
+  const tProgress = MeditationProgress(totalSessions: 1);
+
+  final tSession = MeditationSession(
+    id: 's1',
+    scriptId: '1',
+    category: MeditationCategory.calm,
+    startedAt: DateTime(2025, 1, 1),
+  );
+
+  group('initialize', () {
+    test('should emit [loading, idle] when successful', () async {
+      when(() => mockRecommendScriptUseCase()).thenAnswer((_) async => tScript);
+      when(() => mockGetProgressUseCase()).thenAnswer((_) async => tProgress);
+      when(() => mockAudioService.initialize()).thenAnswer((_) async => {});
+
+      final expected = [
+        const MeditationState(status: MeditationStatus.loading),
+        MeditationState(
+          status: MeditationStatus.idle,
+          script: tScript,
+          steps: tScript.steps,
+          progress: tProgress,
+        ),
+      ];
+
+      expectLater(cubit.stream, emitsInOrder(expected));
+
+      await cubit.initialize();
+    });
+
+    test('should emit [loading, error] when fails', () async {
+      when(() => mockRecommendScriptUseCase()).thenThrow(Exception('error'));
+
+      final expected = [
+        const MeditationState(status: MeditationStatus.loading),
+        const MeditationState(
+          status: MeditationStatus.error,
+          error: 'Exception: error',
+        ),
+      ];
+
+      expectLater(cubit.stream, emitsInOrder(expected));
+
+      await cubit.initialize();
+    });
+  });
+
+  group('startMeditation and timer', () {
+    test('should emit [playing] and increment elapsedSeconds over time', () {
+      fakeAsync((async) {
+        when(() => mockStartSessionUseCase(any())).thenAnswer((_) async => tSession);
+        when(() => mockAudioService.speakText(any())).thenAnswer((_) async => {});
+
+        // Set initial state
+        when(() => mockRecommendScriptUseCase()).thenAnswer((_) async => tScript);
+        when(() => mockGetProgressUseCase()).thenAnswer((_) async => tProgress);
+        when(() => mockAudioService.initialize()).thenAnswer((_) async => {});
+        cubit.initialize();
+        async.flushMicrotasks();
+
+        cubit.startMeditation();
+        async.flushMicrotasks();
+
+        expect(cubit.state.status, MeditationStatus.playing);
+        expect(cubit.state.elapsedSeconds, 0);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(cubit.state.elapsedSeconds, 1);
+
+        async.elapse(const Duration(seconds: 43));
+        expect(cubit.state.elapsedSeconds, 44);
+        expect(cubit.state.currentStep, 0);
+
+        // At 45 seconds it should auto-advance
+        async.elapse(const Duration(seconds: 1));
+        expect(cubit.state.elapsedSeconds, 45);
+        expect(cubit.state.currentStep, 1);
+        verify(() => mockAudioService.speakText(tScript.steps[1])).called(1);
+      });
+    });
+
+    test('timer should stop when paused', () {
+      fakeAsync((async) {
+        when(() => mockStartSessionUseCase(any())).thenAnswer((_) async => tSession);
+        when(() => mockAudioService.speakText(any())).thenAnswer((_) async => {});
+        when(() => mockAudioService.stopTTS()).thenAnswer((_) async => {});
+
+        cubit.emit(MeditationState(
+          status: MeditationStatus.idle,
+          script: tScript,
+          steps: tScript.steps,
+        ));
+
+        cubit.startMeditation();
+        async.flushMicrotasks();
+
+        async.elapse(const Duration(seconds: 5));
+        expect(cubit.state.elapsedSeconds, 5);
+
+        cubit.togglePause();
+        async.flushMicrotasks();
+        expect(cubit.state.status, MeditationStatus.paused);
+
+        async.elapse(const Duration(seconds: 5));
+        expect(cubit.state.elapsedSeconds, 5); // Should not have incremented
+
+        cubit.togglePause(); // resume
+        async.flushMicrotasks();
+        expect(cubit.state.status, MeditationStatus.playing);
+
+        async.elapse(const Duration(seconds: 1));
+        expect(cubit.state.elapsedSeconds, 6);
+      });
+    });
+  });
+
+  group('navigation', () {
+    test('nextStep should increment currentStep and speak', () async {
+      when(() => mockAudioService.speakText(any())).thenAnswer((_) async => {});
+
+      // Initialize and start to get into playing state
+      when(() => mockRecommendScriptUseCase()).thenAnswer((_) async => tScript);
+      when(() => mockGetProgressUseCase()).thenAnswer((_) async => tProgress);
+      when(() => mockAudioService.initialize()).thenAnswer((_) async => {});
+      await cubit.initialize();
+
+      when(() => mockStartSessionUseCase(any())).thenAnswer((_) async => tSession);
+      await cubit.startMeditation();
+
+      expectLater(
+        cubit.stream,
+        emits(
+          MeditationState(
+            status: MeditationStatus.playing,
+            script: tScript,
+            steps: tScript.steps,
+            session: tSession,
+            progress: tProgress,
+            currentStep: 1,
+            elapsedSeconds: 0,
+          ),
+        ),
+      );
+
+      await cubit.nextStep();
+      verify(() => mockAudioService.speakText(tScript.steps[1])).called(1);
+    });
+
+    test('previousStep should decrement currentStep and speak', () async {
+      when(() => mockAudioService.speakText(any())).thenAnswer((_) async => {});
+
+      // Setup state with step 1
+      when(() => mockRecommendScriptUseCase()).thenAnswer((_) async => tScript);
+      when(() => mockGetProgressUseCase()).thenAnswer((_) async => tProgress);
+      when(() => mockAudioService.initialize()).thenAnswer((_) async => {});
+      await cubit.initialize();
+
+      when(() => mockStartSessionUseCase(any())).thenAnswer((_) async => tSession);
+      await cubit.startMeditation();
+      await cubit.nextStep(); // to step 1
+
+      expectLater(
+        cubit.stream,
+        emits(
+          MeditationState(
+            status: MeditationStatus.playing,
+            script: tScript,
+            steps: tScript.steps,
+            session: tSession,
+            progress: tProgress,
+            currentStep: 0,
+            elapsedSeconds: 0,
+          ),
+        ),
+      );
+
+      await cubit.previousStep();
+      verify(() => mockAudioService.speakText(tScript.steps[0])).called(2); // once on start, once on previous
+    });
+  });
+
+  group('togglePause', () {
+    test('should pause when playing', () async {
+      when(() => mockAudioService.stopTTS()).thenAnswer((_) async => {});
+      when(() => mockAudioService.speakText(any())).thenAnswer((_) async => {});
+
+      // Setup state
+      when(() => mockRecommendScriptUseCase()).thenAnswer((_) async => tScript);
+      when(() => mockGetProgressUseCase()).thenAnswer((_) async => tProgress);
+      when(() => mockAudioService.initialize()).thenAnswer((_) async => {});
+      await cubit.initialize();
+      when(() => mockStartSessionUseCase(any())).thenAnswer((_) async => tSession);
+      await cubit.startMeditation();
+
+      expectLater(
+        cubit.stream,
+        emits(
+          MeditationState(
+            status: MeditationStatus.paused,
+            script: tScript,
+            steps: tScript.steps,
+            session: tSession,
+            progress: tProgress,
+            currentStep: 0,
+            elapsedSeconds: 0,
+          ),
+        ),
+      );
+
+      await cubit.togglePause();
+      verify(() => mockAudioService.stopTTS()).called(1);
+    });
+
+    test('should resume when paused', () async {
+      when(() => mockAudioService.stopTTS()).thenAnswer((_) async => {});
+      when(() => mockAudioService.speakText(any())).thenAnswer((_) async => {});
+
+      // Setup state
+      when(() => mockRecommendScriptUseCase()).thenAnswer((_) async => tScript);
+      when(() => mockGetProgressUseCase()).thenAnswer((_) async => tProgress);
+      when(() => mockAudioService.initialize()).thenAnswer((_) async => {});
+      await cubit.initialize();
+      when(() => mockStartSessionUseCase(any())).thenAnswer((_) async => tSession);
+      await cubit.startMeditation();
+      await cubit.togglePause();
+
+      expectLater(
+        cubit.stream,
+        emits(
+          MeditationState(
+            status: MeditationStatus.playing,
+            script: tScript,
+            steps: tScript.steps,
+            session: tSession,
+            progress: tProgress,
+            currentStep: 0,
+            elapsedSeconds: 0,
+          ),
+        ),
+      );
+
+      await cubit.togglePause();
+      verify(() => mockAudioService.speakText(tScript.steps[0])).called(2); // once on start, once on resume
+    });
+  });
+
+  group('finishMeditation', () {
+    test('should complete session and emit completed', () async {
+      when(() => mockAudioService.stopAll()).thenAnswer((_) async => {});
+      when(() => mockAudioService.speakText(any())).thenAnswer((_) async => {});
+      when(() => mockCompleteSessionUseCase(
+            session: any(named: 'session'),
+            elapsedSeconds: any(named: 'elapsedSeconds'),
+            completedSteps: any(named: 'completedSteps'),
+          )).thenAnswer((_) async => {});
+      when(() => mockGetProgressUseCase()).thenAnswer((_) async => tProgress);
+
+      // Setup state
+      when(() => mockRecommendScriptUseCase()).thenAnswer((_) async => tScript);
+      when(() => mockAudioService.initialize()).thenAnswer((_) async => {});
+      await cubit.initialize();
+      when(() => mockStartSessionUseCase(any())).thenAnswer((_) async => tSession);
+      await cubit.startMeditation();
+
+      expectLater(
+        cubit.stream,
+        emits(
+          MeditationState(
+            status: MeditationStatus.completed,
+            script: tScript,
+            steps: tScript.steps,
+            session: tSession,
+            progress: tProgress,
+            currentStep: 0,
+            elapsedSeconds: 0,
+          ),
+        ),
+      );
+
+      await cubit.finishMeditation();
+
+      verify(() => mockCompleteSessionUseCase(
+            session: tSession,
+            elapsedSeconds: 0,
+            completedSteps: 1,
+          )).called(1);
+      verify(() => mockAudioService.speakText('La meditación ha terminado.')).called(1);
+    });
+  });
+}

--- a/test/features/meditation/domain/usecases/complete_session_usecase_test.dart
+++ b/test/features/meditation/domain/usecases/complete_session_usecase_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_session.dart';
+import 'package:orionhealth_health/features/meditation/domain/repositories/meditation_repository.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/complete_session_usecase.dart';
+
+class MockMeditationRepository extends Mock implements MeditationRepository {}
+
+class FakeMeditationSession extends Fake implements MeditationSession {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeMeditationSession());
+  });
+
+  late CompleteSessionUseCase useCase;
+  late MockMeditationRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockMeditationRepository();
+    useCase = CompleteSessionUseCase(mockRepository);
+  });
+
+  final tSession = MeditationSession(
+    id: '1',
+    scriptId: 'script-1',
+    category: MeditationCategory.calm,
+    startedAt: DateTime(2025, 1, 1),
+  );
+
+  test('should call completeSession on the repository', () async {
+    // arrange
+    when(() => mockRepository.completeSession(
+          session: any(named: 'session'),
+          elapsedSeconds: any(named: 'elapsedSeconds'),
+          completedSteps: any(named: 'completedSteps'),
+        )).thenAnswer((_) async => {});
+
+    // act
+    await useCase(
+      session: tSession,
+      elapsedSeconds: 300,
+      completedSteps: 5,
+    );
+
+    // assert
+    verify(() => mockRepository.completeSession(
+          session: tSession,
+          elapsedSeconds: 300,
+          completedSteps: 5,
+        )).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/meditation/domain/usecases/get_progress_usecase_test.dart
+++ b/test/features/meditation/domain/usecases/get_progress_usecase_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_progress.dart';
+import 'package:orionhealth_health/features/meditation/domain/repositories/meditation_repository.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/get_progress_usecase.dart';
+
+class MockMeditationRepository extends Mock implements MeditationRepository {}
+
+void main() {
+  late GetProgressUseCase useCase;
+  late MockMeditationRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockMeditationRepository();
+    useCase = GetProgressUseCase(mockRepository);
+  });
+
+  const tProgress = MeditationProgress(
+    totalSessions: 5,
+    completedSessions: 3,
+    totalCompletedSeconds: 900,
+  );
+
+  test('should initialize repository and get progress', () async {
+    // arrange
+    when(() => mockRepository.initialize()).thenAnswer((_) async => {});
+    when(() => mockRepository.getProgress()).thenAnswer((_) async => tProgress);
+
+    // act
+    final result = await useCase();
+
+    // assert
+    expect(result, tProgress);
+    verify(() => mockRepository.initialize()).called(1);
+    verify(() => mockRepository.getProgress()).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/meditation/domain/usecases/get_scripts_usecase_test.dart
+++ b/test/features/meditation/domain/usecases/get_scripts_usecase_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_script.dart';
+import 'package:orionhealth_health/features/meditation/domain/repositories/meditation_repository.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/get_scripts_usecase.dart';
+
+class MockMeditationRepository extends Mock implements MeditationRepository {}
+
+void main() {
+  late GetScriptsUseCase useCase;
+  late MockMeditationRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockMeditationRepository();
+    useCase = GetScriptsUseCase(mockRepository);
+  });
+
+  const tScripts = [
+    MeditationScript(
+      id: '1',
+      title: 'Title',
+      category: MeditationCategory.calm,
+      durationMinutes: 5,
+      steps: ['Step 1'],
+    ),
+  ];
+
+  test('should initialize repository and get scripts', () async {
+    // arrange
+    when(() => mockRepository.initialize()).thenAnswer((_) async => {});
+    when(() => mockRepository.scripts).thenReturn(tScripts);
+
+    // act
+    final result = await useCase();
+
+    // assert
+    expect(result, tScripts);
+    verify(() => mockRepository.initialize()).called(1);
+    verify(() => mockRepository.scripts).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/meditation/domain/usecases/recommend_script_usecase_test.dart
+++ b/test/features/meditation/domain/usecases/recommend_script_usecase_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_script.dart';
+import 'package:orionhealth_health/features/meditation/domain/repositories/meditation_repository.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/recommend_script_usecase.dart';
+
+class MockMeditationRepository extends Mock implements MeditationRepository {}
+
+void main() {
+  late RecommendScriptUseCase useCase;
+  late MockMeditationRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockMeditationRepository();
+    useCase = RecommendScriptUseCase(mockRepository);
+  });
+
+  const tScript = MeditationScript(
+    id: '1',
+    title: 'Title',
+    category: MeditationCategory.calm,
+    durationMinutes: 5,
+    steps: ['Step 1'],
+  );
+
+  test('should initialize repository and recommend script', () async {
+    // arrange
+    when(() => mockRepository.initialize()).thenAnswer((_) async => {});
+    when(() => mockRepository.recommendScript(memoryHints: any(named: 'memoryHints')))
+        .thenAnswer((_) async => tScript);
+
+    // act
+    final result = await useCase(memoryHints: ['hint']);
+
+    // assert
+    expect(result, tScript);
+    verify(() => mockRepository.initialize()).called(1);
+    verify(() => mockRepository.recommendScript(memoryHints: ['hint'])).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/meditation/domain/usecases/start_session_usecase_test.dart
+++ b/test/features/meditation/domain/usecases/start_session_usecase_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_script.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_session.dart';
+import 'package:orionhealth_health/features/meditation/domain/repositories/meditation_repository.dart';
+import 'package:orionhealth_health/features/meditation/domain/usecases/start_session_usecase.dart';
+
+class MockMeditationRepository extends Mock implements MeditationRepository {}
+
+class FakeMeditationScript extends Fake implements MeditationScript {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeMeditationScript());
+  });
+
+  late StartSessionUseCase useCase;
+  late MockMeditationRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockMeditationRepository();
+    useCase = StartSessionUseCase(mockRepository);
+  });
+
+  const tScript = MeditationScript(
+    id: '1',
+    title: 'Title',
+    category: MeditationCategory.calm,
+    durationMinutes: 5,
+    steps: ['Step 1'],
+  );
+
+  final tSession = MeditationSession(
+    id: '1',
+    scriptId: '1',
+    category: MeditationCategory.calm,
+    startedAt: DateTime(2025, 1, 1),
+  );
+
+  test('should call startSession on the repository', () async {
+    // arrange
+    when(() => mockRepository.startSession(any()))
+        .thenAnswer((_) async => tSession);
+
+    // act
+    final result = await useCase(tScript);
+
+    // assert
+    expect(result, tSession);
+    verify(() => mockRepository.startSession(tScript)).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/meditation/infrastructure/datasources/meditation_local_datasource_test.dart
+++ b/test/features/meditation/infrastructure/datasources/meditation_local_datasource_test.dart
@@ -1,0 +1,64 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_preferences.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_session.dart';
+import 'package:orionhealth_health/features/meditation/infrastructure/datasources/meditation_local_datasource.dart';
+
+void main() {
+  late MeditationLocalDataSource dataSource;
+
+  setUp(() {
+    SharedPreferences.setMockInitialValues({});
+    dataSource = MeditationLocalDataSource();
+  });
+
+  const tPrefs = MeditationPreferences(
+    preferredCategory: MeditationCategory.sleep,
+    preferredDurationMinutes: 15,
+    ttsEnabled: false,
+    lastScriptId: 'sleep-01',
+  );
+
+  final tSession = MeditationSession(
+    id: 'session-1',
+    scriptId: 'calm-01',
+    category: MeditationCategory.calm,
+    startedAt: DateTime(2025, 1, 1),
+    completed: true,
+    elapsedSeconds: 300,
+    completedSteps: 5,
+  );
+
+  group('preferences', () {
+    test('should return null when no preferences are saved', () async {
+      final result = await dataSource.getPreferences();
+      expect(result, isNull);
+    });
+
+    test('should save and retrieve preferences', () async {
+      await dataSource.savePreferences(tPrefs);
+      final result = await dataSource.getPreferences();
+      expect(result, tPrefs);
+    });
+  });
+
+  group('history', () {
+    test('should return empty list when no history is saved', () async {
+      final result = await dataSource.getHistory();
+      expect(result, isEmpty);
+    });
+
+    test('should save and retrieve history', () async {
+      final history = [tSession];
+      await dataSource.saveHistory(history);
+      final result = await dataSource.getHistory();
+
+      expect(result, hasLength(1));
+      expect(result.first.id, tSession.id);
+      expect(result.first.scriptId, tSession.scriptId);
+      expect(result.first.completed, tSession.completed);
+    });
+  });
+}

--- a/test/features/meditation/infrastructure/repositories/meditation_repository_impl_test.dart
+++ b/test/features/meditation/infrastructure/repositories/meditation_repository_impl_test.dart
@@ -1,0 +1,139 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_preferences.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_script.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_session.dart';
+import 'package:orionhealth_health/features/meditation/infrastructure/datasources/meditation_local_datasource.dart';
+import 'package:orionhealth_health/features/meditation/infrastructure/repositories/meditation_repository_impl.dart';
+
+class MockMeditationLocalDataSource extends Mock implements MeditationLocalDataSource {}
+
+class FakeMeditationPreferences extends Fake implements MeditationPreferences {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeMeditationPreferences());
+  });
+
+  late MeditationRepositoryImpl repository;
+  late MockMeditationLocalDataSource mockLocalDataSource;
+
+  setUp(() {
+    mockLocalDataSource = MockMeditationLocalDataSource();
+    repository = MeditationRepositoryImpl(mockLocalDataSource);
+  });
+
+  const tPrefs = MeditationPreferences(
+    preferredCategory: MeditationCategory.sleep,
+    preferredDurationMinutes: 10,
+  );
+
+  final tHistory = [
+    MeditationSession(
+      id: '1',
+      scriptId: 'calm-01',
+      category: MeditationCategory.calm,
+      startedAt: DateTime(2025, 1, 1),
+      completed: true,
+      elapsedSeconds: 300,
+    ),
+  ];
+
+  group('initialize', () {
+    test('should load preferences and history from data source', () async {
+      when(() => mockLocalDataSource.getPreferences()).thenAnswer((_) async => tPrefs);
+      when(() => mockLocalDataSource.getHistory()).thenAnswer((_) async => tHistory);
+
+      await repository.initialize();
+
+      expect(repository.preferences, tPrefs);
+      expect(repository.history, tHistory);
+      expect(repository.scripts.isNotEmpty, isTrue);
+      verify(() => mockLocalDataSource.getPreferences()).called(1);
+      verify(() => mockLocalDataSource.getHistory()).called(1);
+    });
+
+    test('should use default preferences if none found', () async {
+      when(() => mockLocalDataSource.getPreferences()).thenAnswer((_) async => null);
+      when(() => mockLocalDataSource.getHistory()).thenAnswer((_) async => []);
+
+      await repository.initialize();
+
+      expect(repository.preferences, const MeditationPreferences());
+      expect(repository.history, isEmpty);
+    });
+  });
+
+  group('recommendScript', () {
+    setUp(() async {
+      when(() => mockLocalDataSource.getPreferences()).thenAnswer((_) async => tPrefs);
+      when(() => mockLocalDataSource.getHistory()).thenAnswer((_) async => []);
+      await repository.initialize();
+    });
+
+    test('should return script of preferred category', () async {
+      final script = await repository.recommendScript();
+      expect(script.category, tPrefs.preferredCategory);
+    });
+
+    test('should return last script if lastScriptId is set', () async {
+      when(() => mockLocalDataSource.savePreferences(any())).thenAnswer((_) async => {});
+      final prefsWithLast = tPrefs.copyWith(lastScriptId: 'focus-01');
+      await repository.updatePreferences(prefsWithLast);
+
+      final script = await repository.recommendScript();
+      expect(script.id, 'focus-01');
+    });
+  });
+
+  group('session management', () {
+    setUp(() async {
+      when(() => mockLocalDataSource.getPreferences()).thenAnswer((_) async => tPrefs);
+      when(() => mockLocalDataSource.getHistory()).thenAnswer((_) async => []);
+      when(() => mockLocalDataSource.savePreferences(any())).thenAnswer((_) async => {});
+      when(() => mockLocalDataSource.saveHistory(any())).thenAnswer((_) async => {});
+      await repository.initialize();
+    });
+
+    test('startSession should create session and update lastScriptId', () async {
+      final script = repository.scripts.first;
+      final session = await repository.startSession(script);
+
+      expect(session.scriptId, script.id);
+      expect(repository.preferences.lastScriptId, script.id);
+      verify(() => mockLocalDataSource.savePreferences(any())).called(1);
+    });
+
+    test('completeSession should add to history and save', () async {
+      final script = repository.scripts.first;
+      final session = await repository.startSession(script);
+
+      await repository.completeSession(
+        session: session,
+        elapsedSeconds: 300,
+        completedSteps: 5,
+      );
+
+      expect(repository.history.length, 1);
+      expect(repository.history.first.completed, isTrue);
+      expect(repository.history.first.elapsedSeconds, 300);
+      verify(() => mockLocalDataSource.saveHistory(any())).called(1);
+    });
+  });
+
+  group('getProgress', () {
+    test('should calculate progress correctly', () async {
+      when(() => mockLocalDataSource.getPreferences()).thenAnswer((_) async => tPrefs);
+      when(() => mockLocalDataSource.getHistory()).thenAnswer((_) async => tHistory);
+      await repository.initialize();
+
+      final progress = await repository.getProgress();
+
+      expect(progress.totalSessions, 1);
+      expect(progress.completedSessions, 1);
+      expect(progress.totalCompletedSeconds, 300);
+      expect(progress.lastSession, tHistory.first);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds comprehensive unit tests for the meditation feature, covering:
- Domain entities (already existing, verified)
- All UseCases (CompleteSession, GetProgress, GetScripts, RecommendScript, StartSession)
- Application layer (MeditationCubit) with timer and auto-step advancement logic
- Infrastructure layer (MeditationRepositoryImpl and MeditationLocalDataSource)

All 45 logic-related unit tests in test/features/meditation/ are passing.

Fixes #663

---
*PR created automatically by Jules for task [5841116586070912224](https://jules.google.com/task/5841116586070912224) started by @iberi22*