### PR TITLE
Add health_sharing: domain and services layer tests

### DIFF
--- a/test/features/health_sharing/domain/sharing_domain_extended_test.dart
+++ b/test/features/health_sharing/domain/sharing_domain_extended_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+
+void main() {
+  group('SharedHealthPackage Decoding Extended', () {
+    test('decode throws error for invalid base64', () {
+      expect(() => SharedHealthPackage.decode('invalid-base64!'), throwsException);
+    });
+
+    test('decode throws error for invalid JSON content', () {
+      // Valid base64 but invalid JSON
+      const invalidJsonBase64 = 'bm90LWpzb24='; // "not-json"
+      expect(() => SharedHealthPackage.decode(invalidJsonBase64), throwsException);
+    });
+  });
+
+  group('DataCategory Enum Extended', () {
+    test('valueOf handles all known categories', () {
+      for (final category in DataCategory.values) {
+        expect(DataCategory.valueOf(category.name), equals(category));
+      }
+    });
+
+    test('all categories have non-empty display names', () {
+      for (final category in DataCategory.values) {
+        expect(category.displayName, isNotEmpty);
+      }
+    });
+  });
+
+  group('TransferMethod Enum Extended', () {
+    test('all methods have display names and descriptions', () {
+      for (final method in TransferMethod.values) {
+        expect(method.displayName, isNotEmpty);
+        expect(method.description, isNotEmpty);
+      }
+    });
+  });
+}

--- a/test/features/health_sharing/infrastructure/services/ble_sharing_service_extended_test.dart
+++ b/test/features/health_sharing/infrastructure/services/ble_sharing_service_extended_test.dart
@@ -1,0 +1,44 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/ble_sharing_service.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/ble_wrapper.dart';
+
+class MockBleWrapper extends Mock implements BleWrapper {}
+
+void main() {
+  late BleSharingService service;
+  late MockBleWrapper mockBleWrapper;
+
+  setUp(() {
+    mockBleWrapper = MockBleWrapper();
+    service = BleSharingService(bleWrapper: mockBleWrapper);
+  });
+
+  group('BleSharingService Extended', () {
+    test('startAdvertising initializes and calls wrapper', () async {
+      when(() => mockBleWrapper.isSupported).thenAnswer((_) async => true);
+      when(() => mockBleWrapper.startAdvertise(
+            serviceUuid: any(named: 'serviceUuid'),
+            localName: any(named: 'localName'),
+            includePowerLevel: any(named: 'includePowerLevel'),
+          )).thenAnswer((_) async => {});
+
+      await service.startAdvertising('test-node');
+
+      verify(() => mockBleWrapper.startAdvertise(
+            serviceUuid: kOrionHealthServiceUuid,
+            localName: 'test-node',
+            includePowerLevel: true,
+          )).called(1);
+    });
+
+    test('stopAdvertising calls wrapper', () async {
+      when(() => mockBleWrapper.stopAdvertise()).thenAnswer((_) async => {});
+
+      await service.stopAdvertising();
+
+      verify(() => mockBleWrapper.stopAdvertise()).called(1);
+    });
+  });
+}

