### PR TITLE
Fix LlmSettingsRepositoryImpl and SharingCubit tests

### DIFF
--- a/lib/features/settings/data/repositories/llm_settings_repository_impl.dart
+++ b/lib/features/settings/data/repositories/llm_settings_repository_impl.dart
@@ -1,4 +1,5 @@
-﻿import '../../domain/entities/llm_config.dart';
+import '../../domain/entities/app_settings.dart';
+import '../../domain/entities/llm_config.dart';
 import '../../domain/repositories/llm_settings_repository.dart';
 import '../datasources/settings_local_datasource.dart';
 
@@ -8,6 +9,27 @@ class LlmSettingsRepositoryImpl implements LlmSettingsRepository {
 
   @override
   Future<LlmConfig?> getLlmConfig() => _localDataSource.getLlmConfig();
+
   @override
-  Future<void> saveLlmConfig(LlmConfig config) => _localDataSource.saveLlmConfig(config);
+  Future<void> saveLlmConfig(LlmConfig config) =>
+      _localDataSource.saveLlmConfig(config);
+
+  @override
+  Future<AppSettings?> getAppSettings() => _localDataSource.getAppSettings();
+
+  @override
+  Future<void> saveAppSettings(AppSettings settings) =>
+      _localDataSource.saveAppSettings(settings);
+
+  @override
+  Future<String> exportData() async {
+    // Mock implementation for FHIR/JSON export
+    return '{"version": "1.0", "data": "FHIR Bundle Mock"}';
+  }
+
+  @override
+  Future<void> importData(String data) async {
+    // Mock implementation for data import
+    return;
+  }
 }

--- a/test/features/health_sharing/application/sharing_cubit_test.dart
+++ b/test/features/health_sharing/application/sharing_cubit_test.dart
@@ -5,21 +5,32 @@ import 'package:orionhealth_health/features/health_sharing/domain/entities/share
 import 'package:orionhealth_health/features/health_sharing/infrastructure/ble_sharing_service.dart';
 import 'package:orionhealth_health/features/health_sharing/infrastructure/nfc_sharing_service.dart';
 import 'package:orionhealth_health/features/health_sharing/infrastructure/wifi_direct_service.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/usecases/start_sharing_usecase.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/usecases/start_listening_usecase.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/usecases/cancel_sharing_usecase.dart';
 
 class MockBleSharingService extends Mock implements BleSharingService {}
 class MockNfcSharingService extends Mock implements NfcSharingService {}
 class MockWifiDirectService extends Mock implements WifiDirectService {}
