### PR TITLE
Add doctor_verification: datasource and model tests

### DIFF
--- a/test/features/doctor_verification/data/doctor_rating_data_test.dart
+++ b/test/features/doctor_verification/data/doctor_rating_data_test.dart
@@ -1,0 +1,82 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/doctor_rating.dart';
+
+void main() {
+  group('DoctorRating Data Tests', () {
+    test('categories getter parses categoriesJson correctly', () {
+      final categoriesMap = {'Clinical': 5, 'Bedside': 4};
+      final rating = DoctorRating(
+        id: 'r1',
+        doctorId: 'd1',
+        overallScore: 5,
+        categoriesJson: jsonEncode(categoriesMap),
+        createdAt: DateTime.now(),
+        isAnonymous: false,
+        verifiedVisit: true,
+      );
+
+      expect(rating.categories, equals(categoriesMap));
+      expect(rating.categories['Clinical'], 5);
+      expect(rating.categories['Bedside'], 4);
+    });
+
+    test('validate returns true for valid rating', () {
+      final rating = DoctorRating(
+        id: 'r1',
+        doctorId: 'd1',
+        overallScore: 3,
+        categoriesJson: '{}',
+        createdAt: DateTime.now(),
+        isAnonymous: false,
+        verifiedVisit: true,
+        comment: 'Good',
+      );
+
+      expect(rating.validate(), isTrue);
+    });
+
+    test('validate returns false for invalid score (too low)', () {
+      final rating = DoctorRating(
+        id: 'r1',
+        doctorId: 'd1',
+        overallScore: 0,
+        categoriesJson: '{}',
+        createdAt: DateTime.now(),
+        isAnonymous: false,
+        verifiedVisit: true,
+      );
+
+      expect(rating.validate(), isFalse);
+    });
+
+    test('validate returns false for invalid score (too high)', () {
+      final rating = DoctorRating(
+        id: 'r1',
+        doctorId: 'd1',
+        overallScore: 6,
+        categoriesJson: '{}',
+        createdAt: DateTime.now(),
+        isAnonymous: false,
+        verifiedVisit: true,
+      );
+
+      expect(rating.validate(), isFalse);
+    });
+
+    test('validate returns false for excessively long comment', () {
+      final rating = DoctorRating(
+        id: 'r1',
+        doctorId: 'd1',
+        overallScore: 5,
+        categoriesJson: '{}',
+        createdAt: DateTime.now(),
+        isAnonymous: false,
+        verifiedVisit: true,
+        comment: 'a' * 501,
+      );
+
+      expect(rating.validate(), isFalse);
+    });
+  });
+}

