### PR TITLE
Add settings domain and data layer tests

### DIFF
--- a/test/features/settings/data/models/app_settings_model_test.dart
+++ b/test/features/settings/data/models/app_settings_model_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+
+void main() {
+  group('AppSettings Entity (Data layer perspective)', () {
+    // AppSettings is used directly with Isar in this project (as seen in SettingsLocalDataSource),
+    // so it doesn't have a separate DTO. We test its persistence-related aspects if any.
+
+    test('should be able to create from default constructor', () {
+      final settings = AppSettings();
+      expect(settings.themeMode, 'dark');
+    });
+
+    test('copyWith should maintain ID', () {
+      final settings = AppSettings()..id = 123;
+      final updated = settings.copyWith(themeMode: 'light');
+      expect(updated.id, 123);
+      expect(updated.themeMode, 'light');
+    });
+  });
+}

--- a/test/features/settings/data/models/llm_config_model_test.dart
+++ b/test/features/settings/data/models/llm_config_model_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/settings/data/models/llm_config_dto.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
+
+void main() {
+  group('LlmConfigDto', () {
+    final tDto = LlmConfigDto(
+      selectedModel: 'test-model',
+      apiKey: 'test-key',
+    );
+
+    final tEntity = LlmConfig(
+      selectedModel: 'test-model',
+      apiKey: 'test-key',
+    );
+
+    test('fromEntity should return a valid DTO', () {
+      final result = LlmConfigDto.fromEntity(tEntity);
+      expect(result.selectedModel, tEntity.selectedModel);
+      expect(result.apiKey, tEntity.apiKey);
+    });
+
+    test('toEntity should return a valid Entity', () {
+      final result = tDto.toEntity();
+      expect(result.selectedModel, tDto.selectedModel);
+      expect(result.apiKey, tDto.apiKey);
+    });
+
+    test('fromJson should return a valid DTO', () {
+      final Map<String, dynamic> jsonMap = {
+        'selectedModel': 'test-model',
+        'apiKey': 'test-key',
+      };
+      final result = LlmConfigDto.fromJson(jsonMap);
+      expect(result.selectedModel, 'test-model');
+      expect(result.apiKey, 'test-key');
+    });
+
+    test('toJson should return a JSON map containing proper data', () {
+      final result = tDto.toJson();
+      final expectedMap = {
+        'selectedModel': 'test-model',
+        'useCloudApi': true,
+        'allowCloudApiCalls': true,
+        'deviceCapabilityTier': 'medium',
+        'providerType': 'local',
+        'apiKey': 'test-key',
+      };
+      expect(result, expectedMap);
+    });
+  });
+}

--- a/test/features/settings/domain/entities/app_settings_entity_test.dart
+++ b/test/features/settings/domain/entities/app_settings_entity_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+
+void main() {
+  group('AppSettings Entity', () {
+    test('copyWith should change specified values', () {
+      final settings = AppSettings(themeMode: 'dark');
+      final updated = settings.copyWith(themeMode: 'light');
+      expect(updated.themeMode, 'light');
+      expect(updated.languageCode, settings.languageCode);
+    });
+
+    test('toString returns correct format', () {
+      final settings = AppSettings(themeMode: 'system', languageCode: 'en');
+      expect(settings.toString(), contains('themeMode: system'));
+      expect(settings.toString(), contains('languageCode: en'));
+    });
+
+    test('default values are correct', () {
+      final settings = AppSettings();
+      expect(settings.themeMode, 'dark');
+      expect(settings.languageCode, 'es');
+      expect(settings.notificationsEnabled, true);
+    });
+  });
+}

--- a/test/features/settings/domain/entities/llm_config_entity_test.dart
+++ b/test/features/settings/domain/entities/llm_config_entity_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
+
+void main() {
+  group('LlmConfig Entity', () {
+    test('should support equality with same values', () {
+      final config1 = LlmConfig(selectedModel: 'model1');
+      final config2 = LlmConfig(selectedModel: 'model1');
+
+      // LlmConfig does not use Equatable, so we check properties
+      expect(config1.selectedModel, config2.selectedModel);
+      expect(config1.useCloudApi, config2.useCloudApi);
+    });
+
+    test('copyWith should change specified values', () {
+      final config = LlmConfig(selectedModel: 'old');
+      final updated = config.copyWith(selectedModel: 'new');
+      expect(updated.selectedModel, 'new');
+      expect(updated.useCloudApi, config.useCloudApi);
+    });
+
+    test('toString should hide API key', () {
+      final config = LlmConfig(apiKey: 'secret-123');
+      expect(config.toString(), contains('apiKey: ***'));
+      expect(config.toString(), isNot(contains('secret-123')));
+    });
+
+    test('default values are correct', () {
+      final config = LlmConfig();
+      expect(config.selectedModel, 'gemini-2.0-flash');
+      expect(config.useCloudApi, true);
+      expect(config.providerType, 'local');
+    });
+  });
+}

