### PR TITLE
Add health_record presentation and repository tests

### DIFF
--- a/test/features/health_record/infrastructure/repositories/health_record_repository_impl_test.dart
+++ b/test/features/health_record/infrastructure/repositories/health_record_repository_impl_test.dart
@@ -1,0 +1,68 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_attachment.dart';
+import 'package:orionhealth_health/features/health_record/infrastructure/repositories/health_record_repository_impl.dart';
+import 'dart:io';
+import 'package:path/path.dart' as p;
+
+void main() {
+  late Isar isar;
+  late HealthRecordRepositoryImpl repository;
+  late String testDir;
+
+  setUpAll(() async {
+    testDir = p.join(Directory.systemTemp.path, 'test_db_health_records_repo_impl');
+    await Directory(testDir).create(recursive: true);
+
+    await Isar.initializeIsarCore(download: true);
+    isar = await Isar.open(
+      [MedicalRecordSchema],
+      directory: testDir,
+    );
+    repository = HealthRecordRepositoryImpl(isar);
+  });
+
+  tearDownAll(() async {
+    await isar.close();
+    if (await Directory(testDir).exists()) {
+      await Directory(testDir).delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    await isar.writeTxn(() => isar.medicalRecords.clear());
+  });
+
+  group('HealthRecordRepositoryImpl', () {
+    test('saveRecord should persist medical record', () async {
+      final record = MedicalRecord(
+        summary: 'Test Record',
+        type: RecordType.clinicalNote,
+        date: DateTime(2023, 1, 1),
+      );
+
+      await repository.saveRecord(record);
+
+      final results = await isar.medicalRecords.where().findAll();
+      expect(results.length, 1);
+      expect(results.first.summary, 'Test Record');
+    });
+
+    test('getAllRecords should return all persisted records', () async {
+      final records = [
+        MedicalRecord(summary: 'Record 1'),
+        MedicalRecord(summary: 'Record 2'),
+      ];
+
+      await isar.writeTxn(() async {
+        await isar.medicalRecords.putAll(records);
+      });
+
+      final results = await repository.getAllRecords();
+      expect(results.length, 2);
+      expect(results.any((r) => r.summary == 'Record 1'), isTrue);
+      expect(results.any((r) => r.summary == 'Record 2'), isTrue);
+    });
+  });
+}

--- a/test/features/health_record/presentation/pages/health_record_staging_page_test.dart
+++ b/test/features/health_record/presentation/pages/health_record_staging_page_test.dart
@@ -1,0 +1,147 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/health_record/presentation/pages/health_record_staging_page.dart';
+import 'package:orionhealth_health/features/health_record/application/bloc/health_record_cubit.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+
+class MockHealthRecordCubit extends Mock implements HealthRecordCubit {}
+
+void main() {
+  late MockHealthRecordCubit mockCubit;
+  late StreamController<HealthRecordState> stateController;
+
+  setUpAll(() {
+    registerFallbackValue(RecordType.clinicalNote);
+    registerFallbackValue(DateTime.now());
+  });
+
+  setUp(() {
+    mockCubit = MockHealthRecordCubit();
+    stateController = StreamController<HealthRecordState>.broadcast();
+
+    when(() => mockCubit.state).thenReturn(HealthRecordInitial());
+    when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+    when(() => mockCubit.loadRecords()).thenAnswer((_) async {});
+    when(() => mockCubit.resetAndLoad()).thenAnswer((_) async {});
+    when(() => mockCubit.pickPdf()).thenAnswer((_) async {});
+    when(() => mockCubit.pickImage(any())).thenAnswer((_) async {});
+
+    final getIt = GetIt.instance;
+    if (getIt.isRegistered<HealthRecordCubit>()) {
+      getIt.unregister<HealthRecordCubit>();
+    }
+    getIt.registerLazySingleton<HealthRecordCubit>(() => mockCubit);
+  });
+
+  tearDown(() {
+    stateController.close();
+    GetIt.instance.unregister<HealthRecordCubit>();
+  });
+
+  Widget createWidgetUnderTest() {
+    return const MaterialApp(
+      home: HealthRecordStagingPage(),
+    );
+  }
+
+  group('HealthRecordStagingPage', () {
+    testWidgets('loads records on initialization', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+      verify(() => mockCubit.loadRecords()).called(1);
+    });
+
+    testWidgets('shows loading indicator when state is loading', (tester) async {
+      when(() => mockCubit.state).thenReturn(HealthRecordLoading());
+      await tester.pumpWidget(createWidgetUnderTest());
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('renders record history when state is loaded', (tester) async {
+      final records = [
+        MedicalRecord(
+          summary: 'Test Record 1',
+          type: RecordType.clinicalNote,
+          date: DateTime(2023, 1, 1),
+        ),
+      ];
+      when(() => mockCubit.state).thenReturn(HealthRecordLoaded(records));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Test Record 1'), findsOneWidget);
+      expect(find.text('clinicalNote'), findsOneWidget);
+    });
+
+    testWidgets('shows empty message when no records', (tester) async {
+      when(() => mockCubit.state).thenReturn(const HealthRecordLoaded([]));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('No hay registros.'), findsOneWidget);
+    });
+
+    testWidgets('opens selection modal when FAB is pressed', (tester) async {
+      when(() => mockCubit.state).thenReturn(const HealthRecordLoaded([]));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Subir PDF'), findsOneWidget);
+      expect(find.text('Tomar Foto'), findsOneWidget);
+      expect(find.text('Galería'), findsOneWidget);
+    });
+
+    testWidgets('calls pickPdf when PDF is selected in modal', (tester) async {
+      when(() => mockCubit.state).thenReturn(const HealthRecordLoaded([]));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.tap(find.byType(FloatingActionButton));
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Subir PDF'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockCubit.pickPdf()).called(1);
+    });
+
+    testWidgets('shows form when state is HealthRecordFilePicked', (tester) async {
+      when(() => mockCubit.state).thenReturn(const HealthRecordFilePicked(
+        filePath: 'test.pdf',
+        extractedText: 'Extracted text',
+      ));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Nuevo Registro Médico'), findsOneWidget);
+      expect(find.text('Archivo: test.pdf'), findsOneWidget);
+      expect(find.text('Extracted text'), findsOneWidget);
+    });
+
+    testWidgets('shows success snackbar and reloads when saved', (tester) async {
+      when(() => mockCubit.state).thenReturn(const HealthRecordLoaded([]));
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      stateController.add(HealthRecordSaved());
+      await tester.pump();
+
+      expect(find.text('Registro guardado exitosamente'), findsOneWidget);
+      verify(() => mockCubit.resetAndLoad()).called(1);
+    });
+
+    testWidgets('shows error snackbar on error', (tester) async {
+      when(() => mockCubit.state).thenReturn(const HealthRecordLoaded([]));
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      stateController.add(const HealthRecordError('Operation failed'));
+      await tester.pump();
+
+      expect(find.text('Error: Operation failed'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/health_record/presentation/pages/timeline_page_test.dart
+++ b/test/features/health_record/presentation/pages/timeline_page_test.dart
@@ -1,0 +1,150 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:health_wallet/health_wallet.dart';
+import 'package:orionhealth_health/features/health_record/presentation/pages/timeline_page.dart';
+import 'package:orionhealth_health/features/health_record/domain/repositories/health_record_repository.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+
+class MockHealthRecordRepository extends Mock implements HealthRecordRepository {}
+class MockWalletService extends Mock implements WalletService {}
+
+void main() {
+  late MockHealthRecordRepository mockRepo;
+  late MockWalletService mockWalletService;
+
+  setUp(() {
+    mockRepo = MockHealthRecordRepository();
+    mockWalletService = MockWalletService();
+
+    final getIt = GetIt.instance;
+    if (getIt.isRegistered<HealthRecordRepository>()) {
+      getIt.unregister<HealthRecordRepository>();
+    }
+    if (getIt.isRegistered<WalletService>()) {
+      getIt.unregister<WalletService>();
+    }
+    getIt.registerLazySingleton<HealthRecordRepository>(() => mockRepo);
+    getIt.registerLazySingleton<WalletService>(() => mockWalletService);
+  });
+
+  tearDown(() {
+    GetIt.instance.unregister<HealthRecordRepository>();
+    GetIt.instance.unregister<WalletService>();
+  });
+
+  Widget createWidgetUnderTest() {
+    return const MaterialApp(
+      home: TimelinePage(),
+    );
+  }
+
+  group('TimelinePage', () {
+    testWidgets('renders loading indicator initially', (tester) async {
+      when(() => mockRepo.getAllRecords()).thenAnswer((_) async => []);
+      when(() => mockWalletService.getTimeline()).thenAnswer((_) async => []);
+      when(() => mockWalletService.getDataStatistics()).thenAnswer((_) async => {'labs': 0});
+      when(() => mockWalletService.getAllMedicalConcepts()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+    });
+
+    testWidgets('renders timeline entries from local repository', (tester) async {
+      final records = [
+        MedicalRecord(
+          summary: 'Local Clinical Note',
+          type: RecordType.clinicalNote,
+          date: DateTime(2023, 10, 1),
+        ),
+      ];
+
+      when(() => mockRepo.getAllRecords()).thenAnswer((_) async => records);
+      when(() => mockWalletService.getTimeline()).thenAnswer((_) async => []);
+      when(() => mockWalletService.getDataStatistics()).thenAnswer((_) async => {'labs': 0});
+      when(() => mockWalletService.getAllMedicalConcepts()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Nota Clínica'), findsOneWidget);
+      expect(find.text('Local Clinical Note'), findsOneWidget);
+    });
+
+    testWidgets('renders timeline entries from WalletService', (tester) async {
+      final now = DateTime.now();
+      final events = [
+        MedicalEvent(
+          remoteId: '1',
+          description: 'Remote Medical Event',
+          eventDate: now,
+          eventType: EventType.wellnessCheck,
+          facility: 'Test Hospital',
+          createdAt: now,
+          updatedAt: now,
+        ),
+      ];
+
+      when(() => mockRepo.getAllRecords()).thenAnswer((_) async => []);
+      when(() => mockWalletService.getTimeline()).thenAnswer((_) async => events);
+      when(() => mockWalletService.getDataStatistics()).thenAnswer((_) async => {'labs': 0});
+      when(() => mockWalletService.getAllMedicalConcepts()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Remote Medical Event'), findsOneWidget);
+      expect(find.text('WELLNESSCHECK at Test Hospital'), findsOneWidget);
+    });
+
+    testWidgets('renders medical concepts from WalletService', (tester) async {
+      final now = DateTime.now();
+      final concepts = [
+        MedicalConcept(
+          remoteId: '1',
+          doctorName: 'House',
+          notes: 'It is not lupus',
+          conceptDate: now,
+          recommendations: 'Take some rest',
+          createdAt: now,
+          updatedAt: now,
+        ),
+      ];
+
+      when(() => mockRepo.getAllRecords()).thenAnswer((_) async => []);
+      when(() => mockWalletService.getTimeline()).thenAnswer((_) async => []);
+      when(() => mockWalletService.getDataStatistics()).thenAnswer((_) async => {'labs': 0});
+      when(() => mockWalletService.getAllMedicalConcepts()).thenAnswer((_) async => concepts);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pumpAndSettle();
+
+      expect(find.text('Nota de Dr. House'), findsOneWidget);
+      expect(find.text('It is not lupus'), findsOneWidget);
+      expect(find.text('Rec: Take some rest'), findsOneWidget);
+    });
+
+    testWidgets('shows empty message when no data', (tester) async {
+      when(() => mockRepo.getAllRecords()).thenAnswer((_) async => []);
+      when(() => mockWalletService.getTimeline()).thenAnswer((_) async => []);
+      when(() => mockWalletService.getDataStatistics()).thenAnswer((_) async => {'labs': 0});
+      when(() => mockWalletService.getAllMedicalConcepts()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pumpAndSettle();
+
+      expect(find.text('No hay eventos en tu historial médico.'), findsOneWidget);
+    });
+
+    testWidgets('shows error message on failure', (tester) async {
+      when(() => mockRepo.getAllRecords()).thenThrow(Exception('Failed to load'));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Error: Exception: Failed to load'), findsOneWidget);
+    });
+  });
+}

--- a/test/features/health_record/presentation/pages/upload_page_test.dart
+++ b/test/features/health_record/presentation/pages/upload_page_test.dart
@@ -1,0 +1,170 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:orionhealth_health/features/health_record/presentation/pages/upload_page.dart';
+import 'package:orionhealth_health/features/health_record/application/bloc/health_record_cubit.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+
+class MockHealthRecordCubit extends Mock implements HealthRecordCubit {}
+class MockNavigatorObserver extends Mock implements NavigatorObserver {}
+class FakeRoute extends Fake implements Route<dynamic> {}
+
+void main() {
+  late MockHealthRecordCubit mockCubit;
+  late StreamController<HealthRecordState> stateController;
+
+  setUpAll(() {
+    registerFallbackValue(RecordType.clinicalNote);
+    registerFallbackValue(DateTime.now());
+    registerFallbackValue(FakeRoute());
+  });
+
+  setUp(() {
+    mockCubit = MockHealthRecordCubit();
+    stateController = StreamController<HealthRecordState>.broadcast();
+
+    when(() => mockCubit.state).thenReturn(HealthRecordInitial());
+    when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+    when(() => mockCubit.pickPdf()).thenAnswer((_) async {});
+    when(() => mockCubit.pickImage(any())).thenAnswer((_) async {});
+    when(() => mockCubit.reset()).thenAnswer((_) async {});
+  });
+
+  tearDown(() {
+    stateController.close();
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: BlocProvider<HealthRecordCubit>.value(
+        value: mockCubit,
+        child: const UploadPage(),
+      ),
+    );
+  }
+
+  group('UploadPage', () {
+    testWidgets('renders source selection step when state is initial', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Selecciona el origen'), findsOneWidget);
+      expect(find.text('Subir Documento PDF'), findsOneWidget);
+      expect(find.text('Tomar Foto'), findsOneWidget);
+      expect(find.text('Elegir de la Galería'), findsOneWidget);
+    });
+
+    testWidgets('calls pickPdf when PDF option is tapped', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.tap(find.text('Subir Documento PDF'));
+      await tester.pump();
+
+      verify(() => mockCubit.pickPdf()).called(1);
+    });
+
+    testWidgets('calls pickImage(true) when Take Photo is tapped', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.tap(find.text('Tomar Foto'));
+      await tester.pump();
+
+      verify(() => mockCubit.pickImage(true)).called(1);
+    });
+
+    testWidgets('calls pickImage(false) when Gallery is tapped', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.tap(find.text('Elegir de la Galería'));
+      await tester.pump();
+
+      verify(() => mockCubit.pickImage(false)).called(1);
+    });
+
+    testWidgets('shows loading indicator when state is loading', (tester) async {
+      when(() => mockCubit.state).thenReturn(HealthRecordLoading());
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      expect(find.text('Procesando documento...'), findsOneWidget);
+    });
+
+    testWidgets('shows details step when file is picked', (tester) async {
+      when(() => mockCubit.state).thenReturn(const HealthRecordFilePicked(
+        filePath: 'test/path/report.pdf',
+        extractedText: 'Extracted Content',
+      ));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Verificar Información'), findsOneWidget);
+      expect(find.text('Archivo: report.pdf'), findsOneWidget);
+      expect(find.text('Extracted Content'), findsOneWidget);
+    });
+
+    testWidgets('validates and saves record in details step', (tester) async {
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(tester.view.resetPhysicalSize);
+      addTearDown(tester.view.resetDevicePixelRatio);
+
+      when(() => mockCubit.state).thenReturn(const HealthRecordFilePicked(
+        filePath: 'test/path/report.pdf',
+        extractedText: 'Extracted Content',
+      ));
+      when(() => mockCubit.saveRecord(
+        filePath: any(named: 'filePath'),
+        extractedText: any(named: 'extractedText'),
+        summary: any(named: 'summary'),
+        type: any(named: 'type'),
+        date: any(named: 'date'),
+      )).thenAnswer((_) async {});
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      // Enter summary - it's the first TextFormField
+      await tester.enterText(find.byType(TextFormField).first, 'Test Summary');
+
+      await tester.ensureVisible(find.text('GUARDAR REGISTRO'));
+      await tester.tap(find.text('GUARDAR REGISTRO'));
+      await tester.pumpAndSettle();
+
+      verify(() => mockCubit.saveRecord(
+        filePath: 'test/path/report.pdf',
+        extractedText: 'Extracted Content',
+        summary: 'Test Summary',
+        type: any(named: 'type'),
+        date: any(named: 'date'),
+      )).called(1);
+    });
+
+    testWidgets('shows error snackbar when error state is emitted', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      stateController.add(const HealthRecordError('Some error occurred'));
+      await tester.pump();
+
+      expect(find.text('Error: Some error occurred'), findsOneWidget);
+    });
+
+    testWidgets('shows success snackbar and pops when saved state is emitted', (tester) async {
+      final mockObserver = MockNavigatorObserver();
+      await tester.pumpWidget(MaterialApp(
+        navigatorObservers: [mockObserver],
+        home: BlocProvider<HealthRecordCubit>.value(
+          value: mockCubit,
+          child: const UploadPage(),
+        ),
+      ));
+
+      stateController.add(HealthRecordSaved());
+      await tester.pump();
+
+      expect(find.text('¡Registro guardado con éxito!'), findsOneWidget);
+      verify(() => mockObserver.didPop(any(), any())).called(1);
+    });
+  });
+}


### PR DESCRIPTION
Added missing presentation tests for the health_record feature, specifically covering UploadPage, HealthRecordStagingPage, and TimelinePage. Also added infrastructure tests for HealthRecordRepositoryImpl. All tests pass and follow Clean Architecture principles.

Fixes #704

---
*PR created automatically by Jules for task [7598135081797940859](https://jules.google.com/task/7598135081797940859) started by @iberi22*