### PR TITLE
Fix LlmSettingsPage and Meditation test failures and UI warnings

### DIFF
--- a/lib/features/settings/presentation/pages/llm_settings_page.dart
+++ b/lib/features/settings/presentation/pages/llm_settings_page.dart
@@ -1362,93 +1362,116 @@ class _GeneralSettingsTab extends StatelessWidget {
           _SectionHeader(title: l10n.appPreferences, icon: Icons.settings_applications),
           const SizedBox(height: 12),
           GlassmorphicCard(
-            child: Column(
-              children: [
-                _SettingsTile(
-                  icon: Icons.dark_mode,
-                  title: l10n.theme,
-                  subtitle: appSettings.themeMode,
-                  trailing: DropdownButton<String>(
-                    value: appSettings.themeMode,
-                    dropdownColor: AppColors.surfaceVariant,
-                    underline: const SizedBox.shrink(),
-                    items: ['light', 'dark', 'system'].map((m) => DropdownMenuItem(
-                      value: m,
-                      child: Text(m, style: const TextStyle(color: Colors.white, fontSize: 12)),
-                    )).toList(),
-                    onChanged: (v) {
-                      if (v != null) context.read<LlmSettingsCubit>().updateThemeMode(v);
-                    },
+            child: Material(
+              color: Colors.transparent,
+              child: Column(
+                children: [
+                  _SettingsTile(
+                    icon: Icons.dark_mode,
+                    title: l10n.theme,
+                    subtitle: appSettings.themeMode,
+                    trailing: DropdownButton<String>(
+                      value: appSettings.themeMode,
+                      dropdownColor: AppColors.surfaceVariant,
+                      underline: const SizedBox.shrink(),
+                      items: ['light', 'dark', 'system']
+                          .map((m) => DropdownMenuItem(
+                                value: m,
+                                child: Text(m,
+                                    style: const TextStyle(
+                                        color: Colors.white, fontSize: 12)),
+                              ))
+                          .toList(),
+                      onChanged: (v) {
+                        if (v != null) {
+                          context.read<LlmSettingsCubit>().updateThemeMode(v);
+                        }
+                      },
+                    ),
                   ),
-                ),
-                const Divider(color: Colors.white12, height: 1),
-                _SettingsTile(
-                  icon: Icons.language,
-                  title: 'Idioma',
-                  subtitle: appSettings.languageCode,
-                  trailing: DropdownButton<String>(
-                    value: appSettings.languageCode,
-                    dropdownColor: AppColors.surfaceVariant,
-                    underline: const SizedBox.shrink(),
-                    items: ['en', 'es'].map((l) => DropdownMenuItem(
-                      value: l,
-                      child: Text(l.toUpperCase(), style: const TextStyle(color: Colors.white, fontSize: 12)),
-                    )).toList(),
-                    onChanged: (v) {
-                      if (v != null) context.read<LlmSettingsCubit>().updateLanguage(v);
-                    },
+                  const Divider(color: Colors.white12, height: 1),
+                  _SettingsTile(
+                    icon: Icons.language,
+                    title: 'Idioma',
+                    subtitle: appSettings.languageCode,
+                    trailing: DropdownButton<String>(
+                      value: appSettings.languageCode,
+                      dropdownColor: AppColors.surfaceVariant,
+                      underline: const SizedBox.shrink(),
+                      items: ['en', 'es']
+                          .map((l) => DropdownMenuItem(
+                                value: l,
+                                child: Text(l.toUpperCase(),
+                                    style: const TextStyle(
+                                        color: Colors.white, fontSize: 12)),
+                              ))
+                          .toList(),
+                      onChanged: (v) {
+                        if (v != null) {
+                          context.read<LlmSettingsCubit>().updateLanguage(v);
+                        }
+                      },
+                    ),
                   ),
-                ),
-                const Divider(color: Colors.white12, height: 1),
-                SwitchListTile(
-                  secondary: const Icon(Icons.notifications_active, color: AppColors.secondary),
-                  title: Text(l10n.pushNotifications, style: const TextStyle(color: Colors.white, fontSize: 14)),
-                  value: appSettings.notificationsEnabled,
-                  onChanged: (v) => context.read<LlmSettingsCubit>().updateNotificationsEnabled(v),
-                ),
-              ],
+                  const Divider(color: Colors.white12, height: 1),
+                  SwitchListTile(
+                    secondary: const Icon(Icons.notifications_active,
+                        color: AppColors.secondary),
+                    title: Text(l10n.pushNotifications,
+                        style: const TextStyle(
+                            color: Colors.white, fontSize: 14)),
+                    value: appSettings.notificationsEnabled,
+                    onChanged: (v) => context
+                        .read<LlmSettingsCubit>()
+                        .updateNotificationsEnabled(v),
+                  ),
+                ],
+              ),
             ),
           ),
           const SizedBox(height: 24),
           _SectionHeader(title: 'Datos y Privacidad', icon: Icons.security),
           const SizedBox(height: 12),
           GlassmorphicCard(
-            child: Column(
-              children: [
-                ListTile(
-                  leading: const Icon(Icons.file_download, color: AppColors.primary),
-                  title: const Text('Exportar Datos', style: TextStyle(color: Colors.white, fontSize: 14)),
-                  subtitle: const Text('Descargar historial en formato FHIR JSON', style: TextStyle(color: Colors.white54, fontSize: 11)),
-                  onTap: () async {
-                    await context.read<LlmSettingsCubit>().exportData();
-                    if (context.mounted) {
-                      final state = context.read<LlmSettingsCubit>().state;
-                      if (state is LlmSettingsLoaded && state.exportData != null) {
-                        showDialog(
-                          context: context,
-                          builder: (c) => AlertDialog(
-                            backgroundColor: AppColors.surfaceVariant,
-                            title: const Text('Datos Exportados', style: TextStyle(color: Colors.white)),
-                            content: SingleChildScrollView(child: Text(state.exportData!, style: const TextStyle(color: Colors.white70, fontSize: 10))),
-                            actions: [TextButton(onPressed: () => Navigator.pop(c), child: const Text('OK'))],
-                          ),
-                        );
+            child: Material(
+              color: Colors.transparent,
+              child: Column(
+                children: [
+                  ListTile(
+                    leading: const Icon(Icons.file_download, color: AppColors.primary),
+                    title: const Text('Exportar Datos', style: TextStyle(color: Colors.white, fontSize: 14)),
+                    subtitle: const Text('Descargar historial en formato FHIR JSON', style: TextStyle(color: Colors.white54, fontSize: 11)),
+                    onTap: () async {
+                      await context.read<LlmSettingsCubit>().exportData();
+                      if (context.mounted) {
+                        final state = context.read<LlmSettingsCubit>().state;
+                        if (state is LlmSettingsLoaded && state.exportData != null) {
+                          showDialog(
+                            context: context,
+                            builder: (c) => AlertDialog(
+                              backgroundColor: AppColors.surfaceVariant,
+                              title: const Text('Datos Exportados', style: TextStyle(color: Colors.white)),
+                              content: SingleChildScrollView(child: Text(state.exportData!, style: const TextStyle(color: Colors.white70, fontSize: 10))),
+                              actions: [TextButton(onPressed: () => Navigator.pop(c), child: const Text('OK'))],
+                            ),
+                          );
+                        }
                       }
-                    }
-                  },
-                ),
-                const Divider(color: Colors.white12, height: 1),
-                ListTile(
-                  leading: const Icon(Icons.file_upload, color: AppColors.secondary),
-                  title: const Text('Importar Datos', style: TextStyle(color: Colors.white, fontSize: 14)),
-                  subtitle: const Text('Cargar respaldo previo de datos médicos', style: TextStyle(color: Colors.white54, fontSize: 11)),
-                  onTap: () {
-                    // Mock import
-                    context.read<LlmSettingsCubit>().importData('{}');
-                    ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Simulación de importación completada')));
-                  },
-                ),
-              ],
+                    },
+                  ),
+                  const Divider(color: Colors.white12, height: 1),
+                  ListTile(
+                    leading: const Icon(Icons.file_upload, color: AppColors.secondary),
+                    title: const Text('Importar Datos', style: TextStyle(color: Colors.white, fontSize: 14)),
+                    subtitle: const Text('Cargar respaldo previo de datos médicos', style: TextStyle(color: Colors.white54, fontSize: 11)),
+                    onTap: () {
+                      // Mock import
+                      context.read<LlmSettingsCubit>().importData('{}');
+                      ScaffoldMessenger.of(context).showSnackBar(const SnackBar(content: Text('Simulación de importación completada')));
+                    },
+                  ),
+                ],
+              ),
             ),
           ),
         ],
@@ -1489,11 +1512,16 @@ class _SettingsTile extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return ListTile(
-      leading: Icon(icon, color: AppColors.secondary),
-      title: Text(title, style: const TextStyle(color: Colors.white, fontSize: 14)),
-      subtitle: Text(subtitle, style: const TextStyle(color: Colors.white54, fontSize: 12)),
-      trailing: trailing,
+    return Material(
+      color: Colors.transparent,
+      child: ListTile(
+        leading: Icon(icon, color: AppColors.secondary),
+        title: Text(title,
+            style: const TextStyle(color: Colors.white, fontSize: 14)),
+        subtitle: Text(subtitle,
+            style: const TextStyle(color: Colors.white54, fontSize: 12)),
+        trailing: trailing,
+      ),
     );
   }
 }
@@ -1797,8 +1825,10 @@ class _PrivacyToggle extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return SwitchListTile(
-      title: const Text(
+    return Material(
+      color: Colors.transparent,
+      child: SwitchListTile(
+        title: const Text(
         'Permitir llamadas a la nube',
         style: TextStyle(
           color: Colors.white,
@@ -1811,8 +1841,9 @@ class _PrivacyToggle extends StatelessWidget {
       ),
       value: allowCloudApiCalls,
       onChanged: onChanged,
-      activeTrackColor: AppColors.primary.withValues(alpha: 0.5),
-      activeThumbColor: AppColors.primary,
+        activeTrackColor: AppColors.primary.withValues(alpha: 0.5),
+        activeThumbColor: AppColors.primary,
+      ),
     );
   }
 }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1270,10 +1270,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1293,10 +1293,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1946,10 +1946,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/meditation/meditation_screen_test.dart
+++ b/test/features/meditation/meditation_screen_test.dart
@@ -129,7 +129,7 @@ void main() {
   });
 
   testWidgets('MeditationView listener coverage', (tester) async {
-    final controller = StreamController<MeditationState>();
+    final controller = StreamController<MeditationState>.broadcast();
     when(() => mockCubit.stream).thenAnswer((_) => controller.stream);
     when(() => mockCubit.state).thenReturn(const MeditationState(status: MeditationStatus.idle));
 

--- a/test/features/settings/presentation/pages/llm_settings_page_test.dart
+++ b/test/features/settings/presentation/pages/llm_settings_page_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
@@ -8,6 +9,7 @@ import 'package:orionhealth_health/features/settings/domain/entities/app_setting
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
 import 'package:orionhealth_health/features/settings/domain/services/device_capability_service.dart';
 import 'package:orionhealth_health/features/settings/presentation/pages/llm_settings_page.dart';
+import 'package:orionhealth_health/l10n/app_localizations.dart';
 
 class MockLlmSettingsCubit extends Mock implements LlmSettingsCubit {}
 class MockLlmAdapter extends Mock implements LlmAdapter {}
@@ -48,7 +50,12 @@ void main() {
 
   Widget createWidget() {
     return MaterialApp(
-      home: const LlmSettingsPage(),
+      localizationsDelegates: AppLocalizations.localizationsDelegates,
+      supportedLocales: AppLocalizations.supportedLocales,
+      home: BlocProvider<LlmSettingsCubit>.value(
+        value: mockCubit,
+        child: const LlmSettingsPage(),
+      ),
     );
   }
 

--- a/test/features/settings/presentation/pages/settings_page_golden_test.dart
+++ b/test/features/settings/presentation/pages/settings_page_golden_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';
@@ -52,6 +53,7 @@ void main() {
     ));
     when(() => mockCubit.loadSettings()).thenAnswer((_) async {});
     when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockCubit.close()).thenAnswer((_) async {});
   });
 
   testWidgets('Settings Page - Local Tab Golden', (WidgetTester tester) async {
@@ -64,7 +66,10 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         locale: const Locale('es'),
-        home: const LlmSettingsPage(),
+        home: BlocProvider<LlmSettingsCubit>.value(
+          value: mockCubit,
+          child: const LlmSettingsPage(),
+        ),
       ),
     );
 
@@ -91,7 +96,10 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         locale: const Locale('es'),
-        home: const LlmSettingsPage(),
+        home: BlocProvider<LlmSettingsCubit>.value(
+          value: mockCubit,
+          child: const LlmSettingsPage(),
+        ),
       ),
     );
 
@@ -122,7 +130,10 @@ void main() {
         localizationsDelegates: AppLocalizations.localizationsDelegates,
         supportedLocales: AppLocalizations.supportedLocales,
         locale: const Locale('es'),
-        home: const LlmSettingsPage(),
+        home: BlocProvider<LlmSettingsCubit>.value(
+          value: mockCubit,
+          child: const LlmSettingsPage(),
+        ),
       ),
     );
 


### PR DESCRIPTION
This PR addresses several test failures and UI warnings:
1. Resolved "Null check operator used on a null value" in `LlmSettingsPage` tests by providing necessary `AppLocalizations` delegates and correctly injecting the `LlmSettingsCubit` using `BlocProvider`.
2. Fixed "Null is not a subtype of Future" error when closing `MockLlmSettingsCubit` by stubbing the `close()` method.
3. Fixed "Stream has already been listened to" error in meditation widget tests by utilizing a broadcast `StreamController` for the mocked cubit's stream.
4. Resolved Flutter warnings regarding `ListTile` background color and ink splashes by wrapping them in `Material` widgets with transparent backgrounds when nested inside `DecoratedBox`-based containers (`GlassmorphicCard`).
5. Generated localization files to fix compilation errors in tests that rely on `AppLocalizations`.
6. Improved code formatting and indentation in `LlmSettingsPage`.

Fixes #774

---
*PR created automatically by Jules for task [13615438382214823468](https://jules.google.com/task/13615438382214823468) started by @iberi22*