### PR TITLE
[test] Add settings: repository, datasource, and application tests

### DIFF
--- a/test/features/settings/application/llm_settings_cubit_extra_test.dart
+++ b/test/features/settings/application/llm_settings_cubit_extra_test.dart
@@ -1,0 +1,129 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/local_agent/domain/services/llm_adapter.dart';
+import 'package:orionhealth_health/features/settings/application/llm_settings_cubit.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
+import 'package:orionhealth_health/features/settings/domain/repositories/llm_settings_repository.dart';
+import 'package:orionhealth_health/features/settings/domain/services/device_capability_service.dart';
+
+class MockLlmSettingsRepository extends Mock implements LlmSettingsRepository {}
+class MockDeviceCapabilityService extends Mock implements DeviceCapabilityService {}
+class MockLlmAdapter extends Mock implements LlmAdapter {}
+
+void main() {
+  late LlmSettingsCubit cubit;
+  late MockLlmSettingsRepository mockRepository;
+  late MockDeviceCapabilityService mockDeviceCapabilityService;
+  late MockLlmAdapter mockLlmAdapter;
+
+  final testConfig = LlmConfig(
+    selectedModel: 'gemini-2.0-flash',
+  );
+
+  final testAppSettings = AppSettings(
+    themeMode: 'dark',
+    languageCode: 'en',
+    notificationsEnabled: true,
+  );
+
+  const testCapability = DeviceCapability(
+    tier: DeviceCapabilityTier.medium,
+    totalMemoryMb: 4096,
+    availableMemoryMb: 2048,
+    processorCount: 8,
+    supportsGeminiCloud: true,
+    recommendedModel: 'gemini-2.0-flash',
+  );
+
+  setUp(() {
+    mockRepository = MockLlmSettingsRepository();
+    mockDeviceCapabilityService = MockDeviceCapabilityService();
+    mockLlmAdapter = MockLlmAdapter();
+
+    registerFallbackValue(LlmConfig());
+    registerFallbackValue(AppSettings());
+
+    when(() => mockRepository.getLlmConfig()).thenAnswer((_) async => testConfig);
+    when(() => mockRepository.saveLlmConfig(any())).thenAnswer((_) async {});
+    when(() => mockRepository.getAppSettings()).thenAnswer((_) async => testAppSettings);
+    when(() => mockRepository.saveAppSettings(any())).thenAnswer((_) async {});
+    when(() => mockDeviceCapabilityService.detectCapability()).thenAnswer((_) async => testCapability);
+    when(() => mockLlmAdapter.listInstalledModels()).thenAnswer((_) async => []);
+
+    cubit = LlmSettingsCubit(
+      mockRepository,
+      mockDeviceCapabilityService,
+      mockLlmAdapter,
+    );
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  group('LlmSettingsCubit Extra Tests', () {
+    test('updateThemeMode updates state and saves to repository', () async {
+      await cubit.loadSettings();
+      await cubit.updateThemeMode('light');
+
+      expect((cubit.state as LlmSettingsLoaded).appSettings.themeMode, 'light');
+      verify(() => mockRepository.saveAppSettings(any())).called(1);
+    });
+
+    test('updateLanguage updates state and saves to repository', () async {
+      await cubit.loadSettings();
+      await cubit.updateLanguage('es');
+
+      expect((cubit.state as LlmSettingsLoaded).appSettings.languageCode, 'es');
+      verify(() => mockRepository.saveAppSettings(any())).called(1);
+    });
+
+    test('updateNotificationsEnabled updates state and saves to repository', () async {
+      await cubit.loadSettings();
+      await cubit.updateNotificationsEnabled(false);
+
+      expect((cubit.state as LlmSettingsLoaded).appSettings.notificationsEnabled, false);
+      verify(() => mockRepository.saveAppSettings(any())).called(1);
+    });
+
+    test('exportData updates state with exported data', () async {
+      const exportString = '{"data": "test"}';
+      when(() => mockRepository.exportData()).thenAnswer((_) async => exportString);
+
+      await cubit.loadSettings();
+      await cubit.exportData();
+
+      expect((cubit.state as LlmSettingsLoaded).exportData, exportString);
+    });
+
+    test('exportData handles errors', () async {
+      when(() => mockRepository.exportData()).thenThrow(Exception('Export error'));
+
+      await cubit.loadSettings();
+      await cubit.exportData();
+
+      expect((cubit.state as LlmSettingsLoaded).connectionError, contains('Export error'));
+    });
+
+    test('importData calls repository and reloads settings', () async {
+      const importString = '{"data": "test"}';
+      when(() => mockRepository.importData(any())).thenAnswer((_) async {});
+
+      await cubit.loadSettings();
+      await cubit.importData(importString);
+
+      verify(() => mockRepository.importData(importString)).called(1);
+      verify(() => mockRepository.getLlmConfig()).called(2); // Initial load + after import
+    });
+
+    test('importData handles errors', () async {
+      when(() => mockRepository.importData(any())).thenThrow(Exception('Import error'));
+
+      await cubit.loadSettings();
+      await cubit.importData('bad data');
+
+      expect((cubit.state as LlmSettingsLoaded).connectionError, contains('Import error'));
+    });
+  });
+}

--- a/test/features/settings/infrastructure/datasources/settings_local_datasource_infra_test.dart
+++ b/test/features/settings/infrastructure/datasources/settings_local_datasource_infra_test.dart
@@ -1,0 +1,68 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:orionhealth_health/features/settings/data/datasources/settings_local_datasource.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
+
+void main() {
+  late Isar isar;
+  late SettingsLocalDataSource dataSource;
+  late Directory tempDir;
+
+  setUpAll(() async {
+    await Isar.initializeIsarCore(download: true);
+    tempDir = await Directory.systemTemp.createTemp('isar_settings_ds_infra_test');
+  });
+
+  tearDownAll(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    isar = await Isar.open(
+      [LlmConfigSchema, AppSettingsSchema],
+      directory: tempDir.path,
+    );
+    dataSource = SettingsLocalDataSource(isar);
+  });
+
+  tearDown(() async {
+    await isar.close(deleteFromDisk: true);
+  });
+
+  group('SettingsLocalDataSource Infrastructure Test', () {
+    test('getLlmConfig returns persisted config', () async {
+      final config = LlmConfig(selectedModel: 'infra-test');
+      await dataSource.saveLlmConfig(config);
+
+      final result = await dataSource.getLlmConfig();
+      expect(result?.selectedModel, 'infra-test');
+    });
+
+    test('getAppSettings returns persisted settings', () async {
+      final settings = AppSettings(themeMode: 'system');
+      await dataSource.saveAppSettings(settings);
+
+      final result = await dataSource.getAppSettings();
+      expect(result?.themeMode, 'system');
+    });
+
+    test('saveLlmConfig updates existing config', () async {
+      final config1 = LlmConfig(selectedModel: 'model1');
+      await dataSource.saveLlmConfig(config1);
+
+      final saved1 = await dataSource.getLlmConfig();
+      final id = saved1!.id;
+
+      final config2 = saved1.copyWith(selectedModel: 'model2');
+      await dataSource.saveLlmConfig(config2);
+
+      final saved2 = await dataSource.getLlmConfig();
+      expect(saved2!.selectedModel, 'model2');
+      expect(saved2.id, id);
+    });
+  });
+}

--- a/test/features/settings/infrastructure/repositories/llm_settings_repository_impl_extra_test.dart
+++ b/test/features/settings/infrastructure/repositories/llm_settings_repository_impl_extra_test.dart
@@ -1,0 +1,59 @@
+import 'dart:io';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
+import 'package:orionhealth_health/features/settings/infrastructure/repositories/llm_settings_repository_impl.dart';
+
+void main() {
+  late Isar isar;
+  late LlmSettingsRepositoryImpl repository;
+  late Directory tempDir;
+
+  setUpAll(() async {
+    // Note: Isar.initializeIsarCore(download: true) is not needed if libisar.so is in the root
+    tempDir = await Directory.systemTemp.createTemp('isar_settings_extra_test');
+  });
+
+  tearDownAll(() async {
+    if (tempDir.existsSync()) {
+      await tempDir.delete(recursive: true);
+    }
+  });
+
+  setUp(() async {
+    isar = await Isar.open(
+      [LlmConfigSchema, AppSettingsSchema],
+      directory: tempDir.path,
+    );
+    repository = LlmSettingsRepositoryImpl(isar);
+  });
+
+  tearDown(() async {
+    if (isar.isOpen) {
+      await isar.close(deleteFromDisk: true);
+    }
+  });
+
+  group('LlmSettingsRepositoryImpl Extra', () {
+    test('exportData returns a JSON string', () async {
+      final result = await repository.exportData();
+      expect(result, contains('"version"'));
+      expect(result, contains('"data"'));
+    });
+
+    test('importData completes (mock)', () async {
+      expect(repository.importData('{}'), completes);
+    });
+
+    test('getLlmConfig returns null if none exists', () async {
+       final result = await repository.getLlmConfig();
+       expect(result, isNull);
+    });
+
+    test('getAppSettings returns null if none exists', () async {
+       final result = await repository.getAppSettings();
+       expect(result, isNull);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds missing unit tests for the settings feature, specifically focusing on the infrastructure and application layers as requested. It includes tests for the `LlmSettingsCubit`, `LlmSettingsRepositoryImpl`, and `SettingsLocalDataSource`, covering state transitions, persistence logic, and edge cases like error handling. All new tests have been verified to pass.

Fixes #708

---
*PR created automatically by Jules for task [7822072446771906439](https://jules.google.com/task/7822072446771906439) started by @iberi22*