### PR TITLE
Add missing auth tests - application events/state and domain repository

### DIFF
--- a/test/features/auth/application/auth_event_test.dart
+++ b/test/features/auth/application/auth_event_test.dart
@@ -1,0 +1,32 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/auth/application/auth_event.dart';
+
+void main() {
+  group('AuthEvent', () {
+    test('AuthCheckRequested supports value equality', () {
+      expect(AuthCheckRequested(), AuthCheckRequested());
+    });
+
+    test('AuthPinSubmitted supports value equality', () {
+      expect(const AuthPinSubmitted('1234'), const AuthPinSubmitted('1234'));
+      expect(const AuthPinSubmitted('1234'), isNot(const AuthPinSubmitted('4321')));
+    });
+
+    test('AuthPinSetRequested supports value equality', () {
+      expect(const AuthPinSetRequested('1234'), const AuthPinSetRequested('1234'));
+      expect(const AuthPinSetRequested('1234'), isNot(const AuthPinSetRequested('4321')));
+    });
+
+    test('AuthBiometricRequested supports value equality', () {
+      expect(AuthBiometricRequested(), AuthBiometricRequested());
+    });
+
+    test('AuthLogoutRequested supports value equality', () {
+      expect(AuthLogoutRequested(), AuthLogoutRequested());
+    });
+
+    test('AuthClearRequested supports value equality', () {
+      expect(AuthClearRequested(), AuthClearRequested());
+    });
+  });
+}

--- a/test/features/auth/application/bloc/auth_state_test.dart
+++ b/test/features/auth/application/bloc/auth_state_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/auth/application/bloc/auth_state.dart';
+
+void main() {
+  group('AuthState (bloc)', () {
+    test('AuthInitial supports value equality', () {
+      expect(const AuthInitial(), const AuthInitial());
+    });
+
+    test('AuthNotSetup supports value equality', () {
+      expect(const AuthNotSetup(), const AuthNotSetup());
+    });
+
+    test('AuthLocked supports value equality', () {
+      final now = DateTime.now();
+      expect(AuthLocked(now), AuthLocked(now));
+      expect(AuthLocked(now), isNot(AuthLocked(now.add(const Duration(seconds: 1)))));
+    });
+
+    test('AuthUnauthenticated supports value equality', () {
+      expect(const AuthUnauthenticated(), const AuthUnauthenticated());
+      expect(
+        const AuthUnauthenticated(failedAttempts: 1, errorMessage: 'Error'),
+        const AuthUnauthenticated(failedAttempts: 1, errorMessage: 'Error'),
+      );
+      expect(
+        const AuthUnauthenticated(failedAttempts: 1),
+        isNot(const AuthUnauthenticated(failedAttempts: 2)),
+      );
+    });
+
+    test('AuthAuthenticated supports value equality', () {
+      final now = DateTime.now();
+      expect(AuthAuthenticated(now), AuthAuthenticated(now));
+      expect(
+        AuthAuthenticated(now),
+        isNot(AuthAuthenticated(now.add(const Duration(seconds: 1)))),
+      );
+    });
+
+    test('AuthLoading supports value equality', () {
+      expect(const AuthLoading(), const AuthLoading());
+    });
+  });
+}

--- a/test/features/auth/domain/repositories/auth_repository_test.dart
+++ b/test/features/auth/domain/repositories/auth_repository_test.dart
@@ -1,0 +1,49 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_credentials.dart';
+import 'package:orionhealth_health/features/auth/domain/repositories/auth_repository.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+class FakeAuthCredentials extends Fake implements AuthCredentials {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeAuthCredentials());
+  });
+
+  group('AuthRepository Interface', () {
+    late MockAuthRepository mockRepository;
+
+    setUp(() {
+      mockRepository = MockAuthRepository();
+    });
+
+    test('can be mocked and called for all methods', () async {
+      final tCredentials = AuthCredentials()
+        ..hashedPin = 'hashed'
+        ..salt = 'salt';
+
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+      when(() => mockRepository.saveCredentials(any())).thenAnswer((_) async {});
+      when(() => mockRepository.deleteCredentials()).thenAnswer((_) async {});
+      when(() => mockRepository.hasPinSet()).thenAnswer((_) async => true);
+      when(() => mockRepository.isBiometricsEnabled()).thenAnswer((_) async => false);
+
+      final credentials = await mockRepository.getCredentials();
+      await mockRepository.saveCredentials(tCredentials);
+      await mockRepository.deleteCredentials();
+      final hasPin = await mockRepository.hasPinSet();
+      final bioEnabled = await mockRepository.isBiometricsEnabled();
+
+      expect(credentials, tCredentials);
+      expect(hasPin, isTrue);
+      expect(bioEnabled, isFalse);
+
+      verify(() => mockRepository.getCredentials()).called(1);
+      verify(() => mockRepository.saveCredentials(tCredentials)).called(1);
+      verify(() => mockRepository.deleteCredentials()).called(1);
+      verify(() => mockRepository.hasPinSet()).called(1);
+      verify(() => mockRepository.isBiometricsEnabled()).called(1);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds missing unit tests for the authentication feature, specifically covering:
- AuthEvent value equality in lib/features/auth/application/auth_event.dart
- AuthState value equality in lib/features/auth/application/bloc/auth_state.dart
- AuthRepository interface mockability in lib/features/auth/domain/repositories/auth_repository.dart

The tests follow the established patterns in the codebase, using Equatable for value equality checks and mocktail for interface mocking.

Fixes #750

---
*PR created automatically by Jules for task [12840434104469589051](https://jules.google.com/task/12840434104469589051) started by @iberi22*