### PR TITLE
fix: registerFallbackValue for vitals and user_profile tests

### DIFF
--- a/test/features/user_profile/application/bloc/user_profile_cubit_test.dart
+++ b/test/features/user_profile/application/bloc/user_profile_cubit_test.dart
@@ -6,11 +6,11 @@ import 'package:orionhealth_health/features/user_profile/domain/repositories/use
 
 class MockUserProfileRepository extends Mock implements UserProfileRepository {}
 
-class UserProfileFake extends Fake implements UserProfile {}
+class FakeUserProfile extends Fake implements UserProfile {}
 
 void main() {
   setUpAll(() {
-    registerFallbackValue(UserProfileFake());
+    registerFallbackValue(FakeUserProfile());
   });
 
   late UserProfileCubit cubit;

--- a/test/features/user_profile/data/repositories/user_profile_repository_impl_test.dart
+++ b/test/features/user_profile/data/repositories/user_profile_repository_impl_test.dart
@@ -6,14 +6,14 @@ import 'package:orionhealth_health/features/user_profile/domain/entities/user_pr
 
 class MockUserProfileLocalDataSource extends Mock implements UserProfileLocalDataSource {}
 
-class UserProfileFake extends Fake implements UserProfile {}
+class FakeUserProfile extends Fake implements UserProfile {}
 
 void main() {
   late MockUserProfileLocalDataSource mockDataSource;
   late UserProfileRepositoryImpl repository;
 
   setUpAll(() {
-    registerFallbackValue(UserProfileFake());
+    registerFallbackValue(FakeUserProfile());
   });
 
   setUp(() {

--- a/test/features/user_profile/domain/services/user_profile_service_test.dart
+++ b/test/features/user_profile/domain/services/user_profile_service_test.dart
@@ -6,12 +6,14 @@ import 'package:orionhealth_health/features/user_profile/domain/services/user_pr
 
 class MockUserProfileRepository extends Mock implements UserProfileRepository {}
 
+class FakeUserProfile extends Fake implements UserProfile {}
+
 void main() {
   late MockUserProfileRepository mockRepository;
   late UserProfileService service;
 
   setUpAll(() {
-    registerFallbackValue(UserProfile());
+    registerFallbackValue(FakeUserProfile());
   });
 
   setUp(() {

--- a/test/features/user_profile/presentation/pages/user_profile_page_test.dart
+++ b/test/features/user_profile/presentation/pages/user_profile_page_test.dart
@@ -11,13 +11,13 @@ import 'package:flutter_localizations/flutter_localizations.dart';
 
 class MockUserProfileCubit extends Mock implements UserProfileCubit {}
 
-class UserProfileFake extends Fake implements UserProfile {}
+class FakeUserProfile extends Fake implements UserProfile {}
 
 void main() {
   late MockUserProfileCubit mockCubit;
 
   setUpAll(() {
-    registerFallbackValue(UserProfileFake());
+    registerFallbackValue(FakeUserProfile());
   });
 
   setUp(() {

--- a/test/features/vitals/application/vitals_cubit_test.dart
+++ b/test/features/vitals/application/vitals_cubit_test.dart
@@ -12,6 +12,7 @@ class FakeVitalSign extends Fake implements VitalSign {}
 void main() {
   setUpAll(() {
     registerFallbackValue(FakeVitalSign());
+    registerFallbackValue(const <VitalSign>[]);
   });
   late MockVitalSignRepository repository;
   late VitalsCubit cubit;

--- a/test/features/vitals/infrastructure/repositories/vital_sign_repository_impl_mock_test.dart
+++ b/test/features/vitals/infrastructure/repositories/vital_sign_repository_impl_mock_test.dart
@@ -23,6 +23,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(FakeVitalSign());
+    registerFallbackValue(const <VitalSign>[]);
   });
 
   setUp(() {

--- a/test/features/vitals/infrastructure/repositories/vital_sign_repository_impl_test.dart
+++ b/test/features/vitals/infrastructure/repositories/vital_sign_repository_impl_test.dart
@@ -23,6 +23,7 @@ void main() {
 
   setUpAll(() {
     registerFallbackValue(FakeVitalSign());
+    registerFallbackValue(const <VitalSign>[]);
   });
 
   setUp(() {


### PR DESCRIPTION
Fixes mocktail's registerFallbackValue requirements in several test files within the vitals and user_profile features. Adds missing registrations for List<VitalSign> where used with any() and unifies the fake user profile naming to FakeUserProfile for better consistency.

Fixes #785

---
*PR created automatically by Jules for task [12020259673478609948](https://jules.google.com/task/12020259673478609948) started by @iberi22*