--- a/test/features/doctor_verification/data/models/doctor_profile_model_test.dart
+++ b/test/features/doctor_verification/data/models/doctor_profile_model_test.dart
@@ -1,0 +1,105 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/infrastructure/models/doctor_profile_model.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/doctor_profile.dart';
+
+void main() {
+  final tDate = DateTime(2023, 6, 15);
+
+  group('DoctorProfileModel Data Tests', () {
+    test('fromJson handles null optional fields and defaults', () {
+      final jsonMap = <String, dynamic>{
+        'id': 'doc_nulls',
+        'fullName': 'Dr. Null',
+        'specialty': 'Testing',
+        'countryCode': 'TS',
+        'createdAt': tDate.toIso8601String(),
+        'updatedAt': tDate.toIso8601String(),
+        // optional fields missing
+      };
+
+      final result = DoctorProfileModel.fromJson(jsonMap);
+
+      expect(result.id, 'doc_nulls');
+      expect(result.licenseNumber, isNull);
+      expect(result.institution, isNull);
+      expect(result.yearsOfExperience, isNull);
+      expect(result.languages, isEmpty);
+      expect(result.verified, isFalse);
+    });
+
+    test('fromJson handles explicit nulls for optional fields', () {
+      final jsonMap = <String, dynamic>{
+        'id': 'doc_explicit_nulls',
+        'fullName': 'Dr. Explicit',
+        'specialty': 'Testing',
+        'countryCode': 'TS',
+        'licenseNumber': null,
+        'institution': null,
+        'yearsOfExperience': null,
+        'languages': null,
+        'verified': null,
+        'createdAt': tDate.toIso8601String(),
+        'updatedAt': tDate.toIso8601String(),
+      };
+
+      final result = DoctorProfileModel.fromJson(jsonMap);
+
+      expect(result.licenseNumber, isNull);
+      expect(result.institution, isNull);
+      expect(result.yearsOfExperience, isNull);
+      expect(result.languages, isEmpty);
+      expect(result.verified, isFalse);
+    });
+
+    test('toJson produces expected map even with null fields', () {
+      final model = DoctorProfileModel(
+        id: 'doc_to_json',
+        fullName: 'Dr. ToJson',
+        specialty: 'Testing',
+        countryCode: 'TS',
+        createdAt: tDate,
+        updatedAt: tDate,
+      );
+
+      final result = model.toJson();
+
+      expect(result['id'], 'doc_to_json');
+      expect(result['licenseNumber'], isNull);
+      expect(result['institution'], isNull);
+      expect(result['yearsOfExperience'], isNull);
+      expect(result['languages'], isEmpty);
+      expect(result['verified'], isFalse);
+    });
+
+    test('round-trip serialization/deserialization', () {
+      final model = DoctorProfileModel(
+        id: 'round-trip',
+        fullName: 'Dr. RoundTrip',
+        specialty: 'Testing',
+        licenseNumber: 'LIC-999',
+        countryCode: 'TS',
+        institution: 'Test Hospital',
+        yearsOfExperience: 10,
+        languages: ['English'],
+        verified: true,
+        createdAt: tDate,
+        updatedAt: tDate,
+      );
+
+      final json = model.toJson();
+      final deserialized = DoctorProfileModel.fromJson(json);
+
+      expect(deserialized.id, model.id);
+      expect(deserialized.fullName, model.fullName);
+      expect(deserialized.specialty, model.specialty);
+      expect(deserialized.licenseNumber, model.licenseNumber);
+      expect(deserialized.countryCode, model.countryCode);
+      expect(deserialized.institution, model.institution);
+      expect(deserialized.yearsOfExperience, model.yearsOfExperience);
+      expect(deserialized.languages, model.languages);
+      expect(deserialized.verified, model.verified);
+      expect(deserialized.createdAt, model.createdAt);
+      expect(deserialized.updatedAt, model.updatedAt);
+    });
+  });
+}

--- a/test/features/doctor_verification/data/second_opinion_data_test.dart
+++ b/test/features/doctor_verification/data/second_opinion_data_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/second_opinion.dart';
+
+void main() {
+  group('SecondOpinion Data Tests', () {
+    test('SecondOpinionRequest correctly stores data', () {
+      final now = DateTime.now();
+      final request = SecondOpinionRequest(
+        id: 'req1',
+        patientId: 'pat1',
+        primaryDoctorId: 'doc1',
+        symptoms: 'Headache',
+        documents: ['path/to/doc.pdf'],
+        createdAt: now,
+      );
+
+      expect(request.id, 'req1');
+      expect(request.patientId, 'pat1');
+      expect(request.primaryDoctorId, 'doc1');
+      expect(request.symptoms, 'Headache');
+      expect(request.documents, contains('path/to/doc.pdf'));
+      expect(request.createdAt, now);
+    });
+
+    test('SecondOpinionResponse correctly stores data', () {
+      final now = DateTime.now();
+      final response = SecondOpinionResponse(
+        id: 'res1',
+        requestId: 'req1',
+        reviewerDoctorId: 'doc2',
+        recommendation: 'Rest',
+        confidence: 0.9,
+        respondedAt: now,
+      );
+
+      expect(response.id, 'res1');
+      expect(response.requestId, 'req1');
+      expect(response.reviewerDoctorId, 'doc2');
+      expect(response.recommendation, 'Rest');
+      expect(response.confidence, 0.9);
+      expect(response.respondedAt, now);
+    });
+  });
+}

