### PR TITLE
Add meditation domain and application tests

### DIFF
--- a/test/features/meditation/application/meditation_state_test.dart
+++ b/test/features/meditation/application/meditation_state_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/meditation/application/meditation_state.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_progress.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_script.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_session.dart';
+
+void main() {
+  group('MeditationState', () {
+    test('supports value equality', () {
+      expect(
+        const MeditationState(),
+        equals(const MeditationState()),
+      );
+    });
+
+    test('copyWith works correctly', () {
+      const state = MeditationState();
+      final script = MeditationScript(
+        id: '1',
+        title: 'Title',
+        category: MeditationCategory.calm,
+        durationMinutes: 5,
+        steps: ['Step'],
+      );
+      final session = MeditationSession(
+        id: 's1',
+        scriptId: '1',
+        category: MeditationCategory.calm,
+        startedAt: DateTime(2025, 1, 1),
+      );
+      const progress = MeditationProgress(totalSessions: 1);
+
+      final newState = state.copyWith(
+        status: MeditationStatus.playing,
+        script: script,
+        session: session,
+        progress: progress,
+        steps: ['Step'],
+        currentStep: 1,
+        elapsedSeconds: 30,
+        error: 'error',
+      );
+
+      expect(newState.status, MeditationStatus.playing);
+      expect(newState.script, script);
+      expect(newState.session, session);
+      expect(newState.progress, progress);
+      expect(newState.steps, ['Step']);
+      expect(newState.currentStep, 1);
+      expect(newState.elapsedSeconds, 30);
+      expect(newState.error, 'error');
+    });
+
+    test('props contains all fields', () {
+      final state = MeditationState(
+        status: MeditationStatus.idle,
+        error: 'err',
+      );
+
+      expect(state.props, containsAll([
+        MeditationStatus.idle,
+        'err',
+      ]));
+    });
+  });
+}

--- a/test/features/meditation/domain/entities/meditation_category_test.dart
+++ b/test/features/meditation/domain/entities/meditation_category_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+
+void main() {
+  group('MeditationCategory', () {
+    test('has all expected values', () {
+      expect(MeditationCategory.values, hasLength(4));
+      expect(
+        MeditationCategory.values,
+        containsAll([
+          MeditationCategory.calm,
+          MeditationCategory.focus,
+          MeditationCategory.sleep,
+          MeditationCategory.breathing,
+        ]),
+      );
+    });
+
+    test('name accessor works', () {
+      expect(MeditationCategory.calm.name, 'calm');
+      expect(MeditationCategory.focus.name, 'focus');
+      expect(MeditationCategory.sleep.name, 'sleep');
+      expect(MeditationCategory.breathing.name, 'breathing');
+    });
+  });
+}

--- a/test/features/meditation/domain/entities/meditation_preferences_test.dart
+++ b/test/features/meditation/domain/entities/meditation_preferences_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_preferences.dart';
+
+void main() {
+  group('MeditationPreferences', () {
+    test('creates with defaults', () {
+      const prefs = MeditationPreferences();
+
+      expect(prefs.preferredCategory, MeditationCategory.calm);
+      expect(prefs.preferredDurationMinutes, 5);
+      expect(prefs.ttsEnabled, isTrue);
+      expect(prefs.lastScriptId, isNull);
+    });
+
+    test('supports value equality', () {
+      expect(
+        const MeditationPreferences(
+          preferredCategory: MeditationCategory.sleep,
+          preferredDurationMinutes: 10,
+          ttsEnabled: false,
+          lastScriptId: '1',
+        ),
+        equals(const MeditationPreferences(
+          preferredCategory: MeditationCategory.sleep,
+          preferredDurationMinutes: 10,
+          ttsEnabled: false,
+          lastScriptId: '1',
+        )),
+      );
+    });
+
+    test('copyWith overrides specified fields', () {
+      const prefs = MeditationPreferences();
+      final modified = prefs.copyWith(
+        preferredCategory: MeditationCategory.sleep,
+        preferredDurationMinutes: 10,
+        ttsEnabled: false,
+        lastScriptId: 'sleep-01',
+      );
+
+      expect(modified.preferredCategory, MeditationCategory.sleep);
+      expect(modified.preferredDurationMinutes, 10);
+      expect(modified.ttsEnabled, isFalse);
+      expect(modified.lastScriptId, 'sleep-01');
+      // Original unchanged
+      expect(prefs.preferredCategory, MeditationCategory.calm);
+    });
+
+    test('toJson and fromJson roundtrip', () {
+      const prefs = MeditationPreferences(
+        preferredCategory: MeditationCategory.focus,
+        preferredDurationMinutes: 15,
+        ttsEnabled: true,
+        lastScriptId: 'focus-03',
+      );
+
+      final json = prefs.toJson();
+      final restored = MeditationPreferences.fromJson(json);
+
+      expect(restored.preferredCategory, prefs.preferredCategory);
+      expect(restored.preferredDurationMinutes, prefs.preferredDurationMinutes);
+      expect(restored.ttsEnabled, prefs.ttsEnabled);
+      expect(restored.lastScriptId, prefs.lastScriptId);
+    });
+
+    test('fromJson uses defaults for missing fields', () {
+      final json = <String, dynamic>{};
+      final restored = MeditationPreferences.fromJson(json);
+
+      expect(restored.preferredCategory, MeditationCategory.calm);
+      expect(restored.preferredDurationMinutes, 5);
+      expect(restored.ttsEnabled, isTrue);
+      expect(restored.lastScriptId, isNull);
+    });
+  });
+}

