### PR TITLE
Add unit and widget tests for auth feature

### DIFF
--- a/test/features/auth/application/bloc/auth_cubit_test.dart
+++ b/test/features/auth/application/bloc/auth_cubit_test.dart
@@ -1,3 +1,4 @@
+import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mockito/annotations.dart';
 import 'package:mockito/mockito.dart';
@@ -71,18 +72,63 @@ void main() {
     });
     group('Lockout', () {
       test('should emit AuthLocked after 5 failed attempts', () async {
-       final credentials = AuthCredentials()
-        ..hashedPin = 'hashed'
-        ..salt = 'salt'
-        ..failedAttempts = 4;
+        final credentials = AuthCredentials()
+          ..hashedPin = 'hashed'
+          ..salt = 'salt'
+          ..failedAttempts = 4;
 
-      when(mockRepository.getCredentials()).thenAnswer((_) async => credentials);
-      when(mockEncryption.hashPin('1111', 'salt')).thenAnswer((_) async => 'wrong');
+        when(mockRepository.getCredentials()).thenAnswer((_) async => credentials);
+        when(mockEncryption.hashPin('1111', 'salt')).thenAnswer((_) async => 'wrong');
 
-      await authCubit.loginWithPin('1111');
+        await authCubit.loginWithPin('1111');
 
-      expect(authCubit.state, isA<AuthLocked>());
+        expect(authCubit.state, isA<AuthLocked>());
+      });
     });
-  });
+
+    test('setupPin should save credentials and emit AuthAuthenticated', () async {
+      when(mockEncryption.hashPin(any, any)).thenAnswer((_) async => 'hashed');
+      when(mockRepository.saveCredentials(any)).thenAnswer((_) async {});
+
+      await authCubit.setupPin('1234');
+
+      verify(mockRepository.saveCredentials(any)).called(1);
+      expect(authCubit.state, isA<AuthAuthenticated>());
+    });
+
+    test('loginWithBiometrics should authenticate and emit AuthAuthenticated', () async {
+      final credentials = AuthCredentials()..biometricEnabled = true;
+      when(mockRepository.getCredentials()).thenAnswer((_) async => credentials);
+      when(mockBiometric.authenticate(localizedReason: anyNamed('localizedReason')))
+          .thenAnswer((_) async => true);
+
+      await authCubit.loginWithBiometrics();
+
+      expect(authCubit.state, isA<AuthAuthenticated>());
+    });
+
+    test('toggleBiometrics should update repository', () async {
+      final credentials = AuthCredentials()..biometricEnabled = false;
+      when(mockRepository.getCredentials()).thenAnswer((_) async => credentials);
+      when(mockBiometric.authenticate(localizedReason: anyNamed('localizedReason')))
+          .thenAnswer((_) async => true);
+      when(mockRepository.saveCredentials(any)).thenAnswer((_) async {});
+
+      await authCubit.toggleBiometrics(true);
+
+      expect(credentials.biometricEnabled, isTrue);
+      verify(mockRepository.saveCredentials(credentials)).called(1);
+    });
+
+    test('logout should cancel timer and emit AuthUnauthenticated', () async {
+      // First authenticate to start session
+      when(mockEncryption.hashPin(any, any)).thenAnswer((_) async => 'hashed');
+      await authCubit.setupPin('1234');
+      expect(authCubit.state, isA<AuthAuthenticated>());
+
+      authCubit.logout();
+
+      expect(authCubit.state, equals(const AuthUnauthenticated()));
+    });
   });
 }

