### PR TITLE
Add missing vitals domain and infrastructure tests

### DIFF
--- a/test/features/vitals/domain/entities/vital_sign_extended_test.dart
+++ b/test/features/vitals/domain/entities/vital_sign_extended_test.dart
@@ -1,0 +1,74 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+
+void main() {
+  group('VitalSign Extended', () {
+    final now = DateTime.now();
+
+    test('formattedValue handles all VitalSignType values', () {
+      for (final type in VitalSignType.values) {
+        final vital = VitalSign(
+          type: type,
+          value: 10.0,
+          dateTime: now,
+        );
+        // Should not throw and should return a non-empty string
+        expect(vital.formattedValue, isNotEmpty);
+      }
+    });
+
+    test('formattedValue handles large values correctly', () {
+      final vital = VitalSign(
+        type: VitalSignType.steps,
+        value: 1000000,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '1000000 steps');
+    });
+
+    test('formattedValue handles decimal values for heart rate (int cast)', () {
+      final vital = VitalSign(
+        type: VitalSignType.heartRate,
+        value: 72.9,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '72 bpm');
+    });
+
+    test('formattedValue handles zero values', () {
+      final vital = VitalSign(
+        type: VitalSignType.bloodGlucose,
+        value: 0,
+        dateTime: now,
+      );
+      expect(vital.formattedValue, '0 mg/dL');
+    });
+
+    test('id can be set and retrieved', () {
+      final vital = VitalSign(
+        type: VitalSignType.heartRate,
+        value: 72,
+        dateTime: now,
+      );
+      vital.id = 123;
+      expect(vital.id, 123);
+    });
+
+    test('supports setting all fields via constructor', () {
+      final vital = VitalSign(
+        type: VitalSignType.spO2,
+        value: 99,
+        dateTime: now,
+        unit: '%',
+        source: 'Sensor',
+        notes: 'Feeling good',
+      );
+      expect(vital.type, VitalSignType.spO2);
+      expect(vital.value, 99);
+      expect(vital.dateTime, now);
+      expect(vital.unit, '%');
+      expect(vital.source, 'Sensor');
+      expect(vital.notes, 'Feeling good');
+    });
+  });
+}

--- a/test/features/vitals/domain/services/vitals_calculator_comprehensive_test.dart
+++ b/test/features/vitals/domain/services/vitals_calculator_comprehensive_test.dart
@@ -1,0 +1,93 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/vitals/domain/services/vitals_calculator.dart';
+
+void main() {
+  group('VitalsCalculator Comprehensive', () {
+    group('Blood Pressure Classification', () {
+      test('normal BP', () {
+        expect(VitalsCalculator.classifyBloodPressure(119, 79), BloodPressureCategory.normal);
+      });
+
+      test('elevated BP', () {
+        expect(VitalsCalculator.classifyBloodPressure(120, 79), BloodPressureCategory.elevated);
+        expect(VitalsCalculator.classifyBloodPressure(129, 79), BloodPressureCategory.elevated);
+      });
+
+      test('stage 1 hypertension', () {
+        expect(VitalsCalculator.classifyBloodPressure(130, 70), BloodPressureCategory.stage1);
+        expect(VitalsCalculator.classifyBloodPressure(120, 80), BloodPressureCategory.stage1);
+      });
+
+      test('stage 2 hypertension', () {
+        expect(VitalsCalculator.classifyBloodPressure(140, 70), BloodPressureCategory.stage2);
+        expect(VitalsCalculator.classifyBloodPressure(120, 90), BloodPressureCategory.stage2);
+      });
+
+      test('hypertensive crisis', () {
+        expect(VitalsCalculator.classifyBloodPressure(180, 100), BloodPressureCategory.crisis);
+        expect(VitalsCalculator.classifyBloodPressure(140, 120), BloodPressureCategory.crisis);
+      });
+    });
+
+    group('Heart Rate Zone Calculation', () {
+      test('infant heart rate zone (very high HR, young age)', () {
+        // Max HR = 220 - 1 = 219
+        // 50% = 109.5
+        expect(VitalsCalculator.calculateHeartRateZone(100, 1), HeartRateZone.none);
+        expect(VitalsCalculator.calculateHeartRateZone(110, 1), HeartRateZone.zone1);
+      });
+
+      test('elderly heart rate zone', () {
+        // Max HR = 220 - 100 = 120
+        // 50% = 60, 60% = 72, 70% = 84, 80% = 96, 90% = 108
+        expect(VitalsCalculator.calculateHeartRateZone(50, 100), HeartRateZone.none);
+        expect(VitalsCalculator.calculateHeartRateZone(65, 100), HeartRateZone.zone1);
+        expect(VitalsCalculator.calculateHeartRateZone(75, 100), HeartRateZone.zone2);
+        expect(VitalsCalculator.calculateHeartRateZone(90, 100), HeartRateZone.zone3);
+        expect(VitalsCalculator.calculateHeartRateZone(100, 100), HeartRateZone.zone4);
+        expect(VitalsCalculator.calculateHeartRateZone(115, 100), HeartRateZone.zone5);
+      });
+
+      test('handles edge case age 120', () {
+        // Max HR = 220 - 120 = 100
+        expect(VitalsCalculator.calculateHeartRateZone(55, 120), HeartRateZone.zone1);
+      });
+
+      test('handles age > 120', () {
+        expect(VitalsCalculator.calculateHeartRateZone(100, 121), HeartRateZone.none);
+      });
+    });
+
+    group('BMI Edge Cases', () {
+      test('extremely high weight/height', () {
+        // 500kg, 100cm (1m) = 500 BMI
+        expect(VitalsCalculator.calculateBMI(500, 100), 500);
+        expect(VitalsCalculator.classifyBMI(500), BmiCategory.obese);
+      });
+
+      test('extremely low weight/height', () {
+        // 1kg, 200cm (2m) = 1/4 = 0.25 BMI
+        expect(VitalsCalculator.calculateBMI(1, 200), 0.25);
+        expect(VitalsCalculator.classifyBMI(0.25), BmiCategory.underweight);
+      });
+    });
+
+    group('Temperature Conversion Precision', () {
+      test('water freezing point', () {
+        expect(VitalsCalculator.convertTemperature(32, toFahrenheit: false), 0);
+        expect(VitalsCalculator.convertTemperature(0, toFahrenheit: true), 32);
+      });
+
+      test('water boiling point', () {
+        expect(VitalsCalculator.convertTemperature(212, toFahrenheit: false), 100);
+        expect(VitalsCalculator.convertTemperature(100, toFahrenheit: true), 212);
+      });
+
+      test('absolute zero (approx)', () {
+        // -273.15 C = -459.67 F
+        expect(VitalsCalculator.convertTemperature(-273.15, toFahrenheit: true), closeTo(-459.67, 0.01));
+        expect(VitalsCalculator.convertTemperature(-459.67, toFahrenheit: false), closeTo(-273.15, 0.01));
+      });
+    });
+  });
+}