--- a/test/features/settings/domain/usecases/export_data_test.dart
+++ b/test/features/settings/domain/usecases/export_data_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/settings/domain/repositories/llm_settings_repository.dart';
+import 'package:orionhealth_health/features/settings/domain/usecases/export_data.dart';
+
+class MockLlmSettingsRepository extends Mock implements LlmSettingsRepository {}
+
+void main() {
+  late ExportData usecase;
+  late MockLlmSettingsRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockLlmSettingsRepository();
+    usecase = ExportData(mockRepository);
+  });
+
+  const tExportedData = '{"data": "test"}';
+
+  test('should call exportData from repository', () async {
+    // arrange
+    when(() => mockRepository.exportData()).thenAnswer((_) async => tExportedData);
+
+    // act
+    final result = await usecase();
+
+    // assert
+    expect(result, tExportedData);
+    verify(() => mockRepository.exportData()).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/settings/domain/usecases/get_app_settings_test.dart
+++ b/test/features/settings/domain/usecases/get_app_settings_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+import 'package:orionhealth_health/features/settings/domain/repositories/llm_settings_repository.dart';
+import 'package:orionhealth_health/features/settings/domain/usecases/get_app_settings.dart';
+
+class MockLlmSettingsRepository extends Mock implements LlmSettingsRepository {}
+
+void main() {
+  late GetAppSettings usecase;
+  late MockLlmSettingsRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockLlmSettingsRepository();
+    usecase = GetAppSettings(mockRepository);
+  });
+
+  final tAppSettings = AppSettings();
+
+  test('should get app settings from the repository', () async {
+    // arrange
+    when(() => mockRepository.getAppSettings()).thenAnswer((_) async => tAppSettings);
+
+    // act
+    final result = await usecase();
+
+    // assert
+    expect(result, tAppSettings);
+    verify(() => mockRepository.getAppSettings()).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/settings/domain/usecases/import_data_test.dart
+++ b/test/features/settings/domain/usecases/import_data_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/settings/domain/repositories/llm_settings_repository.dart';
+import 'package:orionhealth_health/features/settings/domain/usecases/import_data.dart';
+
+class MockLlmSettingsRepository extends Mock implements LlmSettingsRepository {}
+
+void main() {
+  late ImportData usecase;
+  late MockLlmSettingsRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockLlmSettingsRepository();
+    usecase = ImportData(mockRepository);
+  });
+
+  const tData = '{"data": "test"}';
+
+  test('should call importData from repository', () async {
+    // arrange
+    when(() => mockRepository.importData(any())).thenAnswer((_) async => {});
+
+    // act
+    await usecase(tData);
+
+    // assert
+    verify(() => mockRepository.importData(tData)).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/settings/domain/usecases/update_language_test.dart
+++ b/test/features/settings/domain/usecases/update_language_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+import 'package:orionhealth_health/features/settings/domain/repositories/llm_settings_repository.dart';
+import 'package:orionhealth_health/features/settings/domain/usecases/update_language.dart';
+
+class MockLlmSettingsRepository extends Mock implements LlmSettingsRepository {}
+
+void main() {
+  late UpdateLanguage usecase;
+  late MockLlmSettingsRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(AppSettings());
+  });
+
+  setUp(() {
+    mockRepository = MockLlmSettingsRepository();
+    usecase = UpdateLanguage(mockRepository);
+  });
+
+  const tLanguageCode = 'en';
+
+  test('should update language code in app settings', () async {
+    // arrange
+    final tAppSettings = AppSettings(languageCode: 'es');
+    when(() => mockRepository.getAppSettings()).thenAnswer((_) async => tAppSettings);
+    when(() => mockRepository.saveAppSettings(any())).thenAnswer((_) async => {});
+
+    // act
+    await usecase(tLanguageCode);
+
+    // assert
+    verify(() => mockRepository.getAppSettings()).called(1);
+    verify(() => mockRepository.saveAppSettings(any(that: isA<AppSettings>().having((s) => s.languageCode, 'languageCode', tLanguageCode)))).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+
+  test('should use default AppSettings if repository returns null', () async {
+    // arrange
+    when(() => mockRepository.getAppSettings()).thenAnswer((_) async => null);
+    when(() => mockRepository.saveAppSettings(any())).thenAnswer((_) async => {});
+
+    // act
+    await usecase(tLanguageCode);
+
+    // assert
+    verify(() => mockRepository.getAppSettings()).called(1);
+    verify(() => mockRepository.saveAppSettings(any(that: isA<AppSettings>().having((s) => s.languageCode, 'languageCode', tLanguageCode)))).called(1);
+  });
+}

--- a/test/features/settings/domain/usecases/update_notifications_test.dart
+++ b/test/features/settings/domain/usecases/update_notifications_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+import 'package:orionhealth_health/features/settings/domain/repositories/llm_settings_repository.dart';
+import 'package:orionhealth_health/features/settings/domain/usecases/update_notifications.dart';
+
+class MockLlmSettingsRepository extends Mock implements LlmSettingsRepository {}
+
+void main() {
+  late UpdateNotifications usecase;
+  late MockLlmSettingsRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(AppSettings());
+  });
+
+  setUp(() {
+    mockRepository = MockLlmSettingsRepository();
+    usecase = UpdateNotifications(mockRepository);
+  });
+
+  const tEnabled = false;
+
+  test('should update notifications enabled in app settings', () async {
+    // arrange
+    final tAppSettings = AppSettings(notificationsEnabled: true);
+    when(() => mockRepository.getAppSettings()).thenAnswer((_) async => tAppSettings);
+    when(() => mockRepository.saveAppSettings(any())).thenAnswer((_) async => {});
+
+    // act
+    await usecase(tEnabled);
+
+    // assert
+    verify(() => mockRepository.getAppSettings()).called(1);
+    verify(() => mockRepository.saveAppSettings(any(that: isA<AppSettings>().having((s) => s.notificationsEnabled, 'notificationsEnabled', tEnabled)))).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/settings/domain/usecases/update_theme_test.dart
+++ b/test/features/settings/domain/usecases/update_theme_test.dart
@@ -1,0 +1,38 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
+import 'package:orionhealth_health/features/settings/domain/repositories/llm_settings_repository.dart';
+import 'package:orionhealth_health/features/settings/domain/usecases/update_theme.dart';
+
+class MockLlmSettingsRepository extends Mock implements LlmSettingsRepository {}
+
+void main() {
+  late UpdateTheme usecase;
+  late MockLlmSettingsRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(AppSettings());
+  });
+
+  setUp(() {
+    mockRepository = MockLlmSettingsRepository();
+    usecase = UpdateTheme(mockRepository);
+  });
+
+  const tThemeMode = 'light';
+
+  test('should update theme mode in app settings', () async {
+    // arrange
+    final tAppSettings = AppSettings(themeMode: 'dark');
+    when(() => mockRepository.getAppSettings()).thenAnswer((_) async => tAppSettings);
+    when(() => mockRepository.saveAppSettings(any())).thenAnswer((_) async => {});
+
+    // act
+    await usecase(tThemeMode);
+
+    // assert
+    verify(() => mockRepository.getAppSettings()).called(1);
+    verify(() => mockRepository.saveAppSettings(any(that: isA<AppSettings>().having((s) => s.themeMode, 'themeMode', tThemeMode)))).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}


### PR DESCRIPTION
Added missing unit tests for the settings feature across the domain and data layers. 

Changes include:
- Created `test/features/settings/domain/usecases/` and added tests for all use case classes.
- Added detailed entity tests for `LlmConfig` and `AppSettings` in `test/features/settings/domain/entities/`.
- Added model tests for `LlmConfigDto` in `test/features/settings/data/models/`.
- Verified all new tests pass using `flutter test`.

Note: Repository implementation tests for the data layer were skipped to avoid compilation errors caused by the incomplete interface implementation in the source file, adhering to the rule of not touching `lib/`.

Fixes #707

---
*PR created automatically by Jules for task [11901743457603952766](https://jules.google.com/task/11901743457603952766) started by @iberi22*