--- a/test/features/meditation/domain/entities/meditation_progress_test.dart
+++ b/test/features/meditation/domain/entities/meditation_progress_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_progress.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_session.dart';
+
+void main() {
+  group('MeditationProgress', () {
+    test('creates with defaults', () {
+      const progress = MeditationProgress();
+
+      expect(progress.totalSessions, 0);
+      expect(progress.completedSessions, 0);
+      expect(progress.totalCompletedSeconds, 0);
+      expect(progress.lastSession, isNull);
+    });
+
+    test('supports value equality', () {
+      final session = MeditationSession(
+        id: 's1',
+        scriptId: '1',
+        category: MeditationCategory.calm,
+        startedAt: DateTime(2025, 1, 1),
+      );
+
+      expect(
+        MeditationProgress(
+          totalSessions: 1,
+          completedSessions: 1,
+          totalCompletedSeconds: 300,
+          lastSession: session,
+        ),
+        equals(MeditationProgress(
+          totalSessions: 1,
+          completedSessions: 1,
+          totalCompletedSeconds: 300,
+          lastSession: session,
+        )),
+      );
+    });
+
+    test('creates with custom values', () {
+      final session = MeditationSession(
+        id: 's1',
+        scriptId: 'calm-01',
+        category: MeditationCategory.calm,
+        startedAt: DateTime(2026, 6, 15),
+        completedAt: DateTime(2026, 6, 15, 0, 5),
+        elapsedSeconds: 300,
+        completedSteps: 3,
+        completed: true,
+      );
+
+      final withSession = MeditationProgress(
+        totalSessions: 10,
+        completedSessions: 7,
+        totalCompletedSeconds: 2100,
+        lastSession: session,
+      );
+
+      expect(withSession.totalSessions, 10);
+      expect(withSession.completedSessions, 7);
+      expect(withSession.totalCompletedSeconds, 2100);
+      expect(withSession.lastSession, session);
+    });
+  });
+}

--- a/test/features/meditation/domain/entities/meditation_script_test.dart
+++ b/test/features/meditation/domain/entities/meditation_script_test.dart
@@ -1,0 +1,94 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_script.dart';
+
+void main() {
+  group('MeditationScript', () {
+    const testScript = MeditationScript(
+      id: 'breath-01',
+      title: 'Respiración Profunda',
+      category: MeditationCategory.breathing,
+      durationMinutes: 5,
+      steps: [
+        'Siéntate cómodamente',
+        'Inhala profundamente',
+        'Exhala lentamente',
+      ],
+      tags: ['respiración', 'principiante'],
+    );
+
+    test('creates with required fields', () {
+      expect(testScript.id, 'breath-01');
+      expect(testScript.title, 'Respiración Profunda');
+      expect(testScript.category, MeditationCategory.breathing);
+      expect(testScript.durationMinutes, 5);
+      expect(testScript.steps, hasLength(3));
+    });
+
+    test('supports value equality', () {
+      expect(
+        const MeditationScript(
+          id: '1',
+          title: 'Title',
+          category: MeditationCategory.calm,
+          durationMinutes: 5,
+          steps: ['Step'],
+        ),
+        equals(const MeditationScript(
+          id: '1',
+          title: 'Title',
+          category: MeditationCategory.calm,
+          durationMinutes: 5,
+          steps: ['Step'],
+        )),
+      );
+    });
+
+    test('default tags is empty', () {
+      const noTags = MeditationScript(
+        id: 'test',
+        title: 'Test',
+        category: MeditationCategory.calm,
+        durationMinutes: 3,
+        steps: ['Step 1'],
+      );
+      expect(noTags.tags, isEmpty);
+    });
+
+    test('toJson produces correct map', () {
+      final json = testScript.toJson();
+
+      expect(json['id'], 'breath-01');
+      expect(json['title'], 'Respiración Profunda');
+      expect(json['category'], 'breathing');
+      expect(json['durationMinutes'], 5);
+      expect(json['steps'], isA<List>());
+      expect(json['steps'], hasLength(3));
+      expect(json['tags'], hasLength(2));
+    });
+
+    test('fromJson reconstructs correctly', () {
+      final json = testScript.toJson();
+      final restored = MeditationScript.fromJson(json);
+
+      expect(restored.id, testScript.id);
+      expect(restored.title, testScript.title);
+      expect(restored.category, testScript.category);
+      expect(restored.durationMinutes, testScript.durationMinutes);
+      expect(restored.steps, testScript.steps);
+      expect(restored.tags, testScript.tags);
+    });
+
+    test('fromJson handles missing tags', () {
+      final json = {
+        'id': 'simple',
+        'title': 'Simple',
+        'category': 'calm',
+        'durationMinutes': 3,
+        'steps': ['Step'],
+      };
+      final restored = MeditationScript.fromJson(json);
+      expect(restored.tags, isEmpty);
+    });
+  });
+}

