### PR TITLE
Add missing doctor_verification infrastructure tests and DTO models

### DIFF
--- a/lib/features/doctor_verification/infrastructure/infrastructure.dart
+++ b/lib/features/doctor_verification/infrastructure/infrastructure.dart
@@ -3,5 +3,10 @@
 /// Exports infrastructure implementations migrated from legacy data/ layer.
 export 'datasources/license_registry_local.dart';
 export 'models/doctor_profile_model.dart';
+export 'models/doctor_rating_model.dart';
+export 'models/second_opinion_model.dart';
+export 'models/vouch_model.dart';
 export 'repositories/isar_doctor_profile_repository.dart';
 export 'repositories/isar_rating_repository.dart';
+export 'repositories/isar_second_opinion_repository.dart';
+export 'repositories/isar_vouch_repository.dart';

--- a/lib/features/doctor_verification/infrastructure/models/doctor_rating_model.dart
+++ b/lib/features/doctor_verification/infrastructure/models/doctor_rating_model.dart
@@ -1,0 +1,60 @@
+import 'dart:convert';
+import '../../domain/entities/doctor_rating.dart';
+
+class DoctorRatingModel extends DoctorRating {
+  DoctorRatingModel({
+    required super.id,
+    required super.doctorId,
+    super.patientId,
+    required super.overallScore,
+    required super.categoriesJson,
+    super.comment,
+    required super.createdAt,
+    required super.isAnonymous,
+    required super.verifiedVisit,
+  });
+
+  factory DoctorRatingModel.fromJson(Map<String, dynamic> json) {
+    return DoctorRatingModel(
+      id: json['id'] as String,
+      doctorId: json['doctorId'] as String,
+      patientId: json['patientId'] as String?,
+      overallScore: json['overallScore'] as int,
+      categoriesJson: json['categoriesJson'] is Map
+          ? jsonEncode(json['categoriesJson'])
+          : json['categoriesJson'] as String,
+      comment: json['comment'] as String?,
+      createdAt: DateTime.parse(json['createdAt'] as String),
+      isAnonymous: json['isAnonymous'] as bool? ?? false,
+      verifiedVisit: json['verifiedVisit'] as bool? ?? false,
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'doctorId': doctorId,
+      'patientId': patientId,
+      'overallScore': overallScore,
+      'categoriesJson': categoriesJson,
+      'comment': comment,
+      'createdAt': createdAt.toIso8601String(),
+      'isAnonymous': isAnonymous,
+      'verifiedVisit': verifiedVisit,
+    };
+  }
+
+  factory DoctorRatingModel.fromEntity(DoctorRating entity) {
+    return DoctorRatingModel(
+      id: entity.id,
+      doctorId: entity.doctorId,
+      patientId: entity.patientId,
+      overallScore: entity.overallScore,
+      categoriesJson: entity.categoriesJson,
+      comment: entity.comment,
+      createdAt: entity.createdAt,
+      isAnonymous: entity.isAnonymous,
+      verifiedVisit: entity.verifiedVisit,
+    );
+  }
+}

