### PR TITLE
Add infrastructure and data layer tests for settings feature

### DIFF
--- a/test/features/settings/application/llm_settings_cubit_test.dart
+++ b/test/features/settings/application/llm_settings_cubit_test.dart
@@ -5,6 +5,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/local_agent/domain/services/llm_adapter.dart';
 import 'package:orionhealth_health/features/settings/application/llm_settings_cubit.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
 import 'package:orionhealth_health/features/settings/domain/repositories/llm_settings_repository.dart';
 import 'package:orionhealth_health/features/settings/domain/services/device_capability_service.dart';
@@ -117,9 +118,12 @@ void main() {
     mockLlmAdapter = MockLlmAdapter();
 
     registerFallbackValue(LlmConfig());
+    registerFallbackValue(AppSettings());
 
     when(() => mockRepository.getLlmConfig()).thenAnswer((_) async => testConfig);
     when(() => mockRepository.saveLlmConfig(any())).thenAnswer((_) async {});
+    when(() => mockRepository.getAppSettings()).thenAnswer((_) async => AppSettings());
+    when(() => mockRepository.saveAppSettings(any())).thenAnswer((_) async {});
     when(() => mockDeviceCapabilityService.detectCapability()).thenAnswer((_) async => testCapability);
     when(() => mockLlmAdapter.listInstalledModels()).thenAnswer((_) async => []);
 
@@ -327,7 +331,7 @@ void main() {
         await cubit.verifyConnection();
 
         final loadedState = cubit.state as LlmSettingsLoaded;
-        expect(loadedState.connectionVerified, isTrue);
+        expect(loadedState.connectionVerified, isTrue, reason: loadedState.connectionError);
       }, _MockHttpOverrides(statusCode: 200));
     });
 

