### PR TITLE
Add missing auth tests

### DIFF
--- a/test/features/auth/application/auth_cubit_test.dart
+++ b/test/features/auth/application/auth_cubit_test.dart
@@ -1,0 +1,190 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/application/auth_cubit.dart';
+import 'package:orionhealth_health/features/auth/application/auth_state.dart';
+import 'package:orionhealth_health/features/auth/domain/auth_service.dart';
+
+class MockAuthService extends Mock implements AuthService {}
+
+void main() {
+  late AuthCubit authCubit;
+  late MockAuthService mockAuthService;
+
+  setUp(() {
+    mockAuthService = MockAuthService();
+    authCubit = AuthCubit(mockAuthService);
+  });
+
+  tearDown(() {
+    authCubit.close();
+  });
+
+  group('AuthCubit', () {
+    test('initial state should be AuthStatus.initial', () {
+      expect(authCubit.state.status, AuthStatus.initial);
+    });
+
+    group('checkAuth', () {
+      test('emits loading and then unauthenticated when PIN is not set', () async {
+        when(() => mockAuthService.isPinSet()).thenAnswer((_) async => false);
+        when(() => mockAuthService.isBiometricAvailable()).thenAnswer((_) async => true);
+
+        final expectation = expectLater(
+          authCubit.stream,
+          emitsInOrder([
+            predicate<AuthState>((s) => s.status == AuthStatus.loading),
+            predicate<AuthState>((s) =>
+                s.status == AuthStatus.unauthenticated &&
+                s.isPinSet == false &&
+                s.isBiometricAvailable == true),
+          ]),
+        );
+
+        await authCubit.checkAuth();
+        await expectation;
+      });
+
+      test('emits correct states when PIN is set and biometric succeeds', () async {
+        when(() => mockAuthService.isPinSet()).thenAnswer((_) async => true);
+        when(() => mockAuthService.isBiometricAvailable()).thenAnswer((_) async => true);
+        when(() => mockAuthService.verifyBiometric()).thenAnswer((_) async => AuthResult(success: true, method: AuthMethod.biometric));
+
+        final expectation = expectLater(
+          authCubit.stream,
+          emitsInOrder([
+            predicate<AuthState>((s) => s.status == AuthStatus.loading),
+            predicate<AuthState>((s) => s.status == AuthStatus.pinRequired),
+            predicate<AuthState>((s) => s.status == AuthStatus.biometricPrompt),
+            predicate<AuthState>((s) => s.status == AuthStatus.authenticated),
+          ]),
+        );
+
+        await authCubit.checkAuth();
+        await expectation;
+      });
+    });
+
+    group('submitPin', () {
+      test('emits loading and then authenticated on success', () async {
+        when(() => mockAuthService.verifyPin(any())).thenAnswer((_) async => AuthResult(success: true, method: AuthMethod.pin));
+
+        final expectation = expectLater(
+          authCubit.stream,
+          emitsInOrder([
+            predicate<AuthState>((s) => s.status == AuthStatus.loading),
+            predicate<AuthState>((s) => s.status == AuthStatus.authenticated && s.lastAuthTime != null),
+          ]),
+        );
+
+        await authCubit.submitPin('1234');
+        await expectation;
+      });
+
+      test('emits loading and then error on failure', () async {
+        when(() => mockAuthService.verifyPin(any())).thenAnswer((_) async => AuthResult(success: false, error: 'Invalid', method: AuthMethod.pin));
+
+        final expectation = expectLater(
+          authCubit.stream,
+          emitsInOrder([
+            predicate<AuthState>((s) => s.status == AuthStatus.loading),
+            predicate<AuthState>((s) => s.status == AuthStatus.error && s.error == 'Invalid'),
+          ]),
+        );
+
+        await authCubit.submitPin('1234');
+        await expectation;
+      });
+    });
+
+    group('setPin', () {
+      test('emits loading and then authenticated on success', () async {
+        when(() => mockAuthService.setPin(any())).thenAnswer((_) async => AuthResult(success: true, method: AuthMethod.pin));
+
+        final expectation = expectLater(
+          authCubit.stream,
+          emitsInOrder([
+            predicate<AuthState>((s) => s.status == AuthStatus.loading),
+            predicate<AuthState>((s) => s.status == AuthStatus.authenticated && s.isPinSet == true),
+          ]),
+        );
+
+        await authCubit.setPin('1234');
+        await expectation;
+      });
+
+      test('emits loading and then error on failure', () async {
+        when(() => mockAuthService.setPin(any())).thenAnswer((_) async => AuthResult(success: false, error: 'Fail', method: AuthMethod.pin));
+
+        final expectation = expectLater(
+          authCubit.stream,
+          emitsInOrder([
+            predicate<AuthState>((s) => s.status == AuthStatus.loading),
+            predicate<AuthState>((s) => s.status == AuthStatus.error && s.error == 'Fail'),
+          ]),
+        );
+
+        await authCubit.setPin('1234');
+        await expectation;
+      });
+    });
+
+    group('verifyBiometric', () {
+      test('emits biometricPrompt and then authenticated on success', () async {
+        when(() => mockAuthService.verifyBiometric()).thenAnswer((_) async => AuthResult(success: true, method: AuthMethod.biometric));
+
+        final expectation = expectLater(
+          authCubit.stream,
+          emitsInOrder([
+            predicate<AuthState>((s) => s.status == AuthStatus.biometricPrompt),
+            predicate<AuthState>((s) => s.status == AuthStatus.authenticated),
+          ]),
+        );
+
+        await authCubit.verifyBiometric();
+        await expectation;
+      });
+
+      test('emits biometricPrompt and then pinRequired on failure', () async {
+        when(() => mockAuthService.verifyBiometric()).thenAnswer((_) async => AuthResult(success: false, method: AuthMethod.biometric));
+
+        final expectation = expectLater(
+          authCubit.stream,
+          emitsInOrder([
+            predicate<AuthState>((s) => s.status == AuthStatus.biometricPrompt),
+            predicate<AuthState>((s) => s.status == AuthStatus.pinRequired),
+          ]),
+        );
+
+        await authCubit.verifyBiometric();
+        await expectation;
+      });
+    });
+
+    test('logout emits unauthenticated', () async {
+      final expectation = expectLater(
+        authCubit.stream,
+        emitsInOrder([
+          predicate<AuthState>((s) => s.status == AuthStatus.unauthenticated),
+        ]),
+      );
+
+      await authCubit.logout();
+      await expectation;
+    });
+
+    test('clearAuth calls service and emits unauthenticated', () async {
+      when(() => mockAuthService.clearAuth()).thenAnswer((_) async {});
+
+      final expectation = expectLater(
+        authCubit.stream,
+        emitsInOrder([
+          predicate<AuthState>((s) => s.status == AuthStatus.unauthenticated && s.isPinSet == false),
+        ]),
+      );
+
+      await authCubit.clearAuth();
+      await expectation;
+      verify(() => mockAuthService.clearAuth()).called(1);
+    });
+  });
+}

