### PR TITLE
Fix missing cubit providers in remaining widget/golden tests

### DIFF
--- a/test/features/allergies/presentation/pages/allergies_page_golden_test.dart
+++ b/test/features/allergies/presentation/pages/allergies_page_golden_test.dart
@@ -26,10 +26,12 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: BlocProvider.value(
-        value: mockAllergiesCubit,
-        child: const AllergiesPage(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AllergiesCubit>.value(value: mockAllergiesCubit),
+      ],
+      child: const MaterialApp(
+        home: AllergiesPage(),
       ),
     );
   }

--- a/test/features/eps_connection/presentation/eps_connect_button_test.dart
+++ b/test/features/eps_connection/presentation/eps_connect_button_test.dart
@@ -20,11 +20,13 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: Scaffold(
-        body: BlocProvider<EpsConnectionCubit>.value(
-          value: mockCubit,
-          child: const EpsConnectButton(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<EpsConnectionCubit>.value(value: mockCubit),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: EpsConnectButton(),
         ),
       ),
     );

--- a/test/features/eps_connection/presentation/pages/eps_connection_page_golden_test.dart
+++ b/test/features/eps_connection/presentation/pages/eps_connection_page_golden_test.dart
@@ -29,10 +29,12 @@ void main() {
     when(() => mockCubit.stream).thenAnswer((_) => Stream.value(EpsConnectionLoaded([connection])));
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: BlocProvider<EpsConnectionCubit>.value(
-          value: mockCubit,
-          child: const EpsConnectionPage(),
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<EpsConnectionCubit>.value(value: mockCubit),
+        ],
+        child: const MaterialApp(
+          home: EpsConnectionPage(),
         ),
       ),
     );

--- a/test/features/eps_connection/presentation/pages/eps_connection_page_test.dart
+++ b/test/features/eps_connection/presentation/pages/eps_connection_page_test.dart
@@ -19,10 +19,12 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: BlocProvider<EpsConnectionCubit>.value(
-        value: mockCubit,
-        child: const EpsConnectionPage(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<EpsConnectionCubit>.value(value: mockCubit),
+      ],
+      child: const MaterialApp(
+        home: EpsConnectionPage(),
       ),
     );
   }

--- a/test/features/health_data_import/presentation/pages/health_import_golden_test.dart
+++ b/test/features/health_data_import/presentation/pages/health_import_golden_test.dart
@@ -19,11 +19,11 @@ void main() {
   });
 
   Widget buildTestWidget(HealthImportCubit cubit) {
-    return wrapWithMaterial(
-      BlocProvider<HealthImportCubit>.value(
-        value: cubit,
-        child: const HealthImportPage(),
-      ),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<HealthImportCubit>.value(value: cubit),
+      ],
+      child: wrapWithMaterial(const HealthImportPage()),
     );
   }
 

--- a/test/features/home/presentation/pages/home_page_test.dart
+++ b/test/features/home/presentation/pages/home_page_test.dart
@@ -4,12 +4,17 @@ import 'package:mocktail/mocktail.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:orionhealth_health/features/home/application/home_cubit.dart';
 import 'package:orionhealth_health/features/home/application/home_state.dart';
+import 'package:orionhealth_health/features/dashboard/application/dashboard_cubit.dart';
+import 'package:orionhealth_health/features/dashboard/application/dashboard_state.dart';
 import 'package:orionhealth_health/features/home/presentation/pages/home_page.dart';
 
 class MockHomeCubit extends Mock implements HomeCubit {}
 