--- a/test/features/settings/application/llm_settings_state_test.dart
+++ b/test/features/settings/application/llm_settings_state_test.dart
@@ -1,11 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:orionhealth_health/features/settings/application/llm_settings_cubit.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
 import 'package:orionhealth_health/features/settings/domain/services/device_capability_service.dart';
 
 void main() {
   group('LlmSettingsState', () {
     final testConfig = LlmConfig(selectedModel: 'test-model');
+    final testAppSettings = AppSettings();
     const testCapability = DeviceCapability(
       tier: DeviceCapabilityTier.medium,
       totalMemoryMb: 4096,
@@ -18,11 +20,13 @@ void main() {
     test('LlmSettingsLoaded supports equality', () {
       final state1 = LlmSettingsLoaded(
         config: testConfig,
+        appSettings: testAppSettings,
         deviceCapability: testCapability,
         downloadProgress: const {'model1': 0.5},
       );
       final state2 = LlmSettingsLoaded(
         config: testConfig,
+        appSettings: testAppSettings,
         deviceCapability: testCapability,
         downloadProgress: const {'model1': 0.5},
       );
@@ -33,6 +37,7 @@ void main() {
     test('LlmSettingsLoaded copyWith should update fields', () {
       final state = LlmSettingsLoaded(
         config: testConfig,
+        appSettings: testAppSettings,
         deviceCapability: testCapability,
       );
 

--- a/test/features/settings/data/datasources/settings_local_datasource_test.dart
+++ b/test/features/settings/data/datasources/settings_local_datasource_test.dart
@@ -1,0 +1,88 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:orionhealth_health/features/settings/data/datasources/settings_local_datasource.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
+
+void main() {
+  late Isar isar;
+  late SettingsLocalDataSource dataSource;
+  late Directory tempDir;
+
+  setUpAll(() async {
+    await Isar.initializeIsarCore(download: true);
+    tempDir = await Directory.systemTemp.createTemp('isar_settings_ds_test');
+  });
+
+  tearDownAll(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    isar = await Isar.open(
+      [LlmConfigSchema, AppSettingsSchema],
+      directory: tempDir.path,
+    );
+    dataSource = SettingsLocalDataSource(isar);
+  });
+
+  tearDown(() async {
+    await isar.close(deleteFromDisk: true);
+  });
+
+  group('SettingsLocalDataSource', () {
+    group('LlmConfig', () {
+      test('getLlmConfig returns null when empty', () async {
+        final result = await dataSource.getLlmConfig();
+        expect(result, isNull);
+      });
+
+      test('saveLlmConfig and getLlmConfig should persist and retrieve', () async {
+        final config = LlmConfig(selectedModel: 'test-model');
+        await dataSource.saveLlmConfig(config);
+
+        final retrieved = await dataSource.getLlmConfig();
+        expect(retrieved, isNotNull);
+        expect(retrieved!.selectedModel, 'test-model');
+      });
+    });
+
+    group('AppSettings', () {
+      test('getAppSettings returns null when empty', () async {
+        final result = await dataSource.getAppSettings();
+        expect(result, isNull);
+      });
+
+      test('saveAppSettings and getAppSettings should persist and retrieve', () async {
+        final settings = AppSettings(themeMode: 'light', languageCode: 'en');
+        await dataSource.saveAppSettings(settings);
+
+        final retrieved = await dataSource.getAppSettings();
+        expect(retrieved, isNotNull);
+        expect(retrieved!.themeMode, 'light');
+        expect(retrieved.languageCode, 'en');
+      });
+
+      test('saveAppSettings updates existing settings', () async {
+        final settings1 = AppSettings(themeMode: 'dark');
+        await dataSource.saveAppSettings(settings1);
+
+        final retrieved1 = await dataSource.getAppSettings();
+        final id = retrieved1!.id;
+
+        final settings2 = retrieved1.copyWith(themeMode: 'light');
+        await dataSource.saveAppSettings(settings2);
+
+        final retrieved2 = await dataSource.getAppSettings();
+        expect(retrieved2!.themeMode, 'light');
+        expect(retrieved2.id, id);
+
+        final count = await isar.appSettings.count();
+        expect(count, 1);
+      });
+    });
+  });
+}

--- a/test/features/settings/data/models/llm_config_dto_test.dart
+++ b/test/features/settings/data/models/llm_config_dto_test.dart
@@ -1,0 +1,114 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/settings/data/models/llm_config_dto.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
+
+void main() {
+  group('LlmConfigDto', () {
+    test('should have correct default values', () {
+      const dto = LlmConfigDto();
+      expect(dto.selectedModel, 'gemini-2.0-flash');
+      expect(dto.useCloudApi, true);
+      expect(dto.allowCloudApiCalls, true);
+      expect(dto.deviceCapabilityTier, 'medium');
+      expect(dto.providerType, 'local');
+    });
+
+    test('fromEntity should create a DTO from an entity', () {
+      final entity = LlmConfig(
+        selectedModel: 'model1',
+        useCloudApi: false,
+        allowCloudApiCalls: false,
+        deviceCapabilityTier: 'low',
+        recommendedModel: 'rec1',
+        providerType: 'openai',
+        apiKey: 'key1',
+        baseUrl: 'base1',
+        cloudModel: 'cloud1',
+        localModelId: 'local1',
+      );
+
+      final dto = LlmConfigDto.fromEntity(entity);
+
+      expect(dto.selectedModel, 'model1');
+      expect(dto.useCloudApi, false);
+      expect(dto.allowCloudApiCalls, false);
+      expect(dto.deviceCapabilityTier, 'low');
+      expect(dto.recommendedModel, 'rec1');
+      expect(dto.providerType, 'openai');
+      expect(dto.apiKey, 'key1');
+      expect(dto.baseUrl, 'base1');
+      expect(dto.cloudModel, 'cloud1');
+      expect(dto.localModelId, 'local1');
+    });
+
+    test('toEntity should create an entity from a DTO', () {
+      const dto = LlmConfigDto(
+        selectedModel: 'model1',
+        useCloudApi: false,
+        allowCloudApiCalls: false,
+        deviceCapabilityTier: 'low',
+        recommendedModel: 'rec1',
+        providerType: 'openai',
+        apiKey: 'key1',
+        baseUrl: 'base1',
+        cloudModel: 'cloud1',
+        localModelId: 'local1',
+      );
+
+      final entity = dto.toEntity();
+
+      expect(entity.selectedModel, 'model1');
+      expect(entity.useCloudApi, false);
+      expect(entity.allowCloudApiCalls, false);
+      expect(entity.deviceCapabilityTier, 'low');
+      expect(entity.recommendedModel, 'rec1');
+      expect(entity.providerType, 'openai');
+      expect(entity.apiKey, 'key1');
+      expect(entity.baseUrl, 'base1');
+      expect(entity.cloudModel, 'cloud1');
+      expect(entity.localModelId, 'local1');
+    });
+
+    test('toJson should return a correct map', () {
+      const dto = LlmConfigDto(
+        selectedModel: 'model1',
+        useCloudApi: true,
+        recommendedModel: 'rec1',
+        apiKey: 'key1',
+      );
+
+      final json = dto.toJson();
+
+      expect(json['selectedModel'], 'model1');
+      expect(json['useCloudApi'], true);
+      expect(json['recommendedModel'], 'rec1');
+      expect(json['apiKey'], 'key1');
+      expect(json.containsKey('baseUrl'), isFalse);
+    });
+
+    test('fromJson should create a DTO from a map', () {
+      final json = {
+        'selectedModel': 'model1',
+        'useCloudApi': false,
+        'deviceCapabilityTier': 'high',
+        'providerType': 'gemini',
+        'localModelId': 'local1',
+      };
+
+      final dto = LlmConfigDto.fromJson(json);
+
+      expect(dto.selectedModel, 'model1');
+      expect(dto.useCloudApi, false);
+      expect(dto.deviceCapabilityTier, 'high');
+      expect(dto.providerType, 'gemini');
+      expect(dto.localModelId, 'local1');
+      expect(dto.apiKey, isNull);
+    });
+
+    test('fromJson should use default values for missing fields', () {
+      final dto = LlmConfigDto.fromJson({});
+      expect(dto.selectedModel, 'gemini-2.0-flash');
+      expect(dto.useCloudApi, true);
+    });
+  });
+}

--- a/test/features/settings/domain/entities/app_settings_test.dart
+++ b/test/features/settings/domain/entities/app_settings_test.dart
@@ -1,0 +1,60 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+
+void main() {
+  group('AppSettings', () {
+    test('should have correct default values', () {
+      final settings = AppSettings();
+      expect(settings.themeMode, 'dark');
+      expect(settings.languageCode, 'es');
+      expect(settings.notificationsEnabled, true);
+    });
+
+    test('copyWith should return a new object with updated values', () {
+      final settings = AppSettings(
+        themeMode: 'light',
+        languageCode: 'en',
+        notificationsEnabled: false,
+      );
+      settings.id = 1;
+
+      final updated = settings.copyWith(
+        themeMode: 'system',
+        languageCode: 'fr',
+        notificationsEnabled: true,
+      );
+
+      expect(updated.id, 1);
+      expect(updated.themeMode, 'system');
+      expect(updated.languageCode, 'fr');
+      expect(updated.notificationsEnabled, true);
+    });
+
+    test('copyWith should use original values if parameters are null', () {
+      final settings = AppSettings(
+        themeMode: 'light',
+        languageCode: 'en',
+      );
+      final updated = settings.copyWith();
+
+      expect(updated.themeMode, 'light');
+      expect(updated.languageCode, 'en');
+    });
+
+    test('toString should return a descriptive string', () {
+      final settings = AppSettings(
+        themeMode: 'dark',
+        languageCode: 'es',
+        notificationsEnabled: true,
+      );
+      settings.id = 5;
+
+      final str = settings.toString();
+      expect(str, contains('AppSettings'));
+      expect(str, contains('id: 5'));
+      expect(str, contains('themeMode: dark'));
+      expect(str, contains('languageCode: es'));
+      expect(str, contains('notificationsEnabled: true'));
+    });
+  });
+}

--- a/test/features/settings/infrastructure/repositories/llm_settings_repository_impl_test.dart
+++ b/test/features/settings/infrastructure/repositories/llm_settings_repository_impl_test.dart
@@ -1,6 +1,7 @@
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:isar/isar.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
 import 'package:orionhealth_health/features/settings/infrastructure/repositories/llm_settings_repository_impl.dart';
 
@@ -22,7 +23,7 @@ void main() {
 
   setUp(() async {
     isar = await Isar.open(
-      [LlmConfigSchema],
+      [LlmConfigSchema, AppSettingsSchema],
       directory: tempDir.path,
     );
     repository = LlmSettingsRepositoryImpl(isar);
@@ -69,6 +70,60 @@ void main() {
 
       final count = await isar.llmConfigs.count();
       expect(count, 1);
+    });
+
+    group('AppSettings', () {
+      test('getAppSettings returns null when no settings exist', () async {
+        final result = await repository.getAppSettings();
+        expect(result, isNull);
+      });
+
+      test('saveAppSettings and getAppSettings should persist and retrieve settings', () async {
+        final settings = AppSettings(
+          themeMode: 'light',
+          languageCode: 'en',
+          notificationsEnabled: false,
+        );
+
+        await repository.saveAppSettings(settings);
+
+        final retrieved = await repository.getAppSettings();
+        expect(retrieved, isNotNull);
+        expect(retrieved!.themeMode, 'light');
+        expect(retrieved.languageCode, 'en');
+        expect(retrieved.notificationsEnabled, false);
+      });
+
+      test('saveAppSettings should update existing settings and preserve record count', () async {
+        final settings1 = AppSettings(themeMode: 'dark');
+        await repository.saveAppSettings(settings1);
+
+        final retrieved1 = await repository.getAppSettings();
+        expect(retrieved1, isNotNull);
+        final originalId = retrieved1!.id;
+
+        final settings2 = retrieved1.copyWith(themeMode: 'light');
+        await repository.saveAppSettings(settings2);
+
+        final retrieved2 = await repository.getAppSettings();
+        expect(retrieved2!.themeMode, 'light');
+        expect(retrieved2.id, originalId);
+
+        final count = await isar.appSettings.count();
+        expect(count, 1);
+      });
+    });
+
+    group('Data Portability', () {
+      test('exportData returns a mock FHIR bundle string', () async {
+        final result = await repository.exportData();
+        expect(result, isA<String>());
+        expect(result, contains('FHIR Bundle Mock'));
+      });
+
+      test('importData completes without error', () async {
+        expect(repository.importData('dummy data'), completes);
+      });
     });
   });
 }

--- a/test/features/settings/presentation/pages/llm_settings_page_test.dart
+++ b/test/features/settings/presentation/pages/llm_settings_page_test.dart
@@ -4,6 +4,7 @@ import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/local_agent/domain/services/llm_adapter.dart';
 import 'package:orionhealth_health/features/settings/application/llm_settings_cubit.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
 import 'package:orionhealth_health/features/settings/domain/services/device_capability_service.dart';
 import 'package:orionhealth_health/features/settings/presentation/pages/llm_settings_page.dart';
@@ -53,7 +54,7 @@ void main() {
 
   group('LlmSettingsPage', () {
     testWidgets('renders loading state', (tester) async {
-      when(() => mockCubit.state).thenReturn(const LlmSettingsLoading());
+      when(() => mockCubit.state).thenReturn(LlmSettingsLoading());
 
       await tester.pumpWidget(createWidget());
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
@@ -69,6 +70,7 @@ void main() {
     testWidgets('renders loaded state with tabs', (tester) async {
       when(() => mockCubit.state).thenReturn(LlmSettingsLoaded(
         config: testConfig,
+        appSettings: AppSettings(),
         deviceCapability: testCapability,
       ));
 
@@ -85,6 +87,7 @@ void main() {
     testWidgets('clicking Descargar calls cubit', (tester) async {
       when(() => mockCubit.state).thenReturn(LlmSettingsLoaded(
         config: testConfig,
+        appSettings: AppSettings(),
         deviceCapability: testCapability,
       ));
       when(() => mockCubit.downloadModel(any())).thenAnswer((_) async {});
@@ -101,6 +104,7 @@ void main() {
     testWidgets('switching to MODO tab and toggling cloud switch calls cubit', (tester) async {
       when(() => mockCubit.state).thenReturn(LlmSettingsLoaded(
         config: testConfig,
+        appSettings: AppSettings(),
         deviceCapability: testCapability,
       ));
       when(() => mockCubit.updateAllowCloudApiCalls(any())).thenAnswer((_) async {});

--- a/test/features/settings/presentation/pages/settings_page_golden_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_golden_test.dart
@@ -3,6 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/settings/application/llm_settings_cubit.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
 import 'package:orionhealth_health/features/settings/domain/services/device_capability_service.dart';
 import 'package:orionhealth_health/features/settings/presentation/pages/llm_settings_page.dart';
@@ -45,6 +46,7 @@ void main() {
 
     when(() => mockCubit.state).thenReturn(LlmSettingsLoaded(
       config: config,
+      appSettings: AppSettings(),
       deviceCapability: deviceCapability,
       installedModels: const {'smolLM-135m'},
     ));


### PR DESCRIPTION
Increased test coverage for the settings feature by adding tests for the data and infrastructure layers. This includes:
- New tests for `AppSettings` domain entity.
- New tests for `LlmConfigDto` data model.
- New tests for `SettingsLocalDataSource` using a temporary Isar instance.
- Expanded coverage for `LlmSettingsRepositoryImpl` to include AppSettings management and data portability (import/export).
- Updates to existing tests to ensure compatibility with recent state additions (`appSettings` in `LlmSettingsLoaded`).

Fixes #686

---
*PR created automatically by Jules for task [3385376941826006350](https://jules.google.com/task/3385376941826006350) started by @iberi22*