### PR TITLE
[test] Add missing voice_chat tests for repository and datasource

### DIFF
--- a/test/features/voice_chat/infrastructure/chat_ai_datasource_test.dart
+++ b/test/features/voice_chat/infrastructure/chat_ai_datasource_test.dart
@@ -43,6 +43,14 @@ void main() {
       verify(() => mockAIService.getResponse(text, context: context)).called(1);
     });
 
+    test('getAiResponse should propagate AIService errors', () async {
+      const text = 'Hello';
+      when(() => mockAIService.getResponse(text, context: any(named: 'context')))
+          .thenThrow(Exception('AI Error'));
+
+      expect(() => datasource.getAiResponse(text), throwsException);
+    });
+
     group('transcribe', () {
       final audioBytes = [1, 2, 3];
       final uint8AudioBytes = Uint8List.fromList(audioBytes);
@@ -134,6 +142,20 @@ void main() {
       test('clearMemory should be callable', () async {
         await datasource.clearMemory();
         // Currently a stub, but we verify it can be called without error
+      });
+
+      test('getContextForQuery should propagate memory service errors', () async {
+        when(() => mockMemoryService.getContextForQuery('test'))
+            .thenThrow(Exception('Memory Error'));
+
+        expect(() => datasource.getContextForQuery('test'), throwsException);
+      });
+
+      test('saveToMemory should propagate memory service errors', () async {
+        when(() => mockMemoryService.addMemory(input: 'in', output: 'out'))
+            .thenThrow(Exception('Memory Error'));
+
+        expect(() => datasource.saveToMemory('in', 'out'), throwsException);
       });
     });
   });

--- a/test/features/voice_chat/infrastructure/voice_chat_repository_impl_test.dart
+++ b/test/features/voice_chat/infrastructure/voice_chat_repository_impl_test.dart
@@ -57,6 +57,14 @@ void main() {
       verify(() => mockDatasource.getAiResponse(text, context: [])).called(1);
     });
 
+    test('sendMessage should propagate datasource errors', () async {
+      const text = 'Hello';
+      when(() => mockDatasource.getContextForQuery(text))
+          .thenThrow(Exception('Datasource Error'));
+
+      expect(() => repository.sendMessage(text), throwsException);
+    });
+
     test('getChatHistory should parse history correctly', () async {
       final rawHistory = ['Hello', 'Hi', 'How are you?', 'I am fine'];
       when(() => mockDatasource.getRecentHistory(limit: any(named: 'limit')))
@@ -73,6 +81,27 @@ void main() {
       expect(result[2].role, MessageRole.user);
       expect(result[3].content, 'I am fine');
       expect(result[3].role, MessageRole.ai);
+    });
+
+    test('getChatHistory should handle empty history', () async {
+      when(() => mockDatasource.getRecentHistory(limit: any(named: 'limit')))
+          .thenAnswer((_) async => []);
+
+      final result = await repository.getChatHistory(limit: 20);
+
+      expect(result, isEmpty);
+    });
+
+    test('getChatHistory should handle odd-numbered history', () async {
+      final rawHistory = ['Hello', 'Hi', 'How are you?'];
+      when(() => mockDatasource.getRecentHistory(limit: any(named: 'limit')))
+          .thenAnswer((_) async => rawHistory);
+
+      final result = await repository.getChatHistory(limit: 20);
+
+      expect(result.length, 2);
+      expect(result[0].content, 'Hello');
+      expect(result[1].content, 'Hi');
     });
 
     test('clearHistory should call datasource clearMemory', () async {
@@ -93,6 +122,14 @@ void main() {
 
       expect(result, transcription);
       verify(() => mockDatasource.transcribe(audioBytes)).called(1);
+    });
+
+    test('transcribeAudio should propagate datasource errors', () async {
+      final audioBytes = [1, 2, 3];
+      when(() => mockDatasource.transcribe(audioBytes))
+          .thenThrow(Exception('Datasource Error'));
+
+      expect(() => repository.transcribeAudio(audioBytes), throwsException);
     });
   });
 }


### PR DESCRIPTION
Added unit tests for VoiceChatRepositoryImpl and ChatAiDatasource to cover edge cases and error handling. Specifically, added tests for empty/odd-numbered history in the repository and error propagation for AI and memory services in both the repository and datasource layers.

Fixes #737

---
*PR created automatically by Jules for task [16643419057999239549](https://jules.google.com/task/16643419057999239549) started by @iberi22*