+class MockDashboardCubit extends Mock implements DashboardCubit {}
+
 void main() {
   late MockHomeCubit mockHomeCubit;
+  late MockDashboardCubit mockDashboardCubit;
 
   setUp(() {
     mockHomeCubit = MockHomeCubit();
@@ -18,13 +23,21 @@ void main() {
     when(() => mockHomeCubit.refresh()).thenAnswer((_) async {});
     when(() => mockHomeCubit.stream).thenAnswer((_) => const Stream.empty());
     when(() => mockHomeCubit.close()).thenAnswer((_) async {});
+
+    mockDashboardCubit = MockDashboardCubit();
+    when(() => mockDashboardCubit.state).thenReturn(const DashboardInitial());
+    when(() => mockDashboardCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockDashboardCubit.close()).thenAnswer((_) async {});
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: BlocProvider<HomeCubit>.value(
-        value: mockHomeCubit,
-        child: const Scaffold(body: HomePageView()),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<HomeCubit>.value(value: mockHomeCubit),
+        BlocProvider<DashboardCubit>.value(value: mockDashboardCubit),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(body: HomePageView()),
       ),
     );
   }

--- a/test/features/home/presentation/pages/home_sections_golden_test.dart
+++ b/test/features/home/presentation/pages/home_sections_golden_test.dart
@@ -7,21 +7,32 @@ import 'package:orionhealth_health/features/home/presentation/widgets/health_sta
 import 'package:orionhealth_health/features/dashboard/presentation/pages/home_dashboard_page.dart';
 import 'package:orionhealth_health/features/home/application/home_cubit.dart';
 import 'package:orionhealth_health/features/home/application/home_state.dart';
+import 'package:orionhealth_health/features/dashboard/application/dashboard_cubit.dart';
+import 'package:orionhealth_health/features/dashboard/application/dashboard_state.dart';
 import 'package:orionhealth_health/core/theme/app_theme.dart';
 import 'package:orionhealth_health/l10n/app_localizations.dart';
 import 'package:google_fonts/google_fonts.dart';
 
 class MockHomeCubit extends Mock implements HomeCubit {}
 
+class MockDashboardCubit extends Mock implements DashboardCubit {}
+
 void main() {
   GoogleFonts.config.allowRuntimeFetching = false;
   late MockHomeCubit mockHomeCubit;
+  late MockDashboardCubit mockDashboardCubit;
 
   setUp(() {
     mockHomeCubit = MockHomeCubit();
     when(() => mockHomeCubit.state).thenReturn(const HomeState());
     when(() => mockHomeCubit.stream).thenAnswer((_) => const Stream.empty());
     when(() => mockHomeCubit.close()).thenAnswer((_) async {});
+
+    mockDashboardCubit = MockDashboardCubit();
+    when(() => mockDashboardCubit.state).thenReturn(const DashboardInitial());
+    when(() => mockDashboardCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockDashboardCubit.loadDashboardData()).thenAnswer((_) async {});
+    when(() => mockDashboardCubit.close()).thenAnswer((_) async {});
   });
 
   group('Home Sections Golden Tests', () {
@@ -30,15 +41,17 @@ void main() {
       tester.view.devicePixelRatio = 1.0;
 
       await tester.pumpWidget(
-        MaterialApp(
-          theme: AppTheme.darkTheme,
-          localizationsDelegates: AppLocalizations.localizationsDelegates,
-          supportedLocales: AppLocalizations.supportedLocales,
-          locale: const Locale('en'),
-          home: Scaffold(
-            body: BlocProvider<HomeCubit>.value(
-              value: mockHomeCubit,
-              child: const SingleChildScrollView(
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<HomeCubit>.value(value: mockHomeCubit),
+        ],
+          child: MaterialApp(
+            theme: AppTheme.darkTheme,
+            localizationsDelegates: AppLocalizations.localizationsDelegates,
+            supportedLocales: AppLocalizations.supportedLocales,
+            locale: const Locale('en'),
+            home: const Scaffold(
+              body: SingleChildScrollView(
                 child: HealthStatusGrid(),
               ),
             ),
@@ -64,10 +77,15 @@ void main() {
       tester.view.devicePixelRatio = 1.0;
 
       await tester.pumpWidget(
-        const MaterialApp(
-          themeMode: ThemeMode.dark,
-          home: Scaffold(
-            body: HomeDashboardPage(),
+        MultiBlocProvider(
+          providers: [
+            BlocProvider<DashboardCubit>.value(value: mockDashboardCubit),
+          ],
+          child: const MaterialApp(
+            themeMode: ThemeMode.dark,
+            home: Scaffold(
+              body: HomeDashboardPage(),
+            ),
           ),
         ),
       );

--- a/test/features/home/presentation/widgets/health_status_grid_test.dart
+++ b/test/features/home/presentation/widgets/health_status_grid_test.dart
@@ -19,11 +19,11 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: Scaffold(
-        body: BlocProvider<HomeCubit>.value(
-          value: mockHomeCubit,
-          child: const HealthStatusGrid(),
+    return BlocProvider<HomeCubit>.value(
+      value: mockHomeCubit,
+      child: const MaterialApp(
+        home: Scaffold(
+          body: HealthStatusGrid(),
         ),
       ),
     );

--- a/test/features/medical_research/presentation/widgets/interaction_checker_widget_test.dart
+++ b/test/features/medical_research/presentation/widgets/interaction_checker_widget_test.dart
@@ -8,11 +8,13 @@ import 'package:orionhealth_health/features/medical_research/presentation/widget
 class MockMedicalResearchCubit extends Mock implements MedicalResearchCubit {}
 
 Widget createTestWidget(MedicalResearchCubit cubit) {
-  return MaterialApp(
-    home: Scaffold(
-      body: BlocProvider<MedicalResearchCubit>.value(
-        value: cubit,
-        child: const InteractionCheckerWidget(),
+  return MultiBlocProvider(
+    providers: [
+      BlocProvider<MedicalResearchCubit>.value(value: cubit),
+    ],
+    child: const MaterialApp(
+      home: Scaffold(
+        body: InteractionCheckerWidget(),
       ),
     ),
   );

--- a/test/features/meditation/presentation/golden/meditation_golden_test.dart
+++ b/test/features/meditation/presentation/golden/meditation_golden_test.dart
@@ -38,11 +38,13 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
 
     await tester.pumpWidget(
-      MaterialApp(
-        theme: AppTheme.darkTheme,
-        home: BlocProvider<MeditationCubit>.value(
-          value: mockCubit,
-          child: const MeditationView(),
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<MeditationCubit>.value(value: mockCubit),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.darkTheme,
+          home: const MeditationView(),
         ),
       ),
     );
@@ -76,11 +78,13 @@ void main() {
     tester.view.devicePixelRatio = 1.0;
 
     await tester.pumpWidget(
-      MaterialApp(
-        theme: AppTheme.darkTheme,
-        home: BlocProvider<MeditationCubit>.value(
-          value: mockCubit,
-          child: const MeditationView(),
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<MeditationCubit>.value(value: mockCubit),
+        ],
+        child: MaterialApp(
+          theme: AppTheme.darkTheme,
+          home: const MeditationView(),
         ),
       ),
     );

--- a/test/features/network/governance/presentation/governance_page_test.dart
+++ b/test/features/network/governance/presentation/governance_page_test.dart
@@ -21,10 +21,12 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: BlocProvider<GovernanceCubit>.value(
-        value: mockCubit,
-        child: const GovernancePage(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<GovernanceCubit>.value(value: mockCubit),
+      ],
+      child: const MaterialApp(
+        home: GovernancePage(),
       ),
     );
   }

--- a/test/features/network/incentives/presentation/pages/rewards_page_test.dart
+++ b/test/features/network/incentives/presentation/pages/rewards_page_test.dart
@@ -20,10 +20,12 @@ void main() {
 
   testWidgets('RewardsPage displays empty message when no rewards', (WidgetTester tester) async {
     await tester.pumpWidget(
-      MaterialApp(
-        home: BlocProvider<IncentiveCubit>.value(
-          value: mockCubit,
-          child: const RewardsPage(),
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<IncentiveCubit>.value(value: mockCubit),
+        ],
+        child: const MaterialApp(
+          home: RewardsPage(),
         ),
       ),
     );
@@ -40,10 +42,12 @@ void main() {
     when(() => mockCubit.state).thenReturn(const IncentiveState(rewards: rewards));
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: BlocProvider<IncentiveCubit>.value(
-          value: mockCubit,
-          child: const RewardsPage(),
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<IncentiveCubit>.value(value: mockCubit),
+        ],
+        child: const MaterialApp(
+          home: RewardsPage(),
         ),
       ),
     );
@@ -62,10 +66,12 @@ void main() {
     when(() => mockCubit.claimReward(any(), any())).thenAnswer((_) async {});
 
     await tester.pumpWidget(
-      MaterialApp(
-        home: BlocProvider<IncentiveCubit>.value(
-          value: mockCubit,
-          child: const RewardsPage(),
+      MultiBlocProvider(
+        providers: [
+          BlocProvider<IncentiveCubit>.value(value: mockCubit),
+        ],
+        child: const MaterialApp(
+          home: RewardsPage(),
         ),
       ),
     );

--- a/test/features/voice_chat/presentation/widgets/voice_input_button_test.dart
+++ b/test/features/voice_chat/presentation/widgets/voice_input_button_test.dart
@@ -19,11 +19,13 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: Scaffold(
-        body: BlocProvider<VoiceChatCubit>.value(
-          value: mockCubit,
-          child: const VoiceInputButton(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<VoiceChatCubit>.value(value: mockCubit),
+      ],
+      child: const MaterialApp(
+        home: Scaffold(
+          body: VoiceInputButton(),
         ),
       ),
     );


### PR DESCRIPTION
Standardized multiple widget and golden tests by providing missing Cubits/Blocs. Used MultiBlocProvider and moved it above the MaterialApp root to ensure that navigated pages (e.g., EpsConnectionPage from EpsConnectButton) have access to the required state. Specifically addressed the missing DashboardCubit in home-related tests.

Fixes #780

---
*PR created automatically by Jules for task [3576499544947357524](https://jules.google.com/task/3576499544947357524) started by @iberi22*