### PR TITLE
[test] Add health_record: entity and bloc tests

### DIFF
--- a/test/features/health_record/application/bloc/health_record_cubit_test.dart
+++ b/test/features/health_record/application/bloc/health_record_cubit_test.dart
@@ -1,0 +1,255 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_record/application/bloc/health_record_cubit.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+import 'package:orionhealth_health/features/health_record/domain/repositories/health_record_repository.dart';
+import 'package:orionhealth_health/features/health_record/infrastructure/services/file_picker_service.dart';
+import 'package:orionhealth_health/features/health_record/infrastructure/services/image_picker_service.dart';
+import 'package:orionhealth_health/features/health_record/infrastructure/services/ocr_service.dart';
+import 'package:orionhealth_health/features/local_agent/domain/services/vector_store_service.dart';
+
+class MockHealthRecordRepository extends Mock implements HealthRecordRepository {}
+class MockFilePickerService extends Mock implements FilePickerService {}
+class MockImagePickerService extends Mock implements ImagePickerService {}
+class MockOcrService extends Mock implements OcrService {}
+class MockVectorStoreService extends Mock implements VectorStoreService {}
+
+void main() {
+  late HealthRecordCubit cubit;
+  late MockHealthRecordRepository mockRepository;
+  late MockFilePickerService mockFilePicker;
+  late MockImagePickerService mockImagePicker;
+  late MockOcrService mockOcrService;
+  late MockVectorStoreService mockVectorStore;
+
+  setUpAll(() {
+    registerFallbackValue(MedicalRecord(
+      date: DateTime.now(),
+      type: RecordType.other,
+      summary: '',
+      attachments: [],
+    ));
+  });
+
+  setUp(() {
+    mockRepository = MockHealthRecordRepository();
+    mockFilePicker = MockFilePickerService();
+    mockImagePicker = MockImagePickerService();
+    mockOcrService = MockOcrService();
+    mockVectorStore = MockVectorStoreService();
+
+    cubit = HealthRecordCubit(
+      mockRepository,
+      mockFilePicker,
+      mockImagePicker,
+      mockOcrService,
+      mockVectorStore,
+    );
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  test('initial state is HealthRecordInitial', () {
+    expect(cubit.state, const HealthRecordInitial());
+  });
+
+  group('loadRecords', () {
+    final records = [MedicalRecord(summary: 'Record 1')];
+
+    test('emits [Loading, Loaded] when success', () async {
+      when(() => mockRepository.getAllRecords()).thenAnswer((_) async => records);
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          HealthRecordLoaded(records),
+        ]),
+      );
+
+      await cubit.loadRecords();
+      await expectation;
+    });
+
+    test('emits [Loading, Error] when failure', () async {
+      when(() => mockRepository.getAllRecords()).thenThrow(Exception('Error'));
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordError('Exception: Error'),
+        ]),
+      );
+
+      await cubit.loadRecords();
+      await expectation;
+    });
+  });
+
+  group('resetAndLoad', () {
+    test('calls loadRecords', () async {
+      when(() => mockRepository.getAllRecords()).thenAnswer((_) async => []);
+
+      await cubit.resetAndLoad();
+
+      verify(() => mockRepository.getAllRecords()).called(1);
+    });
+  });
+
+  group('pickPdf', () {
+    test('emits [Loading, FilePicked] when success', () async {
+      when(() => mockFilePicker.pickPdf()).thenAnswer((_) async => 'path.pdf');
+      when(() => mockOcrService.extractText(any())).thenAnswer((_) async => 'text');
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordFilePicked(filePath: 'path.pdf', extractedText: 'text'),
+        ]),
+      );
+
+      await cubit.pickPdf();
+      await expectation;
+    });
+
+    test('emits [Loading, Initial] when cancelled', () async {
+      when(() => mockFilePicker.pickPdf()).thenAnswer((_) async => null);
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordInitial(),
+        ]),
+      );
+
+      await cubit.pickPdf();
+      await expectation;
+    });
+
+    test('emits [Loading, Error] when failure', () async {
+      when(() => mockFilePicker.pickPdf()).thenAnswer((_) async => 'path.pdf');
+      when(() => mockOcrService.extractText(any())).thenThrow(Exception('OCR Error'));
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordError('Exception: OCR Error'),
+        ]),
+      );
+
+      await cubit.pickPdf();
+      await expectation;
+    });
+  });
+
+  group('pickImage', () {
+    test('emits [Loading, FilePicked] from camera success', () async {
+      when(() => mockImagePicker.pickImageFromCamera()).thenAnswer((_) async => 'camera.jpg');
+      when(() => mockOcrService.extractText(any())).thenAnswer((_) async => 'text');
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordFilePicked(filePath: 'camera.jpg', extractedText: 'text'),
+        ]),
+      );
+
+      await cubit.pickImage(true);
+      await expectation;
+    });
+
+    test('emits [Loading, FilePicked] from gallery success', () async {
+      when(() => mockImagePicker.pickImageFromGallery()).thenAnswer((_) async => 'gallery.jpg');
+      when(() => mockOcrService.extractText(any())).thenAnswer((_) async => 'text');
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordFilePicked(filePath: 'gallery.jpg', extractedText: 'text'),
+        ]),
+      );
+
+      await cubit.pickImage(false);
+      await expectation;
+    });
+
+    test('emits [Loading, Initial] when cancelled', () async {
+      when(() => mockImagePicker.pickImageFromCamera()).thenAnswer((_) async => null);
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordInitial(),
+        ]),
+      );
+
+      await cubit.pickImage(true);
+      await expectation;
+    });
+  });
+
+  group('saveRecord', () {
+    final date = DateTime(2025, 1, 1);
+
+    test('emits [Loading, Saved] when success', () async {
+      when(() => mockRepository.saveRecord(any())).thenAnswer((_) async => {});
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordSaved(),
+        ]),
+      );
+
+      await cubit.saveRecord(
+        filePath: 'test.pdf',
+        extractedText: 'text',
+        summary: 'summary',
+        type: RecordType.labResult,
+        date: date,
+      );
+      await expectation;
+    });
+
+    test('emits [Loading, Error] when failure', () async {
+      when(() => mockRepository.saveRecord(any())).thenThrow(Exception('Save Error'));
+
+      final expectation = expectLater(
+        cubit.stream,
+        emitsInOrder([
+          const HealthRecordLoading(),
+          const HealthRecordError('Exception: Save Error'),
+        ]),
+      );
+
+      await cubit.saveRecord(
+        filePath: 'test.pdf',
+        extractedText: 'text',
+        summary: 'summary',
+        type: RecordType.labResult,
+        date: date,
+      );
+      await expectation;
+    });
+  });
+
+  group('reset', () {
+    test('emits HealthRecordInitial', () {
+      cubit.emit(const HealthRecordError('Error'));
+
+      cubit.reset();
+
+      expect(cubit.state, const HealthRecordInitial());
+    });
+  });
+}

