### PR TITLE
Add BlocProvider in auth widget tests

### DIFF
--- a/test/features/auth/presentation/login_page_test.dart
+++ b/test/features/auth/presentation/login_page_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/auth/application/bloc/auth_cubit.dart';
 import 'package:orionhealth_health/features/auth/application/bloc/auth_state.dart';
 import 'package:orionhealth_health/features/auth/presentation/login_page.dart';
+import 'package:orionhealth_health/l10n/app_localizations.dart';
 
 class MockAuthCubit extends Mock implements AuthCubit {}
 
@@ -20,10 +21,14 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: BlocProvider<AuthCubit>.value(
-        value: mockCubit,
-        child: const LoginPage(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthCubit>.value(value: mockCubit),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: LoginPage(),
       ),
     );
   }

--- a/test/features/auth/presentation/pages/login_page_test.dart
+++ b/test/features/auth/presentation/pages/login_page_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/auth/application/auth_cubit.dart';
 import 'package:orionhealth_health/features/auth/application/auth_state.dart';
 import 'package:orionhealth_health/features/auth/presentation/pages/login_page.dart';
+import 'package:orionhealth_health/l10n/app_localizations.dart';
 
 class MockAuthCubit extends Mock implements AuthCubit {}
 
@@ -19,10 +20,14 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: BlocProvider<AuthCubit>.value(
-        value: mockAuthCubit,
-        child: const LoginPage(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthCubit>.value(value: mockAuthCubit),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: LoginPage(),
       ),
     );
   }

--- a/test/features/auth/presentation/setup_pin_page_test.dart
+++ b/test/features/auth/presentation/setup_pin_page_test.dart
@@ -5,6 +5,7 @@ import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/auth/application/bloc/auth_cubit.dart';
 import 'package:orionhealth_health/features/auth/application/bloc/auth_state.dart';
 import 'package:orionhealth_health/features/auth/presentation/setup_pin_page.dart';
+import 'package:orionhealth_health/l10n/app_localizations.dart';
 
 class MockAuthCubit extends Mock implements AuthCubit {}
 
@@ -19,10 +20,14 @@ void main() {
   });
 
   Widget createWidgetUnderTest() {
-    return MaterialApp(
-      home: BlocProvider<AuthCubit>.value(
-        value: mockCubit,
-        child: const SetupPinPage(),
+    return MultiBlocProvider(
+      providers: [
+        BlocProvider<AuthCubit>.value(value: mockCubit),
+      ],
+      child: const MaterialApp(
+        localizationsDelegates: AppLocalizations.localizationsDelegates,
+        supportedLocales: AppLocalizations.supportedLocales,
+        home: SetupPinPage(),
       ),
     );
   }


### PR DESCRIPTION
I have fixed the authentication widget tests by wrapping the `MaterialApp` with a `MultiBlocProvider` that provides the `AuthCubit` (which is the actual implementation used in the codebase, as no `AuthBloc` exists). I also added the necessary `AppLocalizations` delegates to the `MaterialApp` in these tests to ensure they have access to localized strings, following the successful pattern found in the project's golden tests.

Tests for `LoginPage` and `SetupPinPage` were verified to pass after these changes. Unintentional changes to `pubspec.lock` were reverted before submission.

Fixes #778

---
*PR created automatically by Jules for task [12784868249844140215](https://jules.google.com/task/12784868249844140215) started by @iberi22*