--- a/test/features/health_sharing/infrastructure/services/ble_wrapper_test.dart
+++ b/test/features/health_sharing/infrastructure/services/ble_wrapper_test.dart
@@ -1,0 +1,83 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/ble_wrapper.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late BleWrapper bleWrapper;
+  const MethodChannel channel = MethodChannel('orionhealth/ble_peripheral');
+  final List<MethodCall> log = <MethodCall>[];
+
+  setUp(() {
+    bleWrapper = BleWrapper();
+    log.clear();
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      log.add(methodCall);
+      if (methodCall.method == 'startAdvertising') {
+        return null;
+      }
+      if (methodCall.method == 'stopAdvertising') {
+        return null;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+    bleWrapper.dispose();
+  });
+
+  group('BleWrapper', () {
+    test('startAdvertise updates state', () async {
+      expect(bleWrapper.isAdvertising, isFalse);
+
+      await bleWrapper.startAdvertise(
+        serviceUuid: 'test-uuid',
+        localName: 'test-node',
+      );
+
+      expect(bleWrapper.isAdvertising, isTrue);
+      // On non-mobile platforms in CI, it might not invoke the method channel but still sets _isAdvertising = true.
+    });
+
+    test('stopAdvertise updates state', () async {
+      // Start first
+      await bleWrapper.startAdvertise(
+        serviceUuid: 'test-uuid',
+        localName: 'test-node',
+      );
+
+      await bleWrapper.stopAdvertise();
+
+      expect(bleWrapper.isAdvertising, isFalse);
+    });
+
+    test('advertisementState stream emits changes', () async {
+      final states = <bool>[];
+      final sub = bleWrapper.advertisementState.listen(states.add);
+
+      await bleWrapper.startAdvertise(serviceUuid: 'u', localName: 'n');
+      await bleWrapper.stopAdvertise();
+
+      await Future.delayed(Duration.zero);
+      expect(states, [true, false]);
+      await sub.cancel();
+    });
+
+    test('startAdvertise handles MissingPluginException gracefully', () async {
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+        throw MissingPluginException();
+      });
+
+      await bleWrapper.startAdvertise(serviceUuid: 'u', localName: 'n');
+
+      expect(bleWrapper.isAdvertising, isTrue); // Fallback logic in BleWrapper
+    });
+  });
+}

--- a/test/features/health_sharing/infrastructure/services/nfc_handler_test.dart
+++ b/test/features/health_sharing/infrastructure/services/nfc_handler_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/nfc_handler.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late NfcHandler nfcHandler;
+  const MethodChannel channel = MethodChannel(kNfcChannelName);
+  final List<MethodCall> log = <MethodCall>[];
+
+  setUp(() {
+    log.clear();
+    nfcHandler = NfcHandler(channel: channel);
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      log.add(methodCall);
+      if (methodCall.method == 'isNfcAvailable') {
+        return true;
+      }
+      return null;
+    });
+  });
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('NfcHandler', () {
+    test('isNativeAvailable is true by default', () {
+        expect(nfcHandler.isNativeAvailable, isTrue);
+    });
+
+    test('startNfcSession invokes native method', () async {
+      final success = await nfcHandler.startNfcSession();
+      expect(success, isTrue);
+      expect(log.first.method, 'startNfcSession');
+    });
+
+    test('stopNfcSession invokes native method', () async {
+      await nfcHandler.stopNfcSession();
+      expect(log.first.method, 'stopNfcSession');
+    });
+
+    test('beamNdefMessage invokes native method with data', () async {
+      await nfcHandler.beamNdefMessage([1, 2, 3]);
+      expect(log.first.method, 'beamNdefMessage');
+      expect(log.first.arguments['data'], [1, 2, 3]);
+    });
+
+    test('isNfcAvailable sets _nativeAvailable to false on non-mobile', () async {
+        final available = await nfcHandler.isNfcAvailable();
+        expect(available, isFalse);
+        expect(nfcHandler.isNativeAvailable, isFalse);
+    });
+  });
+}

