### PR TITLE
Add unit tests for appointments scheduling domain and services

### DIFF
--- a/test/features/appointments/domain/entities/appointment_test.dart
+++ b/test/features/appointments/domain/entities/appointment_test.dart
@@ -86,5 +86,27 @@ void main() {
       );
       expect(appointment.isPast, isFalse);
     });
+
+    test('isPast should return false for near future (1 min)', () {
+      final now = DateTime.now();
+      final appointment = Appointment(
+        doctorName: 'Dr. House',
+        specialty: 'Diagnostics',
+        dateTime: now.add(const Duration(minutes: 1)),
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.isPast, isFalse);
+    });
+
+    test('isPast should return true for near past (1 min)', () {
+      final now = DateTime.now();
+      final appointment = Appointment(
+        doctorName: 'Dr. House',
+        specialty: 'Diagnostics',
+        dateTime: now.subtract(const Duration(minutes: 1)),
+        status: AppointmentStatus.upcoming,
+      );
+      expect(appointment.isPast, isTrue);
+    });
   });
 }

--- a/test/features/appointments/domain/services/appointment_service_test.dart
+++ b/test/features/appointments/domain/services/appointment_service_test.dart
@@ -52,7 +52,6 @@ void main() {
         status: AppointmentStatus.upcoming,
       );
 
-      // (10:00 < 10:59) AND (10:30 > 10:29) -> TRUE
       final result = service.hasConflict(newApp, existing);
       expect(result, isTrue);
     });
@@ -76,11 +75,9 @@ void main() {
         status: AppointmentStatus.upcoming,
       );
 
-      // (10:30 < 10:30) is FALSE -> FALSE
       final result = service.hasConflict(newApp, existing);
       expect(result, isFalse);
     });
-
 
     test('should return false if existing appointment is cancelled', () {
       final existing = [
@@ -117,7 +114,7 @@ void main() {
       final newApp = Appointment(
         doctorName: 'Dr. Jones',
         specialty: 'Neuro',
-        dateTime: baseDate.add(const Duration(minutes: 30)), // 10:30
+        dateTime: baseDate.add(const Duration(minutes: 60)), // 11:00
         status: AppointmentStatus.upcoming,
       );
 
@@ -161,6 +158,118 @@ void main() {
 
       final result = service.hasConflict(app, [app]);
       expect(result, isFalse);
+    });
+
+    test('should return true if new appointment entirely encompasses an existing one', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'Cardio',
+          dateTime: baseDate.add(const Duration(minutes: 10)), // 10:10 - 10:20
+          durationInMinutes: 10,
+          status: AppointmentStatus.upcoming,
+        )
+      ];
+
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Neuro',
+        dateTime: baseDate, // 10:00 - 10:30
+        durationInMinutes: 30,
+        status: AppointmentStatus.upcoming,
+      );
+
+      final result = service.hasConflict(newApp, existing);
+      expect(result, isTrue);
+    });
+
+    test('should return true if existing appointment entirely encompasses the new one', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'Cardio',
+          dateTime: baseDate, // 10:00 - 10:30
+          durationInMinutes: 30,
+          status: AppointmentStatus.upcoming,
+        )
+      ];
+
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Neuro',
+        dateTime: baseDate.add(const Duration(minutes: 10)), // 10:10 - 10:20
+        durationInMinutes: 10,
+        status: AppointmentStatus.upcoming,
+      );
+
+      final result = service.hasConflict(newApp, existing);
+      expect(result, isTrue);
+    });
+
+    test('should return true if overlap is at the last millisecond', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. Smith',
+          specialty: 'Cardio',
+          dateTime: baseDate, // 10:00:00 - 10:30:00
+          durationInMinutes: 30,
+          status: AppointmentStatus.upcoming,
+        )
+      ];
+
+      final newApp = Appointment(
+        id: 2,
+        doctorName: 'Dr. Jones',
+        specialty: 'Neuro',
+        dateTime: baseDate.add(const Duration(minutes: 29, seconds: 59, milliseconds: 999)),
+        durationInMinutes: 30,
+        status: AppointmentStatus.upcoming,
+      );
+
+      final result = service.hasConflict(newApp, existing);
+      expect(result, isTrue);
+    });
+
+    test('should return true if conflict is in the middle of a list', () {
+      final existing = [
+        Appointment(
+          id: 1,
+          doctorName: 'Dr. One',
+          specialty: 'General',
+          dateTime: baseDate.subtract(const Duration(hours: 2)),
+          status: AppointmentStatus.upcoming,
+        ),
+        Appointment(
+          id: 2,
+          doctorName: 'Dr. Two',
+          specialty: 'General',
+          dateTime: baseDate,
+          status: AppointmentStatus.upcoming,
+        ),
+        Appointment(
+          id: 3,
+          doctorName: 'Dr. Three',
+          specialty: 'General',
+          dateTime: baseDate.add(const Duration(hours: 2)),
+          status: AppointmentStatus.upcoming,
+        ),
+      ];
+
+      final newApp = Appointment(
+        id: 4,
+        doctorName: 'Dr. New',
+        specialty: 'Special',
+        dateTime: baseDate.add(const Duration(minutes: 10)),
+        status: AppointmentStatus.upcoming,
+      );
+
+      final result = service.hasConflict(newApp, existing);
+      expect(result, isTrue);
     });
   });
 