--- a/test/features/health_record/application/bloc/health_record_state_test.dart
+++ b/test/features/health_record/application/bloc/health_record_state_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_record/application/bloc/health_record_cubit.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+
+void main() {
+  group('HealthRecordState', () {
+    test('HealthRecordInitial supports value equality', () {
+      expect(const HealthRecordInitial(), equals(const HealthRecordInitial()));
+    });
+
+    test('HealthRecordLoading supports value equality', () {
+      expect(const HealthRecordLoading(), equals(const HealthRecordLoading()));
+    });
+
+    test('HealthRecordLoaded supports value equality', () {
+      final records = [
+        MedicalRecord(summary: 'Record 1'),
+        MedicalRecord(summary: 'Record 2'),
+      ];
+      expect(
+        HealthRecordLoaded(records),
+        equals(HealthRecordLoaded(records)),
+      );
+    });
+
+    test('HealthRecordFilePicked supports value equality', () {
+      expect(
+        const HealthRecordFilePicked(filePath: 'path', extractedText: 'text'),
+        equals(const HealthRecordFilePicked(filePath: 'path', extractedText: 'text')),
+      );
+    });
+
+    test('HealthRecordSaved supports value equality', () {
+      expect(const HealthRecordSaved(), equals(const HealthRecordSaved()));
+    });
+
+    test('HealthRecordError supports value equality', () {
+      expect(
+        const HealthRecordError('error'),
+        equals(const HealthRecordError('error')),
+      );
+    });
+
+    test('records getter returns empty list for base states', () {
+      expect(const HealthRecordInitial().records, isEmpty);
+      expect(const HealthRecordLoading().records, isEmpty);
+      expect(const HealthRecordSaved().records, isEmpty);
+      expect(const HealthRecordError('error').records, isEmpty);
+    });
+
+    test('records getter returns records for HealthRecordLoaded', () {
+      final records = [MedicalRecord(summary: 'Record 1')];
+      expect(HealthRecordLoaded(records).records, equals(records));
+    });
+
+    test('props are correct for each state', () {
+      expect(const HealthRecordInitial().props, isEmpty);
+      expect(const HealthRecordLoading().props, isEmpty);
+
+      final records = [MedicalRecord(summary: 'Record 1')];
+      expect(HealthRecordLoaded(records).props, [records]);
+
+      expect(
+        const HealthRecordFilePicked(filePath: 'path', extractedText: 'text').props,
+        ['path', 'text'],
+      );
+
+      expect(const HealthRecordSaved().props, isEmpty);
+      expect(const HealthRecordError('error').props, ['error']);
+    });
+  });
+}

--- a/test/features/health_record/domain/entities/medical_record_test.dart
+++ b/test/features/health_record/domain/entities/medical_record_test.dart
@@ -78,6 +78,30 @@ void main() {
       expect(fromJson.attachments.first, equals(attachment));
     });
 
+    test('fromJson should handle null or missing fields', () {
+      final json = {
+        'id': 1,
+        'type': 'other',
+      };
+      final record = MedicalRecord.fromJson(json);
+
+      expect(record.id, 1);
+      expect(record.date, isNull);
+      expect(record.summary, isNull);
+      expect(record.attachments, isEmpty);
+      expect(record.type, RecordType.other);
+    });
+
+    test('fromJson should handle null attachments list', () {
+      final json = {
+        'id': 1,
+        'type': 'other',
+        'attachments': null,
+      };
+      final record = MedicalRecord.fromJson(json);
+      expect(record.attachments, isEmpty);
+    });
+
     test('should handle validation', () {
       final validAttachment = MedicalAttachment(localPath: 'path.pdf');
       final invalidAttachment = MedicalAttachment(localPath: '');


### PR DESCRIPTION
This PR adds missing unit tests for the health_record feature's application and domain layers. 

Specifically:
- Added `health_record_state_test.dart` to verify Equatable implementation and property access for all states.
- Added `health_record_cubit_test.dart` to test state transitions and repository/service interactions for all Cubit methods.
- Expanded `medical_record_test.dart` to include edge case testing for `fromJson`, ensuring robustness against null or missing optional fields.

All new and existing tests in the `test/features/health_record/` directory pass successfully.

Fixes #703

---
*PR created automatically by Jules for task [5009921730017029303](https://jules.google.com/task/5009921730017029303) started by @iberi22*