--- a/test/features/doctor_verification/data/vouch_data_test.dart
+++ b/test/features/doctor_verification/data/vouch_data_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/vouch.dart';
+
+void main() {
+  group('Vouch Data Tests', () {
+    test('Vouch entity correctly stores data', () {
+      final now = DateTime.now();
+      final vouch = Vouch(
+        id: 'v1',
+        vouchedBy: 'doc1',
+        targetDoctor: 'doc2',
+        category: 'Excellence',
+        timestamp: now,
+      );
+
+      expect(vouch.id, 'v1');
+      expect(vouch.vouchedBy, 'doc1');
+      expect(vouch.targetDoctor, 'doc2');
+      expect(vouch.category, 'Excellence');
+      expect(vouch.timestamp, now);
+    });
+  });
+}

--- a/test/features/doctor_verification/infrastructure/datasources/license_registry_local_datasource_test.dart
+++ b/test/features/doctor_verification/infrastructure/datasources/license_registry_local_datasource_test.dart
@@ -1,0 +1,93 @@
+import 'dart:convert';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/doctor_verification/infrastructure/datasources/license_registry_local.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/license_registry.dart';
+
+class MockIsar extends Mock implements Isar {
+  @override
+  Future<T> writeTxn<T>(Future<T> Function() callback, {bool silent = false}) {
+    return callback();
+  }
+}
+
+abstract class IsarCollectionLicense extends IsarCollection<LicenseRegistryLocal> {}
+class MockIsarCollection extends Mock implements IsarCollectionLicense {}
+
+class FakeLicenseRegistryLocal extends Fake implements LicenseRegistryLocal {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late MockIsar mockIsar;
+  late MockIsarCollection mockCollection;
+  late LicenseRegistryLocalDataSource dataSource;
+
+  setUpAll(() {
+    registerFallbackValue(FakeLicenseRegistryLocal());
+  });
+
+  setUp(() {
+    mockIsar = MockIsar();
+    mockCollection = MockIsarCollection();
+    dataSource = LicenseRegistryLocalDataSource(mockIsar);
+
+    // Mock the collection() method which is called by the extension getter
+    when(() => mockIsar.collection<LicenseRegistryLocal>()).thenReturn(mockCollection);
+  });
+
+  group('LicenseRegistryLocalDataSource (Mocked)', () {
+    test('load() should not load assets if database already has data', () async {
+      when(() => mockCollection.count()).thenAnswer((_) async => 5);
+
+      await dataSource.load();
+
+      verify(() => mockCollection.count()).called(1);
+      verifyNever(() => mockCollection.put(any()));
+    });
+
+    test('load() should load assets and put in database if empty', () async {
+      when(() => mockCollection.count()).thenAnswer((_) async => 0);
+      when(() => mockCollection.put(any())).thenAnswer((_) async => 1);
+
+      final testData = {
+        'US': ['hash1', 'hash2'],
+        'CO': ['hash3']
+      };
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        'flutter/assets',
+        (ByteData? message) async {
+           final String key = utf8.decode(message!.buffer.asUint8List());
+           if (key == 'assets/data/license_registry.json') {
+              return ByteData.view(
+                Uint8List.fromList(utf8.encode(json.encode(testData))).buffer
+              );
+           }
+           return null;
+        },
+      );
+
+      await dataSource.load();
+
+      verify(() => mockCollection.count()).called(1);
+      verify(() => mockCollection.put(any())).called(2);
+
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMessageHandler(
+        'flutter/assets',
+        null,
+      );
+    });
+
+    test('load() should handle errors gracefully', () async {
+      when(() => mockCollection.count()).thenThrow(Exception('Isar error'));
+
+      // Should not throw
+      await dataSource.load();
+
+      verify(() => mockCollection.count()).called(1);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds missing unit tests for the data layer of the doctor_verification feature.
- New tests for models and data holders in `test/features/doctor_verification/data/`.
- A new mock-based datasource test in `test/features/doctor_verification/infrastructure/datasources/` that avoids pre-existing environment issues with Isar native libraries.
- Comprehensive coverage for JSON serialization, data validation, and asset loading logic.

Fixes #716

---
*PR created automatically by Jules for task [10377015071916220620](https://jules.google.com/task/10377015071916220620) started by @iberi22*