### PR TITLE
test: move registerFallbackValue to setUpAll in various features

### DIFF
--- a/test/features/eps_connection/infrastructure/oauth_repository_test.dart
+++ b/test/features/eps_connection/infrastructure/oauth_repository_test.dart
@@ -29,6 +29,7 @@ void main() {
   setUpAll(() {
     registerFallbackValue(FakeAuthorizationTokenRequest());
     registerFallbackValue(FakeTokenRequest());
+    registerFallbackValue(<String, dynamic>{});
   });
 
   setUp(() {

--- a/test/features/health_data_import/application/health_import_cubit_test.dart
+++ b/test/features/health_data_import/application/health_import_cubit_test.dart
@@ -15,11 +15,14 @@ void main() {
   late MockHealthDataImportService mockImportService;
   late MockVitalSignRepository mockVitalSignRepository;
 
+  setUpAll(() {
+    registerFallbackValue(HealthDataSource.googleFit);
+  });
+
   setUp(() {
     mockImportService = MockHealthDataImportService();
     mockVitalSignRepository = MockVitalSignRepository();
     cubit = HealthImportCubit(mockImportService, mockVitalSignRepository);
-    registerFallbackValue(HealthDataSource.googleFit);
   });
 
   tearDown(() {

--- a/test/features/local_agent/application/use_cases/smart_search_use_case_test.dart
+++ b/test/features/local_agent/application/use_cases/smart_search_use_case_test.dart
@@ -9,12 +9,14 @@ void main() {
   late MockVectorStoreService mockVectorStore;
   late SmartSearchUseCase useCase;
 
+  setUpAll(() {
+    registerFallbackValue('bm25');
+    registerFallbackValue(5);
+  });
+
   setUp(() {
     mockVectorStore = MockVectorStoreService();
     useCase = SmartSearchUseCase(mockVectorStore);
-
-    registerFallbackValue('bm25');
-    registerFallbackValue(5);
   });
 
   group('SmartSearchUseCase', () {

--- a/test/features/local_agent/infrastructure/gemma_llm_service_test.dart
+++ b/test/features/local_agent/infrastructure/gemma_llm_service_test.dart
@@ -17,6 +17,10 @@ void main() {
   late MockLlmAdapter mockAdapter;
   late GemmaLlmService service;
 
+  setUpAll(() {
+    registerFallbackValue('test-query');
+  });
+
   setUp(() {
     mockVectorStore = MockVectorStoreService();
     mockUserProfileRepo = MockUserProfileRepository();
@@ -27,8 +31,6 @@ void main() {
       mockUserProfileRepo,
       mockAdapter,
     );
-
-    registerFallbackValue('test-query');
   });
 
   group('GemmaLlmService', () {

--- a/test/features/local_agent/infrastructure/rag_llm_service_test.dart
+++ b/test/features/local_agent/infrastructure/rag_llm_service_test.dart
@@ -21,6 +21,10 @@ void main() {
   late MockLlmAdapter mockAdapter;
   late RagLlmService service;
 
+  setUpAll(() {
+    registerFallbackValue('test-query');
+  });
+
   setUp(() {
     mockVectorStore = MockVectorStoreService();
     mockResearch = MockMedicalResearchService();
@@ -33,8 +37,6 @@ void main() {
       mockUserProfileRepo,
       mockAdapter,
     );
-
-    registerFallbackValue('test-query');
 
     // Default stub for performResearch to return empty list
     when(() => mockResearch.performResearch(any()))

--- a/test/features/local_agent/infrastructure/services/isar_vector_store_service_test.dart
+++ b/test/features/local_agent/infrastructure/services/isar_vector_store_service_test.dart
@@ -20,14 +20,16 @@ void main() {
   late MockMedicalKnowledgeRepository mockMedicalRepo;
   late IsarVectorStoreService service;
 
+  setUpAll(() {
+    registerFallbackValue('test-query');
+    registerFallbackValue(<String, dynamic>{});
+  });
+
   setUp(() {
     mockMemoryGraph = MockMemoryGraph();
     mockMedicalRepo = MockMedicalKnowledgeRepository();
 
     service = IsarVectorStoreService(mockMemoryGraph, mockMedicalRepo);
-
-    registerFallbackValue('test-query');
-    registerFallbackValue(<String, dynamic>{});
   });
 
   group('IsarVectorStoreService', () {

--- a/test/features/local_agent/infrastructure/services/medical_indexing_service_test.dart
+++ b/test/features/local_agent/infrastructure/services/medical_indexing_service_test.dart
@@ -17,6 +17,12 @@ void main() {
   late MockPatientContextIndexer mockPatientIndexer;
   late MedicalIndexingService indexingService;
 
+  setUpAll(() {
+    registerFallbackValue('test-id');
+    registerFallbackValue('test-content');
+    registerFallbackValue(<String, dynamic>{});
+  });
+
   setUp(() {
     mockKnowledgeRepo = MockMedicalKnowledgeRepository();
     mockVectorStore = MockVectorStoreService();
@@ -27,10 +33,6 @@ void main() {
       mockVectorStore,
       mockPatientIndexer,
     );
-
-    registerFallbackValue('test-id');
-    registerFallbackValue('test-content');
-    registerFallbackValue(<String, dynamic>{});
   });
 
   group('MedicalIndexingService', () {


### PR DESCRIPTION
This PR updates several test suites to follow Mocktail best practices by moving `registerFallbackValue` calls from `setUp` to `setUpAll`. This prevents redundant registrations and potential "already registered" errors.

Changes:
- Reorganized `setUp` and `setUpAll` in `health_import_cubit_test.dart`, `smart_search_use_case_test.dart`, `gemma_llm_service_test.dart`, `rag_llm_service_test.dart`, `isar_vector_store_service_test.dart`, and `medical_indexing_service_test.dart`.
- Added a missing `Map<String, dynamic>` fallback to `oauth_repository_test.dart`.
- Verified that all other files listed in the task already correctly utilized `setUpAll` for fallback registration.
- Confirmed all tests pass successfully.

Fixes #788

---
*PR created automatically by Jules for task [6697121723099151163](https://jules.google.com/task/6697121723099151163) started by @iberi22*