### PR TITLE
Add onboarding: entity and service layer tests

### DIFF
--- a/test/features/onboarding/application/onboarding_cubit_test.dart
+++ b/test/features/onboarding/application/onboarding_cubit_test.dart
@@ -194,6 +194,32 @@ void main() {
         await expectation;
       });
 
+      test('previousStep at step 0 stays at step 0', () async {
+        await cubit.startOnboarding();
+        expect(cubit.currentStep, 0);
+
+        await cubit.previousStep();
+        expect(cubit.currentStep, 0);
+      });
+
+      test('nextStep at final step does not exceed total steps', () async {
+        await cubit.startOnboarding();
+        // Manually set to last step
+        final lastStep = OnboardingCubit.totalSteps - 1;
+        final profile = (cubit.state as OnboardingInProgress).profile.copyWith(
+              onboardingStep: lastStep,
+              name: 'Test',
+              birthDate: DateTime.now(),
+              sex: 'M',
+              privacyConsent: true,
+            );
+        await cubit.resumeOnboarding(profile);
+        expect(cubit.currentStep, lastStep);
+
+        await cubit.nextStep();
+        expect(cubit.currentStep, lastStep);
+      });
+
       test('skipOnboarding emits OnboardingCompleted', () async {
         await cubit.startOnboarding();
 
@@ -328,6 +354,16 @@ void main() {
       final next = state.copyWith(currentStep: 1);
       expect(next.currentStep, 1);
       expect(next.profile, profile);
+    });
+
+    test('updateAllergies documents current no-op behavior', () async {
+      await cubit.startOnboarding();
+      final originalProfile = (cubit.state as OnboardingInProgress).profile;
+
+      await cubit.updateAllergies(['Peanuts']);
+
+      // Currently updateAllergies is empty in lib/, so profile shouldn't change
+      expect((cubit.state as OnboardingInProgress).profile, equals(originalProfile));
     });
   });
 }

--- a/test/features/onboarding/domain/entities/relevant_standards_test.dart
+++ b/test/features/onboarding/domain/entities/relevant_standards_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/onboarding/domain/services/profile_analysis_service.dart';
+
+void main() {
+  group('RelevantStandards', () {
+    test('supports value storage via constructor', () {
+      const standards = RelevantStandards(
+        icd10Codes: ['E11', 'I10'],
+        loincCodes: ['2345-7', '8480-6'],
+        guidelineIds: ['ADA-2024', 'JNC-8'],
+        medicationClasses: ['metformin', 'ace_inhibitors'],
+        estimatedSizeMB: 45,
+      );
+
+      expect(standards.icd10Codes, ['E11', 'I10']);
+      expect(standards.loincCodes, ['2345-7', '8480-6']);
+      expect(standards.guidelineIds, ['ADA-2024', 'JNC-8']);
+      expect(standards.medicationClasses, ['metformin', 'ace_inhibitors']);
+      expect(standards.estimatedSizeMB, 45);
+    });
+
+    test('default values are empty or zero', () {
+      const standards = RelevantStandards();
+
+      expect(standards.icd10Codes, isEmpty);
+      expect(standards.loincCodes, isEmpty);
+      expect(standards.guidelineIds, isEmpty);
+      expect(standards.medicationClasses, isEmpty);
+      expect(standards.estimatedSizeMB, 0);
+    });
+  });
+}

--- a/test/features/onboarding/domain/services/profile_analysis_service_test.dart
+++ b/test/features/onboarding/domain/services/profile_analysis_service_test.dart
@@ -91,5 +91,37 @@ void main() {
       expect(standards.medicationClasses, isEmpty);
       expect(standards.estimatedSizeMB, 0);
     });
+
+    test('analyzeProfile aggregates codes for multiple conditions', () {
+      final profile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        conditions: const ['Diabetes', 'Hypertension'],
+      );
+
+      final standards = service.analyzeProfile(profile);
+
+      expect(standards.icd10Codes, containsAll(['E10', 'E11', 'I10', 'I11']));
+      expect(standards.loincCodes, containsAll(['2345-7', '4548-4', '8480-6', '8462-4']));
+      expect(standards.guidelineIds, containsAll(['ADA-2024', 'JNC-8']));
+      expect(standards.medicationClasses, containsAll(['insulin', 'metformin', 'ace_inhibitors', 'beta_blockers']));
+      expect(standards.estimatedSizeMB, greaterThan(0));
+    });
+
+    test('analyzeProfile handles unknown conditions gracefully', () {
+      final profile = UserProfile(
+        createdAt: DateTime.now(),
+        updatedAt: DateTime.now(),
+        conditions: const ['Unknown condition 123'],
+      );
+
+      final standards = service.analyzeProfile(profile);
+
+      expect(standards.icd10Codes, isEmpty);
+      expect(standards.loincCodes, isEmpty);
+      expect(standards.guidelineIds, isEmpty);
+      expect(standards.medicationClasses, isEmpty);
+      expect(standards.estimatedSizeMB, 0);
+    });
   });
 }


### PR DESCRIPTION
This PR adds missing unit tests for the onboarding feature, specifically targeting the domain and application layers. 

Changes:
- Created `test/features/onboarding/domain/entities/relevant_standards_test.dart` to verify the `RelevantStandards` data class.
- Updated `test/features/onboarding/domain/services/profile_analysis_service_test.dart` to include tests for multiple medical conditions aggregation and unknown conditions handling.
- Enhanced `test/features/onboarding/application/onboarding_cubit_test.dart` with tests for step boundary conditions (preventing underflow/overflow) and documenting current behavior of the `updateAllergies` method.
- Verified all tests pass in the targeted directories.

Note: `flutter gen-l10n` was run during verification to resolve missing localization errors in the test environment.

Fixes #705

---
*PR created automatically by Jules for task [16901444064338206003](https://jules.google.com/task/16901444064338206003) started by @iberi22*