@@ -237,6 +346,81 @@ void main() {
       final instances = service.generateInstances(app);
       expect(instances.length, 1);
       expect(instances.first, app);
+    });
+
+    test('should return single instance if count is 1', () {
+      final app = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardio',
+        dateTime: baseDate,
+        status: AppointmentStatus.upcoming,
+        recurrenceRule: 'FREQ=DAILY',
+      );
+
+      final instances = service.generateInstances(app, count: 1);
+      expect(instances.length, 1);
+      expect(instances.first.dateTime, baseDate);
+    });
+
+    test('should return no instances if count is 0', () {
+      final app = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardio',
+        dateTime: baseDate,
+        status: AppointmentStatus.upcoming,
+        recurrenceRule: 'FREQ=DAILY',
+      );
+
+      final instances = service.generateInstances(app, count: 0);
+      expect(instances.length, 0);
+    });
+
+    test('should handle year transition (Dec 31st)', () {
+      final yearEnd = DateTime(2023, 12, 31, 10, 0);
+      final app = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardio',
+        dateTime: yearEnd,
+        status: AppointmentStatus.upcoming,
+        recurrenceRule: 'FREQ=DAILY',
+      );
+
+      final instances = service.generateInstances(app, count: 2);
+      expect(instances.length, 2);
+      expect(instances[0].dateTime, yearEnd);
+      expect(instances[1].dateTime, DateTime(2024, 1, 1, 10, 0));
+    });
+
+    test('should handle month transition (Jan 31st)', () {
+      final monthEnd = DateTime(2024, 1, 31, 10, 0);
+      final app = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardio',
+        dateTime: monthEnd,
+        status: AppointmentStatus.upcoming,
+        recurrenceRule: 'FREQ=DAILY',
+      );
+
+      final instances = service.generateInstances(app, count: 2);
+      expect(instances.length, 2);
+      expect(instances[0].dateTime, monthEnd);
+      expect(instances[1].dateTime, DateTime(2024, 2, 1, 10, 0));
+    });
+
+    test('should handle leap year (Feb 28th 2024)', () {
+      final febEnd = DateTime(2024, 2, 28, 10, 0);
+      final app = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardio',
+        dateTime: febEnd,
+        status: AppointmentStatus.upcoming,
+        recurrenceRule: 'FREQ=DAILY',
+      );
+
+      final instances = service.generateInstances(app, count: 2);
+      expect(instances.length, 2);
+      expect(instances[0].dateTime, febEnd);
+      expect(instances[1].dateTime, DateTime(2024, 2, 29, 10, 0));
     });
   });
 }

--- a/test/features/appointments/domain/services/reminder_logic_test.dart
+++ b/test/features/appointments/domain/services/reminder_logic_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+import 'package:orionhealth_health/features/email-citas/domain/services/reminder_service.dart';
+
+void main() {
+  group('Appointment Reminder Logic', () {
+    late ReminderService reminderService;
+
+    setUp(() {
+      reminderService = ReminderService();
+    });
+
+    test('calculateReminderTime should be exactly 24 hours before by default', () {
+      final appTime = DateTime(2025, 1, 10, 15, 0);
+      final app = Appointment(
+        doctorName: 'Dr. Test',
+        specialty: 'Testing',
+        dateTime: appTime,
+        status: AppointmentStatus.upcoming,
+      );
+
+      final reminderTime = reminderService.calculateReminderTime(app);
+      expect(reminderTime, DateTime(2025, 1, 9, 15, 0));
+    });
+
+    test('calculateReminderTime should respect custom lead time', () {
+      final appTime = DateTime(2025, 1, 10, 15, 0);
+      final app = Appointment(
+        doctorName: 'Dr. Test',
+        specialty: 'Testing',
+        dateTime: appTime,
+        status: AppointmentStatus.upcoming,
+      );
+
+      final reminderTime = reminderService.calculateReminderTime(app, leadTime: const Duration(hours: 1));
+      expect(reminderTime, DateTime(2025, 1, 10, 14, 0));
+    });
+
+    test('shouldScheduleReminder should be true for far future appointments', () {
+      // 2 days in the future, reminder is in 1 day
+      final appTime = DateTime.now().add(const Duration(days: 2));
+      final app = Appointment(
+        doctorName: 'Dr. Test',
+        specialty: 'Testing',
+        dateTime: appTime,
+        status: AppointmentStatus.upcoming,
+      );
+
+      expect(reminderService.shouldScheduleReminder(app), isTrue);
+    });
+
+    test('shouldScheduleReminder should be false for past appointments', () {
+      final appTime = DateTime.now().subtract(const Duration(hours: 1));
+      final app = Appointment(
+        doctorName: 'Dr. Test',
+        specialty: 'Testing',
+        dateTime: appTime,
+        status: AppointmentStatus.upcoming,
+      );
+
+      expect(reminderService.shouldScheduleReminder(app), isFalse);
+    });
+
+    test('shouldScheduleReminder should be false if reminder time is in the past even if appointment is in the future', () {
+      // Appointment in 10 hours, but reminder is 24 hours before (which was 14 hours ago)
+      final appTime = DateTime.now().add(const Duration(hours: 10));
+      final app = Appointment(
+        doctorName: 'Dr. Test',
+        specialty: 'Testing',
+        dateTime: appTime,
+        status: AppointmentStatus.upcoming,
+      );
+
+      expect(reminderService.shouldScheduleReminder(app), isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Expanded unit test coverage for the appointments feature. Key additions include:
- Exhaustive overlap detection scenarios (encompassing, boundary conditions).
- Robust recurrence rule testing across month/year boundaries.
- Validation logic for appointment entities.
- Reminder scheduling criteria.
- Organized test structure into domain/entities and domain/services.

Fixes #664

---
*PR created automatically by Jules for task [9126890928535702899](https://jules.google.com/task/9126890928535702899) started by @iberi22*