### PR TITLE
Add auth presentation tests for pages

### DIFF
--- a/test/features/auth/presentation/pages/login_page_test.dart
+++ b/test/features/auth/presentation/pages/login_page_test.dart
@@ -1,0 +1,116 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/application/auth_cubit.dart';
+import 'package:orionhealth_health/features/auth/application/auth_state.dart';
+import 'package:orionhealth_health/features/auth/presentation/pages/login_page.dart';
+
+class MockAuthCubit extends Mock implements AuthCubit {}
+
+void main() {
+  late MockAuthCubit mockAuthCubit;
+
+  setUp(() {
+    mockAuthCubit = MockAuthCubit();
+    when(() => mockAuthCubit.state).thenReturn(const AuthState());
+    when(() => mockAuthCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockAuthCubit.close()).thenAnswer((_) async {});
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: BlocProvider<AuthCubit>.value(
+        value: mockAuthCubit,
+        child: const LoginPage(),
+      ),
+    );
+  }
+
+  group('LoginPage', () {
+    testWidgets('shows PIN setup UI when isPinSet is false', (tester) async {
+      when(() => mockAuthCubit.state).thenReturn(const AuthState(isPinSet: false));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Set up your PIN'), findsOneWidget);
+      expect(find.text('New PIN'), findsOneWidget);
+      expect(find.text('PIN must be 4-6 digits'), findsOneWidget);
+    });
+
+    testWidgets('calls authCubit.setPin when Set PIN button is pressed with valid PIN', (tester) async {
+      when(() => mockAuthCubit.state).thenReturn(const AuthState(isPinSet: false));
+      when(() => mockAuthCubit.setPin(any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.enterText(find.byType(TextField), '1234');
+      await tester.tap(find.text('Set PIN'));
+      await tester.pump();
+
+      verify(() => mockAuthCubit.setPin('1234')).called(1);
+    });
+
+    testWidgets('shows Login form UI when isPinSet is true', (tester) async {
+      when(() => mockAuthCubit.state).thenReturn(const AuthState(isPinSet: true));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Enter PIN'), findsOneWidget);
+      expect(find.text('Login'), findsOneWidget);
+    });
+
+    testWidgets('calls authCubit.submitPin when Login button is pressed with valid PIN', (tester) async {
+      when(() => mockAuthCubit.state).thenReturn(const AuthState(isPinSet: true));
+      when(() => mockAuthCubit.submitPin(any())).thenAnswer((_) async {});
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      await tester.enterText(find.byType(TextField), '1234');
+      await tester.tap(find.text('Login'));
+      await tester.pump();
+
+      verify(() => mockAuthCubit.submitPin('1234')).called(1);
+    });
+
+    testWidgets('shows Use Biometric button when isBiometricAvailable is true and calls verifyBiometric when tapped', (tester) async {
+      when(() => mockAuthCubit.state).thenReturn(const AuthState(isPinSet: true, isBiometricAvailable: true));
+      when(() => mockAuthCubit.verifyBiometric()).thenAnswer((_) async {});
+
+      await tester.pumpWidget(createWidgetUnderTest());
+
+      expect(find.text('Use Biometric'), findsOneWidget);
+      await tester.tap(find.text('Use Biometric'));
+      await tester.pump();
+
+      verify(() => mockAuthCubit.verifyBiometric()).called(1);
+    });
+
+    testWidgets('shows SnackBar with error message when state status is AuthStatus.error', (tester) async {
+      final states = [
+        const AuthState(isPinSet: true),
+        const AuthState(status: AuthStatus.error, error: 'Authentication Failed', isPinSet: true),
+      ];
+      when(() => mockAuthCubit.state).thenReturn(states[0]);
+      when(() => mockAuthCubit.stream).thenAnswer((_) => Stream.fromIterable(states));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump(); // Trigger listener
+
+      expect(find.text('Authentication Failed'), findsOneWidget);
+    });
+
+    group('Accessibility', () {
+      testWidgets('should have a centered OrionHealth text', (tester) async {
+        await tester.pumpWidget(createWidgetUnderTest());
+        expect(find.text('OrionHealth'), findsOneWidget);
+      });
+
+      testWidgets('should show circular progress indicator when loading', (tester) async {
+        when(() => mockAuthCubit.state).thenReturn(const AuthState(status: AuthStatus.loading));
+        await tester.pumpWidget(createWidgetUnderTest());
+        expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      });
+    });
+  });
+}

--- a/test/features/auth/presentation/pages/receive_medical_data_page_test.dart
+++ b/test/features/auth/presentation/pages/receive_medical_data_page_test.dart
@@ -1,0 +1,137 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/auth/presentation/pages/receive_medical_data_page.dart';
+import 'package:orionhealth_health/features/health_sharing/application/sharing_cubit.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+
+class MockSharingCubit extends Mock implements SharingCubit {}
+
+void main() {
+  late MockSharingCubit mockSharingCubit;
+  late StreamController<SharingState> stateController;
+  final getIt = GetIt.instance;
+
+  setUpAll(() {
+    registerFallbackValue(TransferMethod.nfc);
+  });
+
+  setUp(() {
+    mockSharingCubit = MockSharingCubit();
+    stateController = StreamController<SharingState>.broadcast();
+
+    if (getIt.isRegistered<SharingCubit>()) {
+      getIt.unregister<SharingCubit>();
+    }
+    getIt.registerSingleton<SharingCubit>(mockSharingCubit);
+
+    when(() => mockSharingCubit.state).thenReturn(const SharingInitial());
+    when(() => mockSharingCubit.stream).thenAnswer((_) => stateController.stream);
+    when(() => mockSharingCubit.initialize()).thenAnswer((_) async {});
+    when(() => mockSharingCubit.startListening(any())).thenAnswer((_) async {});
+    when(() => mockSharingCubit.close()).thenAnswer((_) async {
+      await stateController.close();
+    });
+  });
+
+  tearDown(() async {
+    await stateController.close();
+  });
+
+  Widget createWidgetUnderTest() {
+    return const MaterialApp(
+      home: Scaffold(
+        body: ReceiveMedicalDataPage(),
+      ),
+    );
+  }
+
+  group('ReceiveMedicalDataPage', () {
+    testWidgets('initialization calls initialize and startListening with NFC', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      verify(() => mockSharingCubit.initialize()).called(1);
+      verify(() => mockSharingCubit.startListening(TransferMethod.nfc)).called(1);
+    });
+
+    testWidgets('displays correct message when state is SharingScanning with NFC', (tester) async {
+      when(() => mockSharingCubit.state).thenReturn(const SharingScanning(TransferMethod.nfc));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      expect(find.text('Tap devices to receive...'), findsOneWidget);
+      expect(find.byIcon(Icons.nfc), findsOneWidget);
+    });
+
+    testWidgets('displays "Connection established" when state is SharingConnected', (tester) async {
+      when(() => mockSharingCubit.state).thenReturn(const SharingConnected(TransferMethod.nfc, 'device-123'));
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      expect(find.text('Connection established'), findsOneWidget);
+    });
+
+    testWidgets('shows preview dialog with "Data Received" when state is SharingReceiving', (tester) async {
+      final package = SharedHealthPackage(
+        id: '1',
+        senderNodeId: 'sender-1',
+        recipientNodeId: 'recipient-1',
+        createdAt: DateTime.now(),
+        expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+        payload: const EncryptedPayload(encryptedData: 'data', iv: 'iv', ephemeralPublicKey: 'key'),
+        metadata: const PackageMetadata(
+          packageType: 'full',
+          consentVerified: true,
+          includedCategories: {DataCategory.vitalSigns},
+          appVersion: '1.0.0',
+        ),
+        signature: 'sig',
+      );
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      stateController.add(SharingReceiving(package: package, method: TransferMethod.nfc));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Data Received'), findsOneWidget);
+      expect(find.text('From: sender-1'), findsOneWidget);
+      expect(find.text('• Signos Vitales'), findsOneWidget);
+    });
+
+    testWidgets('shows success dialog with "Import Complete!" when state is SharingComplete', (tester) async {
+      final result = SharingResult(
+        success: true,
+        bytesTransferred: 1024,
+        transferTime: const Duration(seconds: 5),
+      );
+
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      stateController.add(SharingComplete(result, TransferMethod.nfc));
+      await tester.pump();
+      await tester.pump();
+
+      expect(find.text('Import Complete!'), findsOneWidget);
+      expect(find.text('1024 bytes imported'), findsOneWidget);
+    });
+
+    testWidgets('shows SnackBar on SharingError', (tester) async {
+      await tester.pumpWidget(createWidgetUnderTest());
+      await tester.pump();
+
+      stateController.add(const SharingError('Transfer failed'));
+      await tester.pump();
+
+      expect(find.text('Transfer failed'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Added missing presentation tests for the auth feature's new pages.
- test/features/auth/presentation/pages/login_page_test.dart: Covers the logic in the new login page including PIN setup and login.
- test/features/auth/presentation/pages/receive_medical_data_page_test.dart: Covers the medical data receiving flow.
Utilized mocktail for cubit mocking and handled GetIt dependency injection in tests.

Fixes #710

---
*PR created automatically by Jules for task [14617362434950562141](https://jules.google.com/task/14617362434950562141) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Expanded test coverage for authentication login flows and medical data receiving workflows to ensure reliable UI behavior and user interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->