--- a/test/features/auth/application/auth_models_test.dart
+++ b/test/features/auth/application/auth_models_test.dart
@@ -1,0 +1,65 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/auth/application/auth_event.dart';
+import 'package:orionhealth_health/features/auth/application/auth_state.dart';
+
+void main() {
+  group('AuthEvent', () {
+    test('AuthCheckRequested support value equality', () {
+      expect(AuthCheckRequested(), AuthCheckRequested());
+    });
+
+    test('AuthPinSubmitted support value equality', () {
+      expect(const AuthPinSubmitted('1234'), const AuthPinSubmitted('1234'));
+      expect(const AuthPinSubmitted('1234'), isNot(const AuthPinSubmitted('4321')));
+    });
+
+    test('AuthPinSetRequested support value equality', () {
+      expect(const AuthPinSetRequested('1234'), const AuthPinSetRequested('1234'));
+    });
+
+    test('AuthBiometricRequested support value equality', () {
+      expect(AuthBiometricRequested(), AuthBiometricRequested());
+    });
+
+    test('AuthLogoutRequested support value equality', () {
+      expect(AuthLogoutRequested(), AuthLogoutRequested());
+    });
+
+    test('AuthClearRequested support value equality', () {
+      expect(AuthClearRequested(), AuthClearRequested());
+    });
+  });
+
+  group('AuthState', () {
+    test('support value equality', () {
+      final now = DateTime.now();
+      expect(
+        AuthState(status: AuthStatus.authenticated, lastAuthTime: now),
+        AuthState(status: AuthStatus.authenticated, lastAuthTime: now),
+      );
+    });
+
+    test('copyWith works correctly', () {
+      const state = AuthState(status: AuthStatus.initial);
+      final updated = state.copyWith(status: AuthStatus.loading, isPinSet: true);
+
+      expect(updated.status, AuthStatus.loading);
+      expect(updated.isPinSet, isTrue);
+      expect(updated.isBiometricAvailable, isFalse);
+    });
+
+    test('copyWith preserves values when null is passed', () {
+      const state = AuthState(status: AuthStatus.pinRequired, isPinSet: true);
+      final updated = state.copyWith();
+
+      expect(updated, state);
+    });
+
+    test('copyWith clears error when new error is null (if implementation allows it, but here it seems it just overwrites)', () {
+      const state = AuthState(status: AuthStatus.error, error: 'Some error');
+      final updated = state.copyWith(status: AuthStatus.initial, error: null);
+
+      expect(updated.error, isNull);
+    });
+  });
+}

