### PR TITLE
Add missing sync tests

### DIFF
--- a/test/features/sync/application/sync_state_test.dart
+++ b/test/features/sync/application/sync_state_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/sync/application/sync_state.dart';
+import 'package:orionhealth_health/features/sync/domain/entities/sync_node.dart';
+
+void main() {
+  group('SyncState', () {
+    test('supports value equality', () {
+      final lastSync = DateTime(2023, 1, 1);
+      const nodes = [
+        SyncNode(id: '1', name: 'Node 1', host: 'localhost', port: 8080),
+      ];
+
+      expect(
+        SyncState(
+          status: SyncStatus.initial,
+          lastSyncTime: lastSync,
+          errorMessage: 'error',
+          discoveredNodes: nodes,
+        ),
+        SyncState(
+          status: SyncStatus.initial,
+          lastSyncTime: lastSync,
+          errorMessage: 'error',
+          discoveredNodes: nodes,
+        ),
+      );
+    });
+
+    test('copyWith works correctly', () {
+      final lastSync = DateTime(2023, 1, 1);
+      final newSync = DateTime(2023, 2, 2);
+      const nodes = [
+        SyncNode(id: '1', name: 'Node 1', host: 'localhost', port: 8080),
+      ];
+      const newNodes = [
+        SyncNode(id: '2', name: 'Node 2', host: 'localhost', port: 8081),
+      ];
+
+      final state = SyncState(
+        status: SyncStatus.initial,
+        lastSyncTime: lastSync,
+        errorMessage: 'error',
+        discoveredNodes: nodes,
+      );
+
+      final updatedState = state.copyWith(
+        status: SyncStatus.success,
+        lastSyncTime: newSync,
+        errorMessage: 'no error',
+        discoveredNodes: newNodes,
+      );
+
+      expect(updatedState.status, SyncStatus.success);
+      expect(updatedState.lastSyncTime, newSync);
+      expect(updatedState.errorMessage, 'no error');
+      expect(updatedState.discoveredNodes, newNodes);
+
+      final partiallyUpdated = state.copyWith(status: SyncStatus.loading);
+      expect(partiallyUpdated.status, SyncStatus.loading);
+      expect(partiallyUpdated.lastSyncTime, lastSync);
+      expect(partiallyUpdated.errorMessage, 'error');
+      expect(partiallyUpdated.discoveredNodes, nodes);
+    });
+  });
+}


### PR DESCRIPTION
I have added missing unit tests for the `SyncState` model in the sync feature. I also explored adding tests for the `SyncRepository` implementation and domain interfaces. While I successfully implemented state tests, I encountered difficulties in providing robust unit tests for the Isar-based `SyncRepositoryImpl` without a functioning Isar environment in the sandbox, leading me to prioritize maintaining the existing integration-style tests that were already present.

Fixes #734

---
*PR created automatically by Jules for task [6543346463597038806](https://jules.google.com/task/6543346463597038806) started by @iberi22*