--- a/lib/features/doctor_verification/infrastructure/models/second_opinion_model.dart
+++ b/lib/features/doctor_verification/infrastructure/models/second_opinion_model.dart
@@ -1,0 +1,92 @@
+import '../../domain/entities/second_opinion.dart';
+
+class SecondOpinionRequestModel extends SecondOpinionRequest {
+  SecondOpinionRequestModel({
+    required super.id,
+    required super.patientId,
+    super.primaryDoctorId,
+    required super.symptoms,
+    super.documents,
+    required super.createdAt,
+  });
+
+  factory SecondOpinionRequestModel.fromJson(Map<String, dynamic> json) {
+    return SecondOpinionRequestModel(
+      id: json['id'] as String,
+      patientId: json['patientId'] as String,
+      primaryDoctorId: json['primaryDoctorId'] as String?,
+      symptoms: json['symptoms'] as String,
+      documents: (json['documents'] as List<dynamic>?)
+              ?.map((e) => e as String)
+              .toList() ??
+          const [],
+      createdAt: DateTime.parse(json['createdAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'patientId': patientId,
+      'primaryDoctorId': primaryDoctorId,
+      'symptoms': symptoms,
+      'documents': documents,
+      'createdAt': createdAt.toIso8601String(),
+    };
+  }
+
+  factory SecondOpinionRequestModel.fromEntity(SecondOpinionRequest entity) {
+    return SecondOpinionRequestModel(
+      id: entity.id,
+      patientId: entity.patientId,
+      primaryDoctorId: entity.primaryDoctorId,
+      symptoms: entity.symptoms,
+      documents: entity.documents,
+      createdAt: entity.createdAt,
+    );
+  }
+}
+
+class SecondOpinionResponseModel extends SecondOpinionResponse {
+  SecondOpinionResponseModel({
+    required super.id,
+    required super.requestId,
+    required super.reviewerDoctorId,
+    required super.recommendation,
+    required super.confidence,
+    required super.respondedAt,
+  });
+
+  factory SecondOpinionResponseModel.fromJson(Map<String, dynamic> json) {
+    return SecondOpinionResponseModel(
+      id: json['id'] as String,
+      requestId: json['requestId'] as String,
+      reviewerDoctorId: json['reviewerDoctorId'] as String,
+      recommendation: json['recommendation'] as String,
+      confidence: (json['confidence'] as num).toDouble(),
+      respondedAt: DateTime.parse(json['respondedAt'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'requestId': requestId,
+      'reviewerDoctorId': reviewerDoctorId,
+      'recommendation': recommendation,
+      'confidence': confidence,
+      'respondedAt': respondedAt.toIso8601String(),
+    };
+  }
+
+  factory SecondOpinionResponseModel.fromEntity(SecondOpinionResponse entity) {
+    return SecondOpinionResponseModel(
+      id: entity.id,
+      requestId: entity.requestId,
+      reviewerDoctorId: entity.reviewerDoctorId,
+      recommendation: entity.recommendation,
+      confidence: entity.confidence,
+      respondedAt: entity.respondedAt,
+    );
+  }
+}

--- a/lib/features/doctor_verification/infrastructure/models/vouch_model.dart
+++ b/lib/features/doctor_verification/infrastructure/models/vouch_model.dart
@@ -1,0 +1,41 @@
+import '../../domain/entities/vouch.dart';
+
+class VouchModel extends Vouch {
+  VouchModel({
+    required super.id,
+    required super.vouchedBy,
+    required super.targetDoctor,
+    required super.category,
+    required super.timestamp,
+  });
+
+  factory VouchModel.fromJson(Map<String, dynamic> json) {
+    return VouchModel(
+      id: json['id'] as String,
+      vouchedBy: json['vouchedBy'] as String,
+      targetDoctor: json['targetDoctor'] as String,
+      category: json['category'] as String,
+      timestamp: DateTime.parse(json['timestamp'] as String),
+    );
+  }
+
+  Map<String, dynamic> toJson() {
+    return {
+      'id': id,
+      'vouchedBy': vouchedBy,
+      'targetDoctor': targetDoctor,
+      'category': category,
+      'timestamp': timestamp.toIso8601String(),
+    };
+  }
+
+  factory VouchModel.fromEntity(Vouch entity) {
+    return VouchModel(
+      id: entity.id,
+      vouchedBy: entity.vouchedBy,
+      targetDoctor: entity.targetDoctor,
+      category: entity.category,
+      timestamp: entity.timestamp,
+    );
+  }
+}

--- a/test/features/doctor_verification/infrastructure/infrastructure_test.dart
+++ b/test/features/doctor_verification/infrastructure/infrastructure_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/infrastructure/infrastructure.dart';
+
+void main() {
+  group('Infrastructure Exports Smoke Test', () {
+    test('should export all required classes', () {
+      // Data sources
+      expect(LicenseRegistryLocalDataSource, isNotNull);
+
+      // Models
+      expect(DoctorProfileModel, isNotNull);
+      expect(DoctorRatingModel, isNotNull);
+      expect(SecondOpinionRequestModel, isNotNull);
+      expect(SecondOpinionResponseModel, isNotNull);
+      expect(VouchModel, isNotNull);
+
+      // Repositories
+      expect(IsarDoctorProfileRepository, isNotNull);
+      expect(IsarRatingRepository, isNotNull);
+      expect(IsarSecondOpinionRepository, isNotNull);
+      expect(IsarVouchRepository, isNotNull);
+    });
+  });
+}

--- a/test/features/doctor_verification/infrastructure/models/doctor_rating_model_test.dart
+++ b/test/features/doctor_verification/infrastructure/models/doctor_rating_model_test.dart
@@ -1,0 +1,91 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/doctor_rating.dart';
+import 'package:orionhealth_health/features/doctor_verification/infrastructure/models/doctor_rating_model.dart';
+
+void main() {
+  final tDate = DateTime(2023, 6, 15);
+  final tCategoriesMap = {'Clinical': 5, 'Bedside': 4};
+  final tCategoriesJson = jsonEncode(tCategoriesMap);
+
+  final tEntity = DoctorRating(
+    id: 'r1',
+    doctorId: 'doc1',
+    patientId: 'p1',
+    overallScore: 5,
+    categoriesJson: tCategoriesJson,
+    comment: 'Great doctor',
+    createdAt: tDate,
+    isAnonymous: false,
+    verifiedVisit: true,
+  );
+
+  final tModel = DoctorRatingModel(
+    id: 'r1',
+    doctorId: 'doc1',
+    patientId: 'p1',
+    overallScore: 5,
+    categoriesJson: tCategoriesJson,
+    comment: 'Great doctor',
+    createdAt: tDate,
+    isAnonymous: false,
+    verifiedVisit: true,
+  );
+
+  group('DoctorRatingModel', () {
+    test('should be a subclass of DoctorRating entity', () {
+      expect(tModel, isA<DoctorRating>());
+    });
+
+    test('fromJson should return a valid model', () {
+      final jsonMap = <String, dynamic>{
+        'id': 'r1',
+        'doctorId': 'doc1',
+        'patientId': 'p1',
+        'overallScore': 5,
+        'categoriesJson': tCategoriesJson,
+        'comment': 'Great doctor',
+        'createdAt': tDate.toIso8601String(),
+        'isAnonymous': false,
+        'verifiedVisit': true,
+      };
+
+      final result = DoctorRatingModel.fromJson(jsonMap);
+
+      expect(result.id, tModel.id);
+      expect(result.doctorId, tModel.doctorId);
+      expect(result.overallScore, tModel.overallScore);
+      expect(result.categoriesJson, tModel.categoriesJson);
+      expect(result.createdAt, tModel.createdAt);
+    });
+
+    test('fromJson should handle categoriesJson as Map', () {
+      final jsonMap = <String, dynamic>{
+        'id': 'r1',
+        'doctorId': 'doc1',
+        'overallScore': 5,
+        'categoriesJson': tCategoriesMap,
+        'createdAt': tDate.toIso8601String(),
+      };
+
+      final result = DoctorRatingModel.fromJson(jsonMap);
+      expect(result.categoriesJson, tCategoriesJson);
+    });
+
+    test('toJson should return a JSON map containing the proper data', () {
+      final result = tModel.toJson();
+
+      expect(result['id'], 'r1');
+      expect(result['doctorId'], 'doc1');
+      expect(result['overallScore'], 5);
+      expect(result['categoriesJson'], tCategoriesJson);
+      expect(result['createdAt'], tDate.toIso8601String());
+    });
+
+    test('fromEntity should return a valid model', () {
+      final result = DoctorRatingModel.fromEntity(tEntity);
+      expect(result.id, tModel.id);
+      expect(result.doctorId, tModel.doctorId);
+    });
+  });
+}

--- a/test/features/doctor_verification/infrastructure/models/second_opinion_model_test.dart
+++ b/test/features/doctor_verification/infrastructure/models/second_opinion_model_test.dart
@@ -1,0 +1,127 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/second_opinion.dart';
+import 'package:orionhealth_health/features/doctor_verification/infrastructure/models/second_opinion_model.dart';
+
+void main() {
+  final tDate = DateTime(2023, 6, 15);
+
+  group('SecondOpinionRequestModel', () {
+    final tEntity = SecondOpinionRequest(
+      id: 'req1',
+      patientId: 'p1',
+      primaryDoctorId: 'doc1',
+      symptoms: 'Symptoms',
+      documents: ['doc1.pdf'],
+      createdAt: tDate,
+    );
+
+    final tModel = SecondOpinionRequestModel(
+      id: 'req1',
+      patientId: 'p1',
+      primaryDoctorId: 'doc1',
+      symptoms: 'Symptoms',
+      documents: ['doc1.pdf'],
+      createdAt: tDate,
+    );
+
+    test('should be a subclass of SecondOpinionRequest entity', () {
+      expect(tModel, isA<SecondOpinionRequest>());
+    });
+
+    test('fromJson should return a valid model', () {
+      final jsonMap = <String, dynamic>{
+        'id': 'req1',
+        'patientId': 'p1',
+        'primaryDoctorId': 'doc1',
+        'symptoms': 'Symptoms',
+        'documents': ['doc1.pdf'],
+        'createdAt': tDate.toIso8601String(),
+      };
+
+      final result = SecondOpinionRequestModel.fromJson(jsonMap);
+
+      expect(result.id, tModel.id);
+      expect(result.patientId, tModel.patientId);
+      expect(result.primaryDoctorId, tModel.primaryDoctorId);
+      expect(result.symptoms, tModel.symptoms);
+      expect(result.documents, tModel.documents);
+      expect(result.createdAt, tModel.createdAt);
+    });
+
+    test('toJson should return a JSON map containing the proper data', () {
+      final result = tModel.toJson();
+
+      expect(result['id'], 'req1');
+      expect(result['patientId'], 'p1');
+      expect(result['primaryDoctorId'], 'doc1');
+      expect(result['symptoms'], 'Symptoms');
+      expect(result['documents'], ['doc1.pdf']);
+      expect(result['createdAt'], tDate.toIso8601String());
+    });
+
+    test('fromEntity should return a valid model', () {
+      final result = SecondOpinionRequestModel.fromEntity(tEntity);
+      expect(result.id, tModel.id);
+    });
+  });
+
+  group('SecondOpinionResponseModel', () {
+    final tEntity = SecondOpinionResponse(
+      id: 'res1',
+      requestId: 'req1',
+      reviewerDoctorId: 'doc2',
+      recommendation: 'Recommendation',
+      confidence: 0.9,
+      respondedAt: tDate,
+    );
+
+    final tModel = SecondOpinionResponseModel(
+      id: 'res1',
+      requestId: 'req1',
+      reviewerDoctorId: 'doc2',
+      recommendation: 'Recommendation',
+      confidence: 0.9,
+      respondedAt: tDate,
+    );
+
+    test('should be a subclass of SecondOpinionResponse entity', () {
+      expect(tModel, isA<SecondOpinionResponse>());
+    });
+
+    test('fromJson should return a valid model', () {
+      final jsonMap = <String, dynamic>{
+        'id': 'res1',
+        'requestId': 'req1',
+        'reviewerDoctorId': 'doc2',
+        'recommendation': 'Recommendation',
+        'confidence': 0.9,
+        'respondedAt': tDate.toIso8601String(),
+      };
+
+      final result = SecondOpinionResponseModel.fromJson(jsonMap);
+
+      expect(result.id, tModel.id);
+      expect(result.requestId, tModel.requestId);
+      expect(result.reviewerDoctorId, tModel.reviewerDoctorId);
+      expect(result.recommendation, tModel.recommendation);
+      expect(result.confidence, tModel.confidence);
+      expect(result.respondedAt, tModel.respondedAt);
+    });
+
+    test('toJson should return a JSON map containing the proper data', () {
+      final result = tModel.toJson();
+
+      expect(result['id'], 'res1');
+      expect(result['requestId'], 'req1');
+      expect(result['reviewerDoctorId'], 'doc2');
+      expect(result['recommendation'], 'Recommendation');
+      expect(result['confidence'], 0.9);
+      expect(result['respondedAt'], tDate.toIso8601String());
+    });
+
+    test('fromEntity should return a valid model', () {
+      final result = SecondOpinionResponseModel.fromEntity(tEntity);
+      expect(result.id, tModel.id);
+    });
+  });
+}

--- a/test/features/doctor_verification/infrastructure/models/vouch_model_test.dart
+++ b/test/features/doctor_verification/infrastructure/models/vouch_model_test.dart
@@ -1,0 +1,62 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/vouch.dart';
+import 'package:orionhealth_health/features/doctor_verification/infrastructure/models/vouch_model.dart';
+
+void main() {
+  final tDate = DateTime(2023, 6, 15);
+
+  final tEntity = Vouch(
+    id: 'v1',
+    vouchedBy: 'doc2',
+    targetDoctor: 'doc1',
+    category: 'Clinical Excellence',
+    timestamp: tDate,
+  );
+
+  final tModel = VouchModel(
+    id: 'v1',
+    vouchedBy: 'doc2',
+    targetDoctor: 'doc1',
+    category: 'Clinical Excellence',
+    timestamp: tDate,
+  );
+
+  group('VouchModel', () {
+    test('should be a subclass of Vouch entity', () {
+      expect(tModel, isA<Vouch>());
+    });
+
+    test('fromJson should return a valid model', () {
+      final jsonMap = <String, dynamic>{
+        'id': 'v1',
+        'vouchedBy': 'doc2',
+        'targetDoctor': 'doc1',
+        'category': 'Clinical Excellence',
+        'timestamp': tDate.toIso8601String(),
+      };
+
+      final result = VouchModel.fromJson(jsonMap);
+
+      expect(result.id, tModel.id);
+      expect(result.vouchedBy, tModel.vouchedBy);
+      expect(result.targetDoctor, tModel.targetDoctor);
+      expect(result.category, tModel.category);
+      expect(result.timestamp, tModel.timestamp);
+    });
+
+    test('toJson should return a JSON map containing the proper data', () {
+      final result = tModel.toJson();
+
+      expect(result['id'], 'v1');
+      expect(result['vouchedBy'], 'doc2');
+      expect(result['targetDoctor'], 'doc1');
+      expect(result['category'], 'Clinical Excellence');
+      expect(result['timestamp'], tDate.toIso8601String());
+    });
+
+    test('fromEntity should return a valid model', () {
+      final result = VouchModel.fromEntity(tEntity);
+      expect(result.id, tModel.id);
+    });
+  });
+}


### PR DESCRIPTION
This PR completes the infrastructure layer testing for the doctor_verification feature. 

Key changes:
1.  **New DTO Models**: Added `DoctorRatingModel`, `VouchModel`, `SecondOpinionRequestModel`, and `SecondOpinionResponseModel` in `lib/features/doctor_verification/infrastructure/models/`. These models extend the domain entities and provide `fromJson`, `toJson`, and `fromEntity` methods for clean serialization.
2.  **Infrastructure Exports**: Updated the barrel file `lib/features/doctor_verification/infrastructure/infrastructure.dart` to export the new models and the previously missing `IsarSecondOpinionRepository` and `IsarVouchRepository`.
3.  **Tests**:
    - Added unit tests for all new models in `test/features/doctor_verification/infrastructure/models/`.
    - Added a smoke test in `test/features/doctor_verification/infrastructure/infrastructure_test.dart` to verify all intended classes are exported.
    - Verified that existing repository integration tests in `test/features/doctor_verification/infrastructure/repositories/` are fully functional and passing.

All tests for the `doctor_verification` feature were run and are passing.

Fixes #739

---
*PR created automatically by Jules for task [6511240591762991505](https://jules.google.com/task/6511240591762991505) started by @iberi22*