+
+class MockStartSharingUseCase extends Mock implements StartSharingUseCase {}
+class MockStartListeningUseCase extends Mock implements StartListeningUseCase {}
+class MockCancelSharingUseCase extends Mock implements CancelSharingUseCase {}
 
 class FakeSharedHealthPackage extends Fake implements SharedHealthPackage {}
 
 void main() {
   setUpAll(() {
     registerFallbackValue(FakeSharedHealthPackage());
+    registerFallbackValue(TransferMethod.ble);
   });
 
   late MockBleSharingService mockBleService;
   late MockNfcSharingService mockNfcService;
   late MockWifiDirectService mockWifiService;
+  late MockStartSharingUseCase mockStartSharingUseCase;
+  late MockStartListeningUseCase mockStartListeningUseCase;
+  late MockCancelSharingUseCase mockCancelSharingUseCase;
   late SharingCubit cubit;
 
   final testPackage = SharedHealthPackage(
@@ -46,10 +57,16 @@ void main() {
     mockBleService = MockBleSharingService();
     mockNfcService = MockNfcSharingService();
     mockWifiService = MockWifiDirectService();
+    mockStartSharingUseCase = MockStartSharingUseCase();
+    mockStartListeningUseCase = MockStartListeningUseCase();
+    mockCancelSharingUseCase = MockCancelSharingUseCase();
 
-    when(() => mockBleService.stateStream).thenAnswer((_) => const Stream.empty());
-    when(() => mockNfcService.stateStream).thenAnswer((_) => const Stream.empty());
-    when(() => mockWifiService.stateStream).thenAnswer((_) => const Stream.empty());
+    when(() => mockBleService.stateStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => mockNfcService.stateStream)
+        .thenAnswer((_) => const Stream.empty());
+    when(() => mockWifiService.stateStream)
+        .thenAnswer((_) => const Stream.empty());
 
     when(() => mockBleService.initialize()).thenAnswer((_) async {});
     when(() => mockNfcService.initialize()).thenAnswer((_) async {});
@@ -59,10 +76,22 @@ void main() {
     when(() => mockNfcService.dispose()).thenAnswer((_) => {});
     when(() => mockWifiService.dispose()).thenAnswer((_) => {});
 
+    when(() => mockStartSharingUseCase(
+          method: any(named: 'method'),
+          package: any(named: 'package'),
+          pin: any(named: 'pin'),
+        )).thenAnswer((_) async {});
+    when(() => mockStartListeningUseCase(any(), pin: any(named: 'pin')))
+        .thenAnswer((_) async {});
+    when(() => mockCancelSharingUseCase()).thenAnswer((_) async {});
+
     cubit = SharingCubit(
       bleService: mockBleService,
       nfcService: mockNfcService,
       wifiService: mockWifiService,
+      startSharingUseCase: mockStartSharingUseCase,
+      startListeningUseCase: mockStartListeningUseCase,
+      cancelSharingUseCase: mockCancelSharingUseCase,
     );
   });
 
@@ -85,45 +114,36 @@ void main() {
       verify(() => mockWifiService.initialize()).called(1);
     });
 
-    test('startSharing with NFC calls nfcService.shareData', () async {
-      when(() => mockNfcService.shareData(any())).thenAnswer((_) async => const SharingResult(
-        success: true,
-        bytesTransferred: 100,
-        transferTime: Duration(seconds: 1),
-      ));
-
+    test('startSharing with NFC calls startSharingUseCase', () async {
       await cubit.startSharing(
         method: TransferMethod.nfc,
         package: testPackage,
       );
 
-      verify(() => mockNfcService.shareData(testPackage)).called(1);
+      verify(() => mockStartSharingUseCase(
+            method: TransferMethod.nfc,
+            package: testPackage,
+          )).called(1);
     });
 
-    test('startSharing with BLE calls bleService.startAdvertising', () async {
-      when(() => mockBleService.startAdvertising(any())).thenAnswer((_) async {});
-
+    test('startSharing with BLE calls startSharingUseCase', () async {
       await cubit.startSharing(
         method: TransferMethod.ble,
         package: testPackage,
       );
 
-      verify(() => mockBleService.startAdvertising(testPackage.recipientNodeId)).called(1);
+      verify(() => mockStartSharingUseCase(
+            method: TransferMethod.ble,
+            package: testPackage,
+          )).called(1);
     });
 
-    test('cancelSharing stops all services and emits SharingReady', () async {
-      when(() => mockBleService.disconnect()).thenAnswer((_) async {});
-      when(() => mockBleService.stopAdvertising()).thenAnswer((_) async {});
-      when(() => mockNfcService.stopListening()).thenAnswer((_) async {});
-      when(() => mockWifiService.stop()).thenAnswer((_) async {});
-
+    test('cancelSharing calls cancelSharingUseCase and emits SharingReady',
+        () async {
       await cubit.cancelSharing();
 
-      expect(cubit.state, SharingReady());
-      verify(() => mockBleService.disconnect()).called(1);
-      verify(() => mockBleService.stopAdvertising()).called(1);
-      verify(() => mockNfcService.stopListening()).called(1);
-      verify(() => mockWifiService.stop()).called(1);
+      expect(cubit.state, const SharingReady());
+      verify(() => mockCancelSharingUseCase()).called(1);
     });
   });
 }


### PR DESCRIPTION
This PR fixes analyzer errors and test failures by:
1. Implementing the missing required methods in `LlmSettingsRepositoryImpl` according to its interface. `getAppSettings` and `saveAppSettings` are delegated to the local datasource, while `exportData` and `importData` use stub implementations.
2. Updating `SharingCubit` tests to provide the newly required `UseCase` dependencies in its constructor.
3. Adding a missing `registerFallbackValue` for `TransferMethod` in the sharing cubit tests to fix `mocktail` errors.

Fixes #766

---
*PR created automatically by Jules for task [1981343493842706165](https://jules.google.com/task/1981343493842706165) started by @iberi22*