--- a/test/features/vitals/infrastructure/repositories/vital_sign_repository_impl_mock_test.dart
+++ b/test/features/vitals/infrastructure/repositories/vital_sign_repository_impl_mock_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+import 'package:orionhealth_health/features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart';
+
+class MockIsar extends Mock implements Isar {
+  @override
+  Future<T> writeTxn<T>(Future<T> Function() callback, {bool silent = false}) {
+    return callback();
+  }
+}
+
+abstract class IsarCollectionVitalSign extends IsarCollection<VitalSign> {}
+class MockIsarCollection extends Mock implements IsarCollectionVitalSign {}
+
+class FakeVitalSign extends Fake implements VitalSign {}
+
+void main() {
+  late MockIsar mockIsar;
+  late MockIsarCollection mockCollection;
+  late VitalSignRepositoryImpl repository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeVitalSign());
+  });
+
+  setUp(() {
+    mockIsar = MockIsar();
+    mockCollection = MockIsarCollection();
+    repository = VitalSignRepositoryImpl(mockIsar);
+
+    when(() => mockIsar.vitalSigns).thenReturn(mockCollection);
+  });
+
+  group('VitalSignRepositoryImpl Mocked Extended', () {
+    test('saveVitalSign calls put with correct object', () async {
+      final vital = VitalSign(
+        type: VitalSignType.bloodPressureSystolic,
+        value: 120,
+        dateTime: DateTime.now(),
+      );
+      when(() => mockCollection.put(any())).thenAnswer((_) async => 1);
+
+      await repository.saveVitalSign(vital);
+
+      verify(() => mockCollection.put(vital)).called(1);
+    });
+
+    test('saveVitalSigns with multiple items calls putAll', () async {
+      final vitals = [
+        VitalSign(type: VitalSignType.heartRate, value: 70, dateTime: DateTime.now()),
+        VitalSign(type: VitalSignType.spO2, value: 98, dateTime: DateTime.now()),
+      ];
+      when(() => mockCollection.putAll(any())).thenAnswer((_) async => [1, 2]);
+
+      await repository.saveVitalSigns(vitals);
+
+      verify(() => mockCollection.putAll(vitals)).called(1);
+    });
+
+    test('saveVitalSigns with empty list returns early and does not call putAll', () async {
+      await repository.saveVitalSigns([]);
+      verifyNever(() => mockCollection.putAll(any()));
+    });
+  });
+}


### PR DESCRIPTION
Added missing domain and infrastructure tests for the vitals feature.
The new tests cover:
- VitalSign entity: formattedValue for all VitalSignTypes, optional fields, and ID handling.
- VitalsCalculator service: BMI calculation and classification, Heart Rate Zone calculation with age edge cases, Blood Pressure classification, and Temperature conversion precision.
- VitalSignRepositoryImpl: saveVitalSign and saveVitalSigns using a mocked Isar implementation to ensure compatibility with restricted environments.

Also regenerated localization files to resolve compilation errors in existing tests.

Fixes #715

---
*PR created automatically by Jules for task [9044043364445540387](https://jules.google.com/task/9044043364445540387) started by @iberi22*