### PR TITLE
Complete FHIR Mapper and RDA Parser logic

### DIFF
--- a/lib/features/sync/infrastructure/services/fhir_mapper.dart
+++ b/lib/features/sync/infrastructure/services/fhir_mapper.dart
@@ -39,29 +39,44 @@ class FhirMapper {
     final names = json['name'] as List?;
     if (names == null || names.isEmpty) return null;
 
-    final first = names.first;
-    final given = (first['given'] as List?)?.join(' ') ?? '';
-    final family = first['family'] as String? ?? '';
+    // Try to find official name first
+    final official = names.cast<Map<String, dynamic>>().firstWhere(
+      (n) => n['use'] == 'official',
+      orElse: () => names.first as Map<String, dynamic>,
+    );
+
+    if (official['text'] != null) return official['text'] as String;
+
+    final given = (official['given'] as List?)?.join(' ') ?? '';
+    final family = official['family'] as String? ?? '';
 
     final full = '$given $family'.trim();
     return full.isNotEmpty ? full : null;
   }
 
-  /// Maps FHIR MedicationStatement to Medication
+  /// Maps FHIR MedicationStatement or MedicationRequest to Medication
   static Medication? mapMedicationStatement(Map<String, dynamic> json) {
     final medicationCodeableConcept = json['medicationCodeableConcept'];
-    final name = medicationCodeableConcept?['text'] as String? ??
-                 (medicationCodeableConcept?['coding'] as List?)?.first['display'] as String?;
+    final medicationReference = json['medicationReference'];
+
+    String? name;
+    if (medicationCodeableConcept != null) {
+      name = medicationCodeableConcept['text'] as String? ??
+             (medicationCodeableConcept['coding'] as List?)?.first['display'] as String?;
+    } else if (medicationReference != null) {
+      name = medicationReference['display'] as String?;
+    }
 
     if (name == null) return null;
 
     final effectiveDateTimeStr = json['effectiveDateTime'] as String? ??
-                                json['effectivePeriod']?['start'] as String?;
+                                json['effectivePeriod']?['start'] as String? ??
+                                json['authoredOn'] as String?; // For MedicationRequest
     final startDate = effectiveDateTimeStr != null ? DateTime.tryParse(effectiveDateTimeStr) : DateTime.now();
 
     return Medication(
       name: name,
-      isActive: json['status'] == 'active',
+      isActive: json['status'] == 'active' || json['status'] == 'completed',
       startDate: startDate ?? DateTime.now(),
       notes: json['note'] != null ? (json['note'] as List).map((n) => n['text']).join('\n') : null,
     );
@@ -70,8 +85,18 @@ class FhirMapper {
   /// Maps FHIR AllergyIntolerance to Allergy
   static Allergy? mapAllergyIntolerance(Map<String, dynamic> json) {
     final code = json['code'];
-    final allergen = code?['text'] as String? ??
+    String? allergen = code?['text'] as String? ??
                     (code?['coding'] as List?)?.first['display'] as String?;
+
+    // Fallback to substance in reactions if code is missing
+    if (allergen == null) {
+      final reactions = json['reaction'] as List?;
+      if (reactions != null && reactions.isNotEmpty) {
+        final substance = reactions.first['substance'];
+        allergen = substance?['text'] as String? ??
+                  (substance?['coding'] as List?)?.first['display'] as String?;
+      }
+    }
 
     if (allergen == null) return null;
 
@@ -82,9 +107,9 @@ class FhirMapper {
         severity = AllergySeverity.mild;
         break;
       case 'high':
+      case 'unable-to-assess':
         severity = AllergySeverity.severe;
         break;
-      case 'unable-to-assess':
       default:
         severity = AllergySeverity.moderate;
     }
@@ -99,31 +124,39 @@ class FhirMapper {
   /// Extracts ICD-10 codes from FHIR Condition
   static String? mapConditionCode(Map<String, dynamic> json) {
     final code = json['code'];
-    final codings = code?['coding'] as List?;
-    if (codings == null) return null;
+    if (code == null) return null;
 
-    for (final coding in codings) {
-      if (coding['system'] == 'http://hl7.org/fhir/sid/icd-10') {
-        return coding['code'] as String?;
+    final codings = code['coding'] as List?;
+    if (codings != null) {
+      for (final coding in codings) {
+        if (coding['system'] == 'http://hl7.org/fhir/sid/icd-10') {
+          return coding['code'] as String?;
+        }
+      }
+      // Fallback to first available code
+      if (codings.isNotEmpty) {
+        return codings.first['code'] as String?;
       }
     }
-    return null;
+
+    // Fallback to display text
+    return code['text'] as String?;
   }
 
   /// Maps FHIR Observation to VitalSign
   static List<VitalSign> mapObservation(Map<String, dynamic> json) {
     final code = json['code'];
     final codings = code?['coding'] as List?;
-    if (codings == null) return [];
+    if (codings == null && json['component'] == null) return [];
 
-    final effectiveDateTimeStr = json['effectiveDateTime'] as String?;
+    final effectiveDateTimeStr = json['effectiveDateTime'] as String? ?? json['issued'] as String?;
     final dateTime = effectiveDateTimeStr != null ? DateTime.tryParse(effectiveDateTimeStr) : DateTime.now();
     if (dateTime == null) return [];
 
     final List<VitalSign> vitals = [];
 
     // Handle single value observations
-    if (json['valueQuantity'] != null) {
+    if (json['valueQuantity'] != null && codings != null) {
       final type = _mapLoincToVitalType(codings);
       if (type != null) {
         vitals.add(VitalSign(
@@ -161,8 +194,10 @@ class FhirMapper {
 
   static VitalSignType? _mapLoincToVitalType(List codings) {
     for (final coding in codings) {
+      final code = coding['code'] as String?;
+      final display = (coding['display'] as String?)?.toLowerCase() ?? '';
+
       if (coding['system'] == 'http://loinc.org') {
-        final code = coding['code'] as String?;
         switch (code) {
           case '8867-4': return VitalSignType.heartRate;
           case '8310-5': return VitalSignType.temperature;
@@ -171,8 +206,20 @@ class FhirMapper {
           case '2708-6': return VitalSignType.spO2;
           case '59408-5': return VitalSignType.oxygenSaturation;
           case '15074-8': return VitalSignType.bloodGlucose;
+          case '60621-0': return VitalSignType.steps;
+          case '93832-4': return VitalSignType.sleep;
         }
       }
+
+      // Fallback to display name matching
+      if (display.contains('heart rate')) return VitalSignType.heartRate;
+      if (display.contains('temperature')) return VitalSignType.temperature;
+      if (display.contains('systolic')) return VitalSignType.bloodPressureSystolic;
+      if (display.contains('diastolic')) return VitalSignType.bloodPressureDiastolic;
+      if (display.contains('oxygen saturation') || display.contains('spo2')) return VitalSignType.spO2;
+      if (display.contains('glucose')) return VitalSignType.bloodGlucose;
+      if (display.contains('steps')) return VitalSignType.steps;
+      if (display.contains('sleep')) return VitalSignType.sleep;
     }
     return null;
   }

--- a/lib/features/sync/infrastructure/services/rda_parser.dart
+++ b/lib/features/sync/infrastructure/services/rda_parser.dart
@@ -26,13 +26,16 @@ class RdaParser {
       }
     }
 
-    if (composition == null) return null;
+    if (composition == null) {
+      // Fallback: Create a synthetic composition from entries if no Composition found
+      return _createSyntheticComposition(entries);
+    }
     return _parseComposition(composition, entries);
   }
 
   static Map<String, dynamic> _parseComposition(
-    Map<String, dynamic> composition,
-    [List<dynamic>? bundleEntries,
+    Map<String, dynamic> composition, [
+    List<dynamic>? bundleEntries,
   ]) {
     final sections = <Map<String, dynamic>>[];
 
@@ -48,7 +51,7 @@ class RdaParser {
           'code': coding?.isNotEmpty == true ? coding!.first['code'] : null,
           'text': sectionMap['text']?['div'],
           'entries': entries
-                  ?.map((e) => _resolveReference(e, bundleEntries))
+                  ?.map((e) => _resolveReference(e, bundleEntries, composition))
                   .where((e) => e != null)
                   .toList() ??
               [],
@@ -72,16 +75,31 @@ class RdaParser {
     };
   }
 
-  /// Resolve a reference to its full resource in the bundle
+  /// Resolve a reference to its full resource in the bundle or source
   static Map<String, dynamic>? _resolveReference(
     dynamic reference,
-    List<dynamic>? bundleEntries,
-  ) {
+    List<dynamic>? bundleEntries, [
+    Map<String, dynamic>? sourceResource,
+  ]) {
     if (reference == null) return null;
 
     final ref = reference as Map<String, dynamic>;
     final refStr = ref['reference'] as String?;
-    if (refStr == null || bundleEntries == null) return ref;
+    if (refStr == null) return ref;
+
+    // Handle contained resources (starting with #)
+    if (refStr.startsWith('#') && sourceResource != null) {
+      final id = refStr.substring(1);
+      final contained = sourceResource['contained'] as List?;
+      if (contained != null) {
+        for (final res in contained) {
+          final resMap = res as Map<String, dynamic>;
+          if (resMap['id'] == id) return resMap;
+        }
+      }
+    }
+
+    if (bundleEntries == null) return ref;
 
     final resourceId = refStr.split('/').last;
 
@@ -106,6 +124,79 @@ class RdaParser {
   static String? _extractDisplay(dynamic reference) {
     if (reference == null) return null;
     final ref = reference as Map<String, dynamic>;
-    return ref['display'] as String? ?? ref['reference'] as String?;
+    if (ref['display'] != null) return ref['display'] as String;
+    if (ref['text'] != null) return ref['text'] as String;
+    if (ref['reference'] != null) return ref['reference'] as String;
+
+    final identifier = ref['identifier'] as Map<String, dynamic>?;
+    if (identifier != null) {
+      return identifier['value'] as String? ?? identifier['system'] as String?;
+    }
+    return null;
+  }
+
+  static Map<String, dynamic> _createSyntheticComposition(List<dynamic> entries) {
+    final sections = <Map<String, dynamic>>[];
+    final resourcesBySection = <String, List<Map<String, dynamic>>>{};
+
+    for (final entry in entries) {
+      final resource = entry['resource'] as Map<String, dynamic>?;
+      if (resource == null) continue;
+
+      final type = resource['resourceType'] as String?;
+      String? sectionTitle;
+      switch (type) {
+        case 'MedicationStatement':
+        case 'MedicationRequest':
+          sectionTitle = 'Medications';
+          break;
+        case 'AllergyIntolerance':
+          sectionTitle = 'Allergies';
+          break;
+        case 'Condition':
+          sectionTitle = 'Conditions';
+          break;
+        case 'Observation':
+          sectionTitle = 'Observations';
+          break;
+      }
+
+      if (sectionTitle != null) {
+        resourcesBySection.putIfAbsent(sectionTitle, () => []).add(resource);
+      }
+    }
+
+    resourcesBySection.forEach((title, resources) {
+      sections.add({
+        'title': title,
+        'entries': resources,
+      });
+    });
+
+    // Try to find patient name
+    String? patientName;
+    for (final entry in entries) {
+      final resource = entry['resource'] as Map<String, dynamic>?;
+      if (resource?['resourceType'] == 'Patient') {
+        final names = resource!['name'] as List?;
+        if (names != null && names.isNotEmpty) {
+          final first = names.first;
+          final given = (first['given'] as List?)?.join(' ') ?? '';
+          final family = first['family'] as String? ?? '';
+          patientName = '$given $family'.trim();
+          if (patientName!.isEmpty) patientName = null;
+        }
+        break;
+      }
+    }
+
+    return {
+      'id': 'synthetic-${DateTime.now().millisecondsSinceEpoch}',
+      'date': DateTime.now().toIso8601String(),
+      'title': 'Synthetic Summary',
+      'status': 'final',
+      'patient': patientName,
+      'sections': sections,
+    };
   }
 }

--- a/test/features/sync/infrastructure/services/fhir_mapper_test.dart
+++ b/test/features/sync/infrastructure/services/fhir_mapper_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:orionhealth_health/features/sync/infrastructure/services/fhir_mapper.dart';
 import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
 import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
 
 void main() {
   group('FhirMapper', () {
@@ -33,6 +34,96 @@ void main() {
       expect(result.uniqueId, '123');
     });
 
+    test('mapPatient should prioritize official name and text', () {
+      final json = {
+        'resourceType': 'Patient',
+        'name': [
+          {'family': 'Smith', 'given': ['Jane'], 'use': 'usual'},
+          {'text': 'Jane Official Smith', 'use': 'official'}
+        ]
+      };
+      final existing = UserProfile();
+      final result = FhirMapper.mapPatient(json, existing);
+      expect(result.name, 'Jane Official Smith');
+    });
+
+    test('mapMedicationStatement should map correctly (codeable)', () {
+      final json = {
+        'resourceType': 'MedicationStatement',
+        'status': 'active',
+        'medicationCodeableConcept': {
+          'text': 'Aspirin 81mg'
+        },
+        'effectiveDateTime': '2023-01-01T00:00:00Z'
+      };
+      final result = FhirMapper.mapMedicationStatement(json);
+      expect(result!.name, 'Aspirin 81mg');
+      expect(result.isActive, true);
+    });
+
+    test('mapMedicationStatement should map MedicationRequest and authoredOn', () {
+      final json = {
+        'resourceType': 'MedicationRequest',
+        'status': 'completed',
+        'medicationReference': {
+          'display': 'Ibuprofen'
+        },
+        'authoredOn': '2023-02-01'
+      };
+      final result = FhirMapper.mapMedicationStatement(json);
+      expect(result!.name, 'Ibuprofen');
+      expect(result.isActive, true);
+      expect(result.startDate, DateTime(2023, 2, 1));
+    });
+
+    test('mapAllergyIntolerance should map correctly', () {
+      final json = {
+        'resourceType': 'AllergyIntolerance',
+        'code': {'text': 'Peanuts'},
+        'criticality': 'high'
+      };
+      final result = FhirMapper.mapAllergyIntolerance(json);
+      expect(result!.allergen, 'Peanuts');
+      expect(result.severity, AllergySeverity.severe);
+    });
+
+    test('mapAllergyIntolerance should fallback to substance', () {
+      final json = {
+        'resourceType': 'AllergyIntolerance',
+        'reaction': [
+          {
+            'substance': {'text': 'Latex'}
+          }
+        ]
+      };
+      final result = FhirMapper.mapAllergyIntolerance(json);
+      expect(result!.allergen, 'Latex');
+    });
+
+    test('mapConditionCode should handle ICD-10 and fallbacks', () {
+      final json1 = {
+        'code': {
+          'coding': [
+            {'system': 'other', 'code': 'ABC'},
+            {'system': 'http://hl7.org/fhir/sid/icd-10', 'code': 'I10'}
+          ]
+        }
+      };
+      expect(FhirMapper.mapConditionCode(json1), 'I10');
+
+      final json2 = {
+        'code': {
+          'coding': [{'code': 'XYZ'}]
+        }
+      };
+      expect(FhirMapper.mapConditionCode(json2), 'XYZ');
+
+      final json3 = {
+        'code': {'text': 'Hypertension'}
+      };
+      expect(FhirMapper.mapConditionCode(json3), 'Hypertension');
+    });
+
     test('mapObservation should map LOINC codes to VitalSigns', () {
       final json = {
         'resourceType': 'Observation',
@@ -49,6 +140,43 @@ void main() {
       expect(results.length, 1);
       expect(results[0].type, VitalSignType.heartRate);
       expect(results[0].value, 75);
+    });
+
+    test('mapObservation should handle components', () {
+      final json = {
+        'resourceType': 'Observation',
+        'component': [
+          {
+            'code': {'coding': [{'system': 'http://loinc.org', 'code': '8480-6'}]},
+            'valueQuantity': {'value': 120}
+          },
+          {
+            'code': {'coding': [{'system': 'http://loinc.org', 'code': '8462-4'}]},
+            'valueQuantity': {'value': 80}
+          }
+        ],
+        'effectiveDateTime': '2023-10-27T10:00:00Z'
+      };
+
+      final results = FhirMapper.mapObservation(json);
+      expect(results.length, 2);
+      expect(results.any((v) => v.type == VitalSignType.bloodPressureSystolic && v.value == 120), true);
+      expect(results.any((v) => v.type == VitalSignType.bloodPressureDiastolic && v.value == 80), true);
+    });
+
+    test('_mapLoincToVitalType should handle display name fallback', () {
+      final json = {
+        'resourceType': 'Observation',
+        'code': {
+          'coding': [
+            {'display': 'Body temperature'}
+          ]
+        },
+        'valueQuantity': {'value': 36.5},
+        'effectiveDateTime': '2023-10-27T10:00:00Z'
+      };
+      final results = FhirMapper.mapObservation(json);
+      expect(results[0].type, VitalSignType.temperature);
     });
   });
 }

--- a/test/features/sync/infrastructure/services/rda_parser_test.dart
+++ b/test/features/sync/infrastructure/services/rda_parser_test.dart
@@ -69,21 +69,33 @@ void main() {
       expect(result['sections'][0]['entries'][0]['resourceType'], 'Observation');
     });
 
-    test('parse returns null for empty Bundle', () {
-      final result = RdaParser.parse({'resourceType': 'Bundle', 'entry': []});
-      expect(result, isNull);
-    });
-
-    test('parse returns null for Bundle without Composition', () {
+    test('parse returns synthetic summary for Bundle without Composition', () {
       final bundle = {
         'resourceType': 'Bundle',
         'entry': [
           {
-            'resource': {'resourceType': 'Patient', 'id': 'p1'}
+            'resource': {
+              'resourceType': 'Patient',
+              'name': [{'given': ['John'], 'family': 'Doe'}]
+            }
+          },
+          {
+            'resource': {
+              'resourceType': 'MedicationStatement',
+              'medicationCodeableConcept': {'text': 'Aspirin'}
+            }
           }
         ]
       };
       final result = RdaParser.parse(bundle);
+      expect(result!['title'], 'Synthetic Summary');
+      expect(result['patient'], 'John Doe');
+      expect(result['sections'].length, 1);
+      expect(result['sections'][0]['title'], 'Medications');
+    });
+
+    test('parse returns null for empty Bundle', () {
+      final result = RdaParser.parse({'resourceType': 'Bundle', 'entry': []});
       expect(result, isNull);
     });
 
@@ -134,6 +146,22 @@ void main() {
       expect(entries[0]['id'], 'o1');
       expect(entries[1]['id'], 'o2');
       expect(entries[2]['id'], 'o3');
+    });
+
+    test('_resolveReference handles contained resources', () {
+      final composition = {
+        'resourceType': 'Composition',
+        'contained': [
+          {'resourceType': 'Practitioner', 'id': 'p1', 'name': [{'text': 'Dr. Smith'}]}
+        ],
+        'section': [
+          {
+            'entry': [{'reference': '#p1'}]
+          }
+        ]
+      };
+      final result = RdaParser.parse(composition);
+      expect(result!['sections'][0]['entries'][0]['name'][0]['text'], 'Dr. Smith');
     });
   });
 }


### PR DESCRIPTION
Completed the placeholder implementations in `FhirMapper` and `RdaParser` to support clinical data synchronization.

Key changes:
- `FhirMapper`: Added support for `MedicationRequest`, prioritized 'official' names, added fallbacks to `text` and `display` fields for medications and conditions, and expanded LOINC mapping for vitals (steps, sleep).
- `RdaParser`: Added a synthetic summary generator for Bundles without a `Composition`, and implemented support for resolving internal contained resources (those starting with `#`).
- Tests: Updated `fhir_mapper_test.dart` and `rda_parser_test.dart` with new scenarios to verify the enhanced logic.

Fixes #801

---
*PR created automatically by Jules for task [6291818502793807376](https://jules.google.com/task/6291818502793807376) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automatic synthetic summary generation when medical records lack composition data.
  * Enhanced reference resolution for contained medical resources.

* **Bug Fixes & Improvements**
  * Improved patient name extraction with fallback logic for incomplete data.
  * Enhanced medication mapping to support multiple data sources and expanded active status recognition.
  * Better allergy allergen and criticality extraction with comprehensive fallbacks.
  * Improved vital signs and condition code extraction with broader data source support.

* **Tests**
  * Expanded test coverage for medication, allergy, and vital signs mapping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->