### PR TITLE
Restore sync barrel files and fix interface inconsistencies

### DIFF
--- a/lib/features/sync/domain/repositories/sync_repository.dart
+++ b/lib/features/sync/domain/repositories/sync_repository.dart
@@ -11,10 +11,19 @@ abstract class SyncRepository {
   /// Gets the timestamp of the last successful synchronization.
   Future<DateTime?> getLastSyncTime();
 
+  /// Updates the timestamp of the last successful synchronization.
+  Future<void> setLastSyncTime(DateTime time);
+
   /// Synchronizes patient profile and clinical data (medications, allergies, vitals, conditions).
   ///
   /// Throws an [Exception] if the token is missing or if the sync fails.
   Future<void> syncAll();
+
+  /// Synchronizes patient profile data.
+  Future<void> syncPatient(String patientId, String token);
+
+  /// Synchronizes RDA clinical data.
+  Future<void> syncRda(String patientId, String token);
 
   /// Synchronizes data only if the last sync was performed more than 6 hours ago.
   ///
@@ -22,5 +31,5 @@ abstract class SyncRepository {
   Future<bool> syncIfStale();
 
   /// Returns a list of discovered nodes in the local network.
-  Future<List<SyncNode>> getDiscoveredNodes();
+  List<SyncNode> getDiscoveredNodes();
 }

--- a/lib/features/sync/domain/sync_repository.dart
+++ b/lib/features/sync/domain/sync_repository.dart
@@ -1,0 +1,2 @@
+export 'repositories/sync_repository.dart';
+export 'entities/sync_node.dart';

--- a/lib/features/sync/domain/sync_service.dart
+++ b/lib/features/sync/domain/sync_service.dart
@@ -1,0 +1,1 @@
+export 'services/sync_service.dart';

--- a/lib/features/sync/infrastructure/repositories/sync_repository.dart
+++ b/lib/features/sync/infrastructure/repositories/sync_repository.dart
@@ -7,7 +7,6 @@ import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:injectable/injectable.dart';
 import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
-import '../../domain/entities/sync_node.dart';
 import '../../domain/sync_repository.dart';
 import '../../../user_profile/domain/entities/user_profile.dart';
 import '../../../medications/domain/entities/medication.dart' as app_med;
@@ -181,12 +180,27 @@ class SyncRepositoryImpl implements SyncRepository {
 
   @override
   List<SyncNode> getDiscoveredNodes() {
-    return _discoveryService.currentNodes.map((node) => SyncNode(
-      id: node.attributes['nodeId'] ?? node.name,
-      name: node.name,
-      host: node.hostname ?? 'unknown',
-      port: node.port,
-    )).toList();
+    return _discoveryService.currentNodes
+        .map((node) => SyncNode(
+              id: node.attributes['nodeId'] ?? node.name,
+              name: node.name,
+              host: node.hostname ?? 'unknown',
+              port: node.port,
+            ))
+        .toList();
+  }
+
+  @override
+  Future<bool> syncIfStale() async {
+    final lastSync = await getLastSyncTime();
+    final now = DateTime.now();
+
+    if (lastSync == null || now.difference(lastSync) > const Duration(hours: 6)) {
+      await syncAll();
+      await setLastSyncTime(now);
+      return true;
+    }
+    return false;
   }
 
   @override

--- a/lib/features/sync/infrastructure/services/sync_service_impl.dart
+++ b/lib/features/sync/infrastructure/services/sync_service_impl.dart
@@ -23,7 +23,7 @@ class SyncServiceImpl implements SyncService {
   }
 
   Future<void> _syncMedicalStandards() async {
-    final peers = await _syncRepository.getDiscoveredNodes();
+    final peers = _syncRepository.getDiscoveredNodes();
 
     if (peers.isNotEmpty) {
       // Try to sync from the first available peer

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -22,7 +22,6 @@ import 'features/local_agent/infrastructure/services/medical_indexing_service.da
 import 'features/onboarding/presentation/pages/onboarding_page.dart';
 import 'features/onboarding/application/onboarding_cubit.dart';
 import 'features/sync/domain/sync_repository.dart';
-import 'features/sync/infrastructure/repositories/sync_repository.dart';
 import 'features/home/presentation/pages/main_navigation_page.dart';
 
 // ─────────────────────────────────────────────

--- a/test/features/sync/domain/repositories/sync_repository_interface_test.dart
+++ b/test/features/sync/domain/repositories/sync_repository_interface_test.dart
@@ -44,12 +44,12 @@ void main() {
       expect(result, isTrue);
     });
 
-    test('getDiscoveredNodes returns list of nodes', () async {
+    test('getDiscoveredNodes returns list of nodes', () {
       final nodes = [
         const SyncNode(id: '1', name: 'Node 1', host: 'localhost', port: 8080),
       ];
-      when(() => mockSyncRepository.getDiscoveredNodes()).thenAnswer((_) async => nodes);
-      final result = await mockSyncRepository.getDiscoveredNodes();
+      when(() => mockSyncRepository.getDiscoveredNodes()).thenReturn(nodes);
+      final result = mockSyncRepository.getDiscoveredNodes();
       expect(result, nodes);
     });
   });

--- a/test/features/sync/domain/repositories/sync_repository_test.dart
+++ b/test/features/sync/domain/repositories/sync_repository_test.dart
@@ -44,10 +44,10 @@ void main() {
       expect(result, isTrue);
     });
 
-    test('getDiscoveredNodes signature verification', () async {
+    test('getDiscoveredNodes signature verification', () {
       final nodes = [const SyncNode(id: '1', name: 'Node 1', host: 'localhost', port: 8080)];
-      when(() => mockSyncRepository.getDiscoveredNodes()).thenAnswer((_) async => nodes);
-      final result = await mockSyncRepository.getDiscoveredNodes();
+      when(() => mockSyncRepository.getDiscoveredNodes()).thenReturn(nodes);
+      final result = mockSyncRepository.getDiscoveredNodes();
       expect(result, nodes);
     });
   });

--- a/test/features/sync/infrastructure/services/sync_service_impl_test.dart
+++ b/test/features/sync/infrastructure/services/sync_service_impl_test.dart
@@ -21,7 +21,7 @@ void main() {
 
   group('SyncServiceImpl', () {
     test('performFullSync performs sync with medical standards fallback to remote', () async {
-      when(() => mockSyncRepository.getDiscoveredNodes()).thenAnswer((_) async => []);
+      when(() => mockSyncRepository.getDiscoveredNodes()).thenReturn([]);
       when(() => mockMedicalStandardsSyncService.syncAll(peerIp: any(named: 'peerIp')))
           .thenAnswer((_) async => <ms.SyncResult>[]);
       when(() => mockSyncRepository.syncAll()).thenAnswer((_) async => {});
@@ -36,7 +36,7 @@ void main() {
       final nodes = [
         const SyncNode(id: '1', name: 'Node 1', host: '192.168.1.1', port: 8080),
       ];
-      when(() => mockSyncRepository.getDiscoveredNodes()).thenAnswer((_) async => nodes);
+      when(() => mockSyncRepository.getDiscoveredNodes()).thenReturn(nodes);
       when(() => mockMedicalStandardsSyncService.syncAll(peerIp: any(named: 'peerIp')))
           .thenAnswer((_) async => <ms.SyncResult>[]);
       when(() => mockSyncRepository.syncAll()).thenAnswer((_) async => {});

--- a/test/features/sync/presentation/pages/sync_page_test.dart
+++ b/test/features/sync/presentation/pages/sync_page_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';


### PR DESCRIPTION
This PR restores the repository-level barrel file `lib/features/sync/domain/sync_repository.dart` and the service-level barrel file `lib/features/sync/domain/sync_service.dart` that were accidentally deleted. 

Additionally, it addresses inconsistencies between the `SyncRepository` domain interface and its infrastructure implementation by:
1. Adding missing methods (`setLastSyncTime`, `syncPatient`, `syncRda`) to the domain interface.
2. Implementing `syncIfStale` in the infrastructure layer.
3. Ensuring `getDiscoveredNodes` remains synchronous as per the original design and code review feedback.
4. Updating all affected tests and service usages.
5. Cleaning up unused imports discovered during analysis.

These changes resolve multiple compilation errors (uri_does_not_exist, undefined_identifier) and restore proper Clean Architecture layering for the sync feature.

Fixes #765

---
*PR created automatically by Jules for task [16516243844292043311](https://jules.google.com/task/16516243844292043311) started by @iberi22*