--- a/test/features/auth/infrastructure/repositories/auth_repository_impl_test.dart
+++ b/test/features/auth/infrastructure/repositories/auth_repository_impl_test.dart
@@ -68,6 +68,14 @@ void main() {
       expect(await repository.isBiometricsEnabled(), isTrue);
     });
 
+    test('hasPinSet should return false when no credentials', () async {
+      expect(await repository.hasPinSet(), isFalse);
+    });
+
+    test('isBiometricsEnabled should return false when no credentials', () async {
+      expect(await repository.isBiometricsEnabled(), isFalse);
+    });
+
     test('deleteCredentials should clear all credentials', () async {
       final credentials = AuthCredentials()..hashedPin = 'hashed';
       await repository.saveCredentials(credentials);

--- a/test/features/auth/presentation/pages/share_medical_data_page_test.dart
+++ b/test/features/auth/presentation/pages/share_medical_data_page_test.dart
@@ -1,0 +1,169 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/auth/presentation/pages/share_medical_data_page.dart';
+import 'package:orionhealth_health/features/health_sharing/application/sharing_cubit.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+
+class MockSharingCubit extends Mock implements SharingCubit {}
+
+void main() {
+  late MockSharingCubit mockSharingCubit;
+  final getIt = GetIt.instance;
+
+  setUpAll(() {
+    registerFallbackValue(TransferMethod.ble);
+    registerFallbackValue(SharedHealthPackage(
+      id: '',
+      senderNodeId: '',
+      recipientNodeId: '',
+      createdAt: DateTime.now(),
+      expiresAt: DateTime.now(),
+      payload: const EncryptedPayload(encryptedData: '', iv: '', ephemeralPublicKey: '', authTag: ''),
+      metadata: const PackageMetadata(packageType: '', consentVerified: true, includedCategories: {}, appVersion: '1.0.0'),
+      signature: '',
+    ));
+  });
+
+  setUp(() {
+    mockSharingCubit = MockSharingCubit();
+    getIt.registerSingleton<SharingCubit>(mockSharingCubit);
+
+    when(() => mockSharingCubit.state).thenReturn(SharingInitial());
+    when(() => mockSharingCubit.initialize()).thenAnswer((_) async {});
+    when(() => mockSharingCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockSharingCubit.close()).thenAnswer((_) async {});
+  });
+
+  tearDown(() async {
+    await getIt.unregister<SharingCubit>();
+  });
+
+  Widget createWidgetUnderTest() {
+    return const MaterialApp(
+      home: ShareMedicalDataPage(),
+    );
+  }
+
+  testWidgets('renders ShareMedicalDataPage with initial state', (tester) async {
+    tester.view.physicalSize = const Size(1080, 1920);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() => tester.view.resetPhysicalSize());
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    expect(find.text('Share Medical Data'), findsOneWidget);
+    expect(find.text('Select data to share'), findsOneWidget);
+    expect(find.text('Transfer method'), findsOneWidget);
+    expect(find.text('Select at least one category'), findsOneWidget);
+  });
+
+  testWidgets('can select categories and method', (tester) async {
+    tester.view.physicalSize = const Size(1080, 1920);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() => tester.view.resetPhysicalSize());
+
+    when(() => mockSharingCubit.state).thenReturn(const SharingReady());
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    // Select a category
+    await tester.tap(find.text(DataCategory.vitalSigns.displayName));
+    await tester.pump();
+
+    expect(find.text('1 categories selected'), findsOneWidget);
+    expect(find.text('Share'), findsOneWidget);
+
+    // Change transfer method
+    await tester.tap(find.text(TransferMethod.ble.displayName));
+    await tester.pump();
+
+    final radio = tester.widget<RadioListTile<TransferMethod>>(
+      find.widgetWithText(RadioListTile<TransferMethod>, TransferMethod.ble.displayName),
+    );
+    expect(radio.value, TransferMethod.ble);
+  });
+
+  testWidgets('calls startSharing when Share button is pressed', (tester) async {
+    tester.view.physicalSize = const Size(1080, 1920);
+    tester.view.devicePixelRatio = 1.0;
+    addTearDown(() => tester.view.resetPhysicalSize());
+
+    when(() => mockSharingCubit.state).thenReturn(const SharingReady());
+    when(() => mockSharingCubit.startSharing(
+          method: any(named: 'method'),
+          package: any(named: 'package'),
+        )).thenAnswer((_) async {});
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    // Select category to enable button
+    await tester.tap(find.text(DataCategory.vitalSigns.displayName));
+    await tester.pump();
+
+    await tester.ensureVisible(find.text('Share'));
+    await tester.tap(find.text('Share'));
+    await tester.pump();
+
+    verify(() => mockSharingCubit.startSharing(
+          method: any(named: 'method'),
+          package: any(named: 'package'),
+        )).called(1);
+  });
+
+  testWidgets('shows transferring UI when in scanning state', (tester) async {
+    when(() => mockSharingCubit.state).thenReturn(const SharingScanning(TransferMethod.nfc));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    expect(find.text('Searching for devices...'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('shows success dialog on SharingComplete', (tester) async {
+    final controller = StreamController<SharingState>.broadcast();
+    when(() => mockSharingCubit.stream).thenAnswer((_) => controller.stream);
+    when(() => mockSharingCubit.state).thenReturn(const SharingReady());
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    const result = SharingResult(success: true, bytesTransferred: 1024, transferTime: Duration(seconds: 5));
+    const completeState = SharingComplete(result, TransferMethod.nfc);
+
+    when(() => mockSharingCubit.state).thenReturn(completeState);
+    controller.add(completeState);
+
+    await tester.pump();
+    await tester.pump(); // Second pump for dialog animation
+
+    expect(find.text('Shared successfully!'), findsOneWidget);
+    expect(find.text('1024 bytes transferred'), findsOneWidget);
+
+    await controller.close();
+  });
+
+  testWidgets('shows snackbar on SharingError', (tester) async {
+    final controller = StreamController<SharingState>.broadcast();
+    when(() => mockSharingCubit.stream).thenAnswer((_) => controller.stream);
+    when(() => mockSharingCubit.state).thenReturn(const SharingReady());
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    controller.add(const SharingError('Error message'));
+    await tester.pump(); // Trigger listener
+    await tester.pump(); // Trigger snackbar animation
+
+    expect(find.text('Error message'), findsOneWidget);
+
+    await controller.close();
+  });
+}


### PR DESCRIPTION
This PR adds missing unit and widget tests for the authentication feature.

Key changes:
- Created `test/features/auth/application/auth_cubit_test.dart` to cover all public methods and state transitions of the primary `AuthCubit`.
- Created `test/features/auth/application/auth_models_test.dart` to verify `Equatable` and `copyWith` logic for `AuthEvent` and `AuthState`.
- Enhanced `test/features/auth/infrastructure/repositories/auth_repository_impl_test.dart` by adding tests for `hasPinSet` and `isBiometricsEnabled` when no credentials exist.
- Created `test/features/auth/presentation/pages/share_medical_data_page_test.dart` to verify UI rendering and interaction with `SharingCubit`.
- Resolved compilation errors in `auth_gate_test.dart` caused by missing localization files by running `flutter gen-l10n`.
- Verified that all 77 tests in the `auth` feature pass.

Fixes #735

---
*PR created automatically by Jules for task [13646382208151840845](https://jules.google.com/task/13646382208151840845) started by @iberi22*