--- a/test/features/auth/infrastructure/services/biometric_service_test.dart
+++ b/test/features/auth/infrastructure/services/biometric_service_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:local_auth/local_auth.dart';
+import 'package:orionhealth_health/features/auth/infrastructure/services/biometric_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+  late BiometricService biometricService;
+  final List<MethodCall> log = <MethodCall>[];
+
+  setUp(() {
+    biometricService = BiometricService();
+    log.clear();
+
+    // The channel name for local_auth package
+    const MethodChannel channel = MethodChannel('plugins.flutter.io/local_auth');
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      log.add(methodCall);
+      switch (methodCall.method) {
+        case 'canCheckBiometrics':
+          return true;
+        case 'isDeviceSupported':
+          return true;
+        case 'getAvailableBiometrics':
+          return <String>['fingerprint', 'face'];
+        case 'authenticate':
+          return true;
+        default:
+          return null;
+      }
+    });
+  });
+
+  group('BiometricService', () {
+    test('isBiometricAvailable returns true when supported', () async {
+      final result = await biometricService.isBiometricAvailable();
+      expect(result, isTrue);
+    });
+
+    test('getAvailableBiometrics returns list of biometrics', () async {
+      final result = await biometricService.getAvailableBiometrics();
+      expect(result, contains(BiometricType.fingerprint));
+      expect(result, contains(BiometricType.face));
+    });
+
+    test('authenticate returns true on success', () async {
+      final result = await biometricService.authenticate(localizedReason: 'test');
+      expect(result, isTrue);
+      expect(log, anyElement(predicate((MethodCall m) => m.method == 'authenticate')));
+    });
+
+    test('authenticate returns false on PlatformException', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(const MethodChannel('plugins.flutter.io/local_auth'), (MethodCall methodCall) async {
+        if (methodCall.method == 'authenticate') {
+          throw PlatformException(code: 'error');
+        }
+        return null;
+      });
+
+      final result = await biometricService.authenticate(localizedReason: 'test');
+      expect(result, isFalse);
+    });
+  });
+}