--- a/test/features/health_sharing/infrastructure/services/nfc_sharing_service_extended_test.dart
+++ b/test/features/health_sharing/infrastructure/services/nfc_sharing_service_extended_test.dart
@@ -1,0 +1,69 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/nfc_sharing_service.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/nfc_handler.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+
+class MockNfcHandler extends Mock implements NfcHandler {}
+
+void main() {
+  late NfcSharingService service;
+  late MockNfcHandler mockNfcHandler;
+
+  setUp(() {
+    mockNfcHandler = MockNfcHandler();
+    service = NfcSharingService(nfcHandler: mockNfcHandler);
+  });
+
+  final testPackage = SharedHealthPackage(
+    id: 'id',
+    senderNodeId: 's',
+    recipientNodeId: 'r',
+    createdAt: DateTime.now(),
+    expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+    payload: const EncryptedPayload(
+      encryptedData: '',
+      iv: '',
+      ephemeralPublicKey: '',
+    ),
+    metadata: const PackageMetadata(
+      packageType: 'full',
+      consentVerified: true,
+      includedCategories: {},
+      appVersion: '1.0.0',
+    ),
+    signature: '',
+  );
+
+  group('NfcSharingService Extended', () {
+    test('shareData fails if NFC not enabled', () async {
+      when(() => mockNfcHandler.isNfcAvailable()).thenAnswer((_) async => false);
+
+      final result = await service.shareData(testPackage);
+
+      expect(result.success, isFalse);
+      expect(result.error, 'NFC not available');
+    });
+
+    test('shareData calls beamNdefMessage if enabled (simulated)', () async {
+      // In CI, NfcSharingService.initialize will see Platform.isLinux and set _isEnabled to false
+      // regardless of what NfcHandler says.
+      // So we test the behavior when _isEnabled is false.
+
+      when(() => mockNfcHandler.isNfcAvailable()).thenAnswer((_) async => true);
+      await service.initialize();
+
+      final result = await service.shareData(testPackage);
+      // It should be false because we are on Linux.
+      expect(result.success, isFalse);
+    });
+
+    test('stopListening calls stopNfcSession', () async {
+      when(() => mockNfcHandler.stopNfcSession()).thenAnswer((_) async => {});
+
+      await service.stopListening();
+
+      verify(() => mockNfcHandler.stopNfcSession()).called(1);
+    });
+  });
+}

--- a/test/features/health_sharing/infrastructure/services/wifi_direct_service_extended_test.dart
+++ b/test/features/health_sharing/infrastructure/services/wifi_direct_service_extended_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/infrastructure/wifi_direct_service.dart';
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late WifiDirectService service;
+  const MethodChannel channel = MethodChannel('orionhealth/wifi_p2p');
+  final List<MethodCall> log = <MethodCall>[];
+
+  setUp(() {
+    service = WifiDirectService();
+    log.clear();
+
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      log.add(methodCall);
+      if (methodCall.method == 'mdnsDiscover') {
+        return [
+          {'name': 'Device 1', 'address': '192.168.1.10:9124'},
+        ];
+      }
+      return null;
+    });
+  });
+
+  tearDown(() async {
+    await service.stop();
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, null);
+  });
+
+  group('WifiDirectService Extended', () {
+    test('discoverDevices calls mdnsDiscover on fallback', () async {
+      // In CI (Linux), Platform.isAndroid/iOS is false, so it falls back to mDNS.
+      final devices = await service.discoverDevices(
+        timeout: const Duration(milliseconds: 100),
+      );
+
+      expect(devices, isNotEmpty);
+      expect(devices.first.name, 'Device 1');
+      expect(log.any((call) => call.method == 'mdnsDiscover'), isTrue);
+    });
+
+    test('startServer and stop lifecycle', () async {
+      await service.startServer(port: 0);
+      expect(service.serverAddress, isNotNull);
+
+      await service.stop();
+      expect(service.serverAddress, isNull);
+    });
+
+    test('initialize emits ready state', () async {
+      final states = <WifiSharingState>[];
+      final sub = service.stateStream.listen(states.add);
+
+      await service.initialize();
+
+      await Future.delayed(Duration.zero);
+      expect(states.any((s) => s.status == 'ready'), isTrue);
+      await sub.cancel();
+    });
+  });
+}


### PR DESCRIPTION
This submission adds missing unit tests for the domain and infrastructure services layers of the health_sharing feature. 

Key changes:
- New tests for `BleWrapper` and `NfcHandler` in `test/features/health_sharing/infrastructure/services/`, covering platform channel interactions and fallback logic.
- Extended service tests for `BleSharingService`, `NfcSharingService`, and `WifiDirectService` to cover initialization, lifecycle, and error handling.
- Extended domain tests in `test/features/health_sharing/domain/sharing_domain_extended_test.dart` covering entity decoding edge cases and exhaustive enum verification.
- Ensured all tests are compatible with the Linux-based CI environment by mocking platform-specific behaviors.
- Verified that no existing tests were deleted or modified, and that all new tests pass successfully.

Fixes #712

---
*PR created automatically by Jules for task [14162281531392443353](https://jules.google.com/task/14162281531392443353) started by @iberi22*