--- a/test/features/meditation/domain/entities/meditation_session_test.dart
+++ b/test/features/meditation/domain/entities/meditation_session_test.dart
@@ -1,0 +1,84 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_category.dart';
+import 'package:orionhealth_health/features/meditation/domain/entities/meditation_session.dart';
+
+void main() {
+  group('MeditationSession', () {
+    final now = DateTime(2026, 6, 15, 19, 0, 0);
+
+    test('creates with required fields', () {
+      final record = MeditationSession(
+        id: 'session-1',
+        scriptId: 'breath-01',
+        category: MeditationCategory.breathing,
+        startedAt: now,
+      );
+
+      expect(record.id, 'session-1');
+      expect(record.scriptId, 'breath-01');
+      expect(record.category, MeditationCategory.breathing);
+      expect(record.startedAt, now);
+      expect(record.completedAt, isNull);
+      expect(record.elapsedSeconds, 0);
+      expect(record.completedSteps, 0);
+      expect(record.completed, isFalse);
+    });
+
+    test('supports value equality', () {
+      final session1 = MeditationSession(
+        id: '1',
+        scriptId: 's1',
+        category: MeditationCategory.calm,
+        startedAt: now,
+      );
+      final session2 = MeditationSession(
+        id: '1',
+        scriptId: 's1',
+        category: MeditationCategory.calm,
+        startedAt: now,
+      );
+
+      expect(session1, equals(session2));
+    });
+
+    test('toJson and fromJson roundtrip', () {
+      final record = MeditationSession(
+        id: 'session-2',
+        scriptId: 'calm-01',
+        category: MeditationCategory.calm,
+        startedAt: now,
+        completedAt: now.add(const Duration(minutes: 5)),
+        elapsedSeconds: 300,
+        completedSteps: 3,
+        completed: true,
+      );
+
+      final json = record.toJson();
+      final restored = MeditationSession.fromJson(json);
+
+      expect(restored.id, record.id);
+      expect(restored.scriptId, record.scriptId);
+      expect(restored.category, record.category);
+      expect(restored.startedAt, record.startedAt);
+      expect(restored.completedAt, record.completedAt);
+      expect(restored.elapsedSeconds, record.elapsedSeconds);
+      expect(restored.completedSteps, record.completedSteps);
+      expect(restored.completed, record.completed);
+    });
+
+    test('fromJson handles null completedAt', () {
+      final json = {
+        'id': 'session-3',
+        'scriptId': 'sleep-02',
+        'category': 'sleep',
+        'startedAt': now.toIso8601String(),
+      };
+
+      final restored = MeditationSession.fromJson(json);
+      expect(restored.completedAt, isNull);
+      expect(restored.elapsedSeconds, 0);
+      expect(restored.completedSteps, 0);
+      expect(restored.completed, isFalse);
+    });
+  });
+}


### PR DESCRIPTION
Added missing unit tests for the meditation feature's domain entities and application state.

Changes:
- Created individual test files for MeditationCategory, MeditationPreferences, MeditationProgress, MeditationScript, and MeditationSession in `test/features/meditation/domain/entities/`.
- Created `test/features/meditation/application/meditation_state_test.dart` to test state management.
- Ensured all new tests follow the project's Clean Architecture testing structure and pass successfully.
- Verified that all five meditation use cases already had comprehensive tests in `test/features/meditation/domain/usecases/`.

Fixes #713

---
*PR created automatically by Jules for task [5255568079559715909](https://jules.google.com/task/5255568079559715909) started by @iberi22*