--- a/test/features/auth/infrastructure/services/secure_storage_service_test.dart
+++ b/test/features/auth/infrastructure/services/secure_storage_service_test.dart
@@ -1,0 +1,100 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:orionhealth_health/features/auth/infrastructure/secure_storage_service.dart';
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  late SecureStorageServiceImpl secureStorage;
+  late MockFlutterSecureStorage mockStorage;
+
+  setUp(() {
+    mockStorage = MockFlutterSecureStorage();
+    secureStorage = SecureStorageServiceImpl(storage: mockStorage);
+  });
+
+  group('SecureStorageService', () {
+    test('write should call storage.write', () async {
+      when(() => mockStorage.write(
+            key: any(named: 'key'),
+            value: any(named: 'value'),
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).thenAnswer((_) async {});
+
+      await secureStorage.write('test_key', 'test_value');
+
+      verify(() => mockStorage.write(
+            key: 'test_key',
+            value: 'test_value',
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).called(1);
+    });
+
+    test('read should call storage.read', () async {
+      when(() => mockStorage.read(
+            key: any(named: 'key'),
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).thenAnswer((_) async => 'stored_value');
+
+      final result = await secureStorage.read('test_key');
+
+      expect(result, equals('stored_value'));
+      verify(() => mockStorage.read(
+            key: 'test_key',
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).called(1);
+    });
+
+    test('delete should call storage.delete', () async {
+      when(() => mockStorage.delete(
+            key: any(named: 'key'),
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).thenAnswer((_) async {});
+
+      await secureStorage.delete('test_key');
+
+      verify(() => mockStorage.delete(
+            key: 'test_key',
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).called(1);
+    });
+
+    test('deleteAll should call storage.deleteAll', () async {
+      when(() => mockStorage.deleteAll(
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).thenAnswer((_) async {});
+
+      await secureStorage.deleteAll();
+
+      verify(() => mockStorage.deleteAll(
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).called(1);
+    });
+
+    test('containsKey should call storage.containsKey', () async {
+      when(() => mockStorage.containsKey(
+            key: any(named: 'key'),
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).thenAnswer((_) async => true);
+
+      final result = await secureStorage.containsKey('test_key');
+
+      expect(result, isTrue);
+      verify(() => mockStorage.containsKey(
+            key: 'test_key',
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).called(1);
+    });
+  });
+}

--- a/test/features/auth/presentation/login_page_test.dart
+++ b/test/features/auth/presentation/login_page_test.dart
@@ -1,0 +1,78 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/application/bloc/auth_cubit.dart';
+import 'package:orionhealth_health/features/auth/application/bloc/auth_state.dart';
+import 'package:orionhealth_health/features/auth/presentation/login_page.dart';
+
+class MockAuthCubit extends Mock implements AuthCubit {}
+
+void main() {
+  late MockAuthCubit mockCubit;
+
+  setUp(() {
+    mockCubit = MockAuthCubit();
+    when(() => mockCubit.state).thenReturn(const AuthUnauthenticated());
+    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockCubit.loginWithBiometrics()).thenAnswer((_) async {});
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: BlocProvider<AuthCubit>.value(
+        value: mockCubit,
+        child: const LoginPage(),
+      ),
+    );
+  }
+
+  group('LoginPage', () {
+    testWidgets('renders PIN input and login button', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byType(TextField), findsOneWidget);
+      expect(find.text('Entrar'), findsOneWidget);
+    });
+
+    testWidgets('shows error message from state', (tester) async {
+      when(() => mockCubit.state).thenReturn(const AuthUnauthenticated(errorMessage: 'Invalid PIN'));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Invalid PIN'), findsOneWidget);
+    });
+
+    testWidgets('calls loginWithPin when form submitted', (tester) async {
+      when(() => mockCubit.loginWithPin(any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.enterText(find.byType(TextField), '1234');
+      await tester.tap(find.text('Entrar'));
+      await tester.pump();
+
+      verify(() => mockCubit.loginWithPin('1234')).called(1);
+    });
+
+    testWidgets('calls loginWithBiometrics when fingerprint icon tapped', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.tap(find.byIcon(Icons.fingerprint));
+      await tester.pump();
+
+      verify(() => mockCubit.loginWithBiometrics()).called(2); // One in initState, one on tap
+    });
+
+    testWidgets('shows lockout screen when state is AuthLocked', (tester) async {
+      final lockoutTime = DateTime.now().add(const Duration(minutes: 5));
+      when(() => mockCubit.state).thenReturn(AuthLocked(lockoutTime));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Acceso Bloqueado'), findsOneWidget);
+      expect(find.byIcon(Icons.lock), findsOneWidget);
+    });
+  });
+}

--- a/test/features/auth/presentation/setup_pin_page_test.dart
+++ b/test/features/auth/presentation/setup_pin_page_test.dart
@@ -1,0 +1,73 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/application/bloc/auth_cubit.dart';
+import 'package:orionhealth_health/features/auth/application/bloc/auth_state.dart';
+import 'package:orionhealth_health/features/auth/presentation/setup_pin_page.dart';
+
+class MockAuthCubit extends Mock implements AuthCubit {}
+
+void main() {
+  late MockAuthCubit mockCubit;
+
+  setUp(() {
+    mockCubit = MockAuthCubit();
+    when(() => mockCubit.state).thenReturn(AuthNotSetup());
+    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: BlocProvider<AuthCubit>.value(
+        value: mockCubit,
+        child: const SetupPinPage(),
+      ),
+    );
+  }
+
+  group('SetupPinPage', () {
+    testWidgets('renders PIN and confirm fields', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Nuevo PIN'), findsOneWidget);
+      expect(find.text('Confirmar PIN'), findsOneWidget);
+      expect(find.text('Guardar PIN'), findsOneWidget);
+    });
+
+    testWidgets('shows error when PIN too short', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.enterText(find.widgetWithText(TextField, 'Nuevo PIN'), '123');
+      await tester.tap(find.text('Guardar PIN'));
+      await tester.pump();
+
+      expect(find.text('El PIN debe tener al menos 4 dígitos'), findsOneWidget);
+    });
+
+    testWidgets('shows error when PINs do not match', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.enterText(find.widgetWithText(TextField, 'Nuevo PIN'), '1234');
+      await tester.enterText(find.widgetWithText(TextField, 'Confirmar PIN'), '1235');
+      await tester.tap(find.text('Guardar PIN'));
+      await tester.pump();
+
+      expect(find.text('Los PINs no coinciden'), findsOneWidget);
+    });
+
+    testWidgets('calls setupPin when valid PIN entered', (tester) async {
+      when(() => mockCubit.setupPin(any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.enterText(find.widgetWithText(TextField, 'Nuevo PIN'), '1234');
+      await tester.enterText(find.widgetWithText(TextField, 'Confirmar PIN'), '1234');
+      await tester.tap(find.text('Guardar PIN'));
+      await tester.pump();
+
+      verify(() => mockCubit.setupPin('1234')).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Added unit tests for AuthCubit, BiometricService, and SecureStorageService. Added widget tests for LoginPage and SetupPinPage. Expanded existing AuthCubit tests to cover more scenarios. Verified all new tests pass.

Fixes #684

---
*PR created automatically by Jules for task [6398038653254556660](https://jules.google.com/task/6398038653254556660) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded test coverage for the authentication system, including PIN setup and validation workflows.
  * Added comprehensive tests for biometric authentication functionality and platform integration.
  * Enhanced testing for secure credential storage operations.
  * Implemented widget tests validating login and PIN setup screen interactions, error handling, and lockout behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->