### PR TITLE
Fix registerFallbackValue for appointments and calendar_import tests

### DIFF
--- a/test/features/appointments/application/appointments_cubit_test.dart
+++ b/test/features/appointments/application/appointments_cubit_test.dart
@@ -12,6 +12,8 @@ class FakeAppointment extends Fake implements Appointment {}
 void main() {
   setUpAll(() {
     registerFallbackValue(FakeAppointment());
+    registerFallbackValue(<Appointment>[]);
+    registerFallbackValue(AppointmentStatus.upcoming);
   });
   late MockAppointmentRepository repository;
   late AppointmentsCubit cubit;

--- a/test/features/appointments/domain/usecases/save_appointment_usecase_test.dart
+++ b/test/features/appointments/domain/usecases/save_appointment_usecase_test.dart
@@ -11,6 +11,8 @@ class AppointmentFake extends Fake implements Appointment {}
 void main() {
   setUpAll(() {
     registerFallbackValue(AppointmentFake());
+    registerFallbackValue(<Appointment>[]);
+    registerFallbackValue(AppointmentStatus.upcoming);
   });
 
   late SaveAppointmentUseCase useCase;

--- a/test/features/appointments/infrastructure/repositories/isar_appointment_repository_mock_test.dart
+++ b/test/features/appointments/infrastructure/repositories/isar_appointment_repository_mock_test.dart
@@ -23,6 +23,8 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(FakeAppointment());
+    registerFallbackValue(<Appointment>[]);
+    registerFallbackValue(AppointmentStatus.upcoming);
   });
 
   setUp(() {

--- a/test/features/appointments/presentation/pages/appointments_page_test.dart
+++ b/test/features/appointments/presentation/pages/appointments_page_test.dart
@@ -27,6 +27,8 @@ void main() {
   setUpAll(() {
     initializeDateFormatting('es', null);
     registerFallbackValue(FakeAppointment());
+    registerFallbackValue(<Appointment>[]);
+    registerFallbackValue(AppointmentStatus.upcoming);
   });
 
   setUp(() async {

--- a/test/features/calendar_import/application/calendar_import_cubit_test.dart
+++ b/test/features/calendar_import/application/calendar_import_cubit_test.dart
@@ -27,6 +27,10 @@ void main() {
     registerFallbackValue(
       CalendarEvent(title: 'test', startDateTime: DateTime.now()),
     );
+    registerFallbackValue(<Appointment>[]);
+    registerFallbackValue(<CalendarEvent>[]);
+    registerFallbackValue(AppointmentStatus.upcoming);
+    registerFallbackValue(CalendarEventSource.unknown);
   });
 
   late CalendarImportCubit cubit;

--- a/test/features/calendar_import/domain/usecases/import_calendar_usecase_test.dart
+++ b/test/features/calendar_import/domain/usecases/import_calendar_usecase_test.dart
@@ -28,6 +28,10 @@ void main() {
         startDateTime: DateTime.now(),
       ),
     );
+    registerFallbackValue(<Appointment>[]);
+    registerFallbackValue(<CalendarEvent>[]);
+    registerFallbackValue(AppointmentStatus.upcoming);
+    registerFallbackValue(CalendarEventSource.unknown);
   });
 
   late MockCalendarRepo mockCalendarRepo;

--- a/test/features/calendar_import/presentation/pages/calendar_import_golden_test.dart
+++ b/test/features/calendar_import/presentation/pages/calendar_import_golden_test.dart
@@ -16,12 +16,6 @@ void main() {
 
   setUpAll(() {
     getIt.allowReassignment = true;
-  });
-
-  setUp(() {
-    mockCubit = MockCalendarImportCubit();
-    getIt.registerSingleton<CalendarImportCubit>(mockCubit);
-
     registerFallbackValue(
       Appointment(
         doctorName: '',
@@ -36,6 +30,15 @@ void main() {
         startDateTime: DateTime.now(),
       ),
     );
+    registerFallbackValue(<Appointment>[]);
+    registerFallbackValue(<CalendarEvent>[]);
+    registerFallbackValue(AppointmentStatus.upcoming);
+    registerFallbackValue(CalendarEventSource.unknown);
+  });
+
+  setUp(() {
+    mockCubit = MockCalendarImportCubit();
+    getIt.registerSingleton<CalendarImportCubit>(mockCubit);
   });
 
   Widget buildTestWidget(CalendarImportCubit cubit) {

--- a/test/features/calendar_import/presentation/pages/calendar_import_page_test.dart
+++ b/test/features/calendar_import/presentation/pages/calendar_import_page_test.dart
@@ -27,6 +27,8 @@ void main() {
       ),
     );
     registerFallbackValue(FakeRoute());
+    registerFallbackValue(<Appointment>[]);
+    registerFallbackValue(AppointmentStatus.upcoming);
   });
 
   setUp(() {


### PR DESCRIPTION
This PR ensures that all mocktail `registerFallbackValue` calls are correctly placed in `setUpAll` and cover all necessary types, including lists and enums, for the appointments and calendar_import features. This prevents potential 'registration not found' errors when using `any()` in tests.

Fixes #786

---
*PR created automatically by Jules for task [3585081776142565523](https://jules.google.com/task/3585081776142565523) started by @iberi22*