### PR TITLE
Complete Clean Architecture for Sync Feature

### DIFF
--- a/lib/core/di/fhir_module.dart
+++ b/lib/core/di/fhir_module.dart
@@ -8,8 +8,5 @@ import '../../features/sync/infrastructure/services/fhir_client.dart';
 @module
 abstract class FhirModule {
   @lazySingleton
-  http.Client get httpClient => http.Client();
-
-  @lazySingleton
-  FhirClient get fhirClient => FhirClient(client: httpClient);
+  FhirClient fhirClient(http.Client httpClient) => FhirClient(client: httpClient);
 }

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -1,0 +1,881 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+// **************************************************************************
+// InjectableConfigGenerator
+// **************************************************************************
+
+// ignore_for_file: type=lint
+// coverage:ignore-file
+
+// ignore_for_file: no_leading_underscores_for_library_prefixes
+import 'package:device_calendar/device_calendar.dart' as _i13;
+import 'package:dio/dio.dart' as _i21;
+import 'package:flutter/services.dart' as _i73;
+import 'package:flutter_appauth/flutter_appauth.dart' as _i30;
+import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i32;
+import 'package:get_it/get_it.dart' as _i1;
+import 'package:google_generative_ai/google_generative_ai.dart' as _i34;
+import 'package:health_wallet/health_wallet.dart' as _i25;
+import 'package:http/http.dart' as _i17;
+import 'package:injectable/injectable.dart' as _i2;
+import 'package:isar/isar.dart' as _i46;
+import 'package:isar_agent_memory/isar_agent_memory.dart' as _i24;
+import 'package:medical_standards/medical_standards.dart' as _i54;
+
+import '../../features/about/application/about_cubit.dart' as _i111;
+import '../../features/about/data/datasources/about_local_datasource.dart'
+    as _i4;
+import '../../features/about/data/datasources/about_remote_datasource.dart'
+    as _i112;
+import '../../features/about/domain/repositories/i_about_repository.dart'
+    as _i39;
+import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
+    as _i40;
+import '../../features/allergies/application/allergies_cubit.dart' as _i179;
+import '../../features/allergies/domain/repositories/allergy_repository.dart'
+    as _i113;
+import '../../features/allergies/domain/services/allergy_service.dart' as _i5;
+import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
+    as _i114;
+import '../../features/appointments/application/appointments_cubit.dart'
+    as _i117;
+import '../../features/appointments/domain/repositories/appointment_repository.dart'
+    as _i115;
+import '../../features/appointments/domain/services/appointment_service.dart'
+    as _i6;
+import '../../features/appointments/domain/usecases/delete_appointment_usecase.dart'
+    as _i128;
+import '../../features/appointments/domain/usecases/get_all_appointments_usecase.dart'
+    as _i137;
+import '../../features/appointments/domain/usecases/save_appointment_usecase.dart'
+    as _i169;
+import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
+    as _i116;
+import '../../features/auth/application/auth_cubit.dart' as _i181;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i180;
+import '../../features/auth/domain/auth_service.dart' as _i120;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i118;
+import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
+    as _i119;
+import '../../features/auth/infrastructure/services/biometric_service.dart'
+    as _i9;
+import '../../features/auth/infrastructure/services/encryption_service.dart'
+    as _i26;
+import '../../features/calendar_import/application/calendar_import_cubit.dart'
+    as _i184;
+import '../../features/calendar_import/domain/repositories/calendar_repository.dart'
+    as _i14;
+import '../../features/calendar_import/domain/usecases/import_calendar_usecase.dart'
+    as _i155;
+import '../../features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart'
+    as _i12;
+import '../../features/calendar_import/infrastructure/repositories/calendar_repository_impl.dart'
+    as _i15;
+import '../../features/dashboard/application/dashboard_cubit.dart' as _i185;
+import '../../features/dashboard/data/datasources/dashboard_local_datasource.dart'
+    as _i18;
+import '../../features/dashboard/data/repositories/dashboard_repository_impl.dart'
+    as _i127;
+import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
+    as _i126;
+import '../../features/dashboard/domain/usecases/get_dashboard_stats_usecase.dart'
+    as _i140;
+import '../../features/dashboard/domain/usecases/get_recent_activity_usecase.dart'
+    as _i142;
+import '../../features/doctor_verification/application/badge_cubit.dart'
+    as _i183;
+import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
+    as _i134;
+import '../../features/doctor_verification/application/second_opinion_cubit.dart'
+    as _i170;
+import '../../features/doctor_verification/application/vouch_cubit.dart'
+    as _i178;
+import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
+    as _i132;
+import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
+    as _i83;
+import '../../features/doctor_verification/domain/repositories/second_opinion_repository.dart'
+    as _i88;
+import '../../features/doctor_verification/domain/repositories/vouch_repository.dart'
+    as _i108;
+import '../../features/doctor_verification/domain/services/badge_calculator.dart'
+    as _i182;
+import '../../features/doctor_verification/domain/services/license_verifier.dart'
+    as _i48;
+import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
+    as _i47;
+import '../../features/doctor_verification/infrastructure/repositories/isar_doctor_profile_repository.dart'
+    as _i133;
+import '../../features/doctor_verification/infrastructure/repositories/isar_rating_repository.dart'
+    as _i84;
+import '../../features/doctor_verification/infrastructure/repositories/isar_second_opinion_repository.dart'
+    as _i89;
+import '../../features/doctor_verification/infrastructure/repositories/isar_vouch_repository.dart'
+    as _i109;
+import '../../features/email-citas/application/email_citas_cubit.dart' as _i135;
+import '../../features/email-citas/domain/repositories/email_repository.dart'
+    as _i22;
+import '../../features/email-citas/infrastructure/repositories/email_repository_impl.dart'
+    as _i23;
+import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
+    as _i187;
+import '../../features/eps_connection/data/datasources/oauth_local_datasource.dart'
+    as _i77;
+import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
+    as _i78;
+import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
+    as _i125;
+import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
+    as _i129;
+import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
+    as _i139;
+import '../../features/eps_connection/infrastructure/oauth_repository.dart'
+    as _i79;
+import '../../features/health_data_import/application/health_import_cubit.dart'
+    as _i149;
+import '../../features/health_data_import/data/datasources/health_data_file_datasource.dart'
+    as _i147;
+import '../../features/health_data_import/data/datasources/health_data_sensor_datasource.dart'
+    as _i36;
+import '../../features/health_data_import/domain/services/health_data_import_service.dart'
+    as _i35;
+import '../../features/health_data_import/infrastructure/data_source.dart'
+    as _i90;
+import '../../features/health_data_import/infrastructure/health_data_repository_impl.dart'
+    as _i148;
+import '../../features/health_record/application/bloc/health_record_cubit.dart'
+    as _i189;
+import '../../features/health_record/domain/repositories/health_record_repository.dart'
+    as _i150;
+import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+    as _i151;
+import '../../features/health_record/infrastructure/services/file_picker_service.dart'
+    as _i28;
+import '../../features/health_record/infrastructure/services/image_picker_service.dart'
+    as _i41;
+import '../../features/health_record/infrastructure/services/ocr_service.dart'
+    as _i80;
+import '../../features/health_sharing/application/sharing_cubit.dart' as _i197;
+import '../../features/health_sharing/data/datasources/health_sharing_local_datasource.dart'
+    as _i152;
+import '../../features/health_sharing/data/datasources/health_sharing_remote_datasource.dart'
+    as _i37;
+import '../../features/health_sharing/domain/usecases/cancel_sharing_usecase.dart'
+    as _i122;
+import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
+    as _i173;
+import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
+    as _i174;
+import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
+    as _i121;
+import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i10;
+import '../../features/health_sharing/infrastructure/nfc_handler.dart' as _i72;
+import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
+    as _i74;
+import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
+    as _i110;
+import '../../features/home/application/home_cubit.dart' as _i190;
+import '../../features/home/domain/repositories/home_repository.dart' as _i153;
+import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
+    as _i188;
+import '../../features/home/infrastructure/datasources/health_summary_datasource.dart'
+    as _i38;
+import '../../features/home/infrastructure/repositories/home_repository_impl.dart'
+    as _i154;
+import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
+    as _i172;
+import '../../features/local_agent/data/datasources/chat_message_local_datasource.dart'
+    as _i123;
+import '../../features/local_agent/data/datasources/local_model_local_datasource.dart'
+    as _i53;
+import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
+    as _i55;
+import '../../features/local_agent/domain/services/llm_adapter.dart' as _i49;
+import '../../features/local_agent/domain/services/vector_store_service.dart'
+    as _i101;
+import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
+    as _i51;
+import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
+    as _i31;
+import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
+    as _i156;
+import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
+    as _i33;
+import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
+    as _i157;
+import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
+    as _i50;
+import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
+    as _i159;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i158;
+import '../../features/local_agent/infrastructure/rag_llm_service.dart'
+    as _i192;
+import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
+    as _i56;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i57;
+import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
+    as _i102;
+import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
+    as _i191;
+import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
+    as _i52;
+import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
+    as _i194;
+import '../../features/local_agent/infrastructure/services/model_download_service.dart'
+    as _i71;
+import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
+    as _i166;
+import '../../features/medical_research/application/medical_research_cubit.dart'
+    as _i195;
+import '../../features/medical_research/domain/services/medical_scraper_service.dart'
+    as _i58;
+import '../../features/medical_research/domain/services/medical_standards_service.dart'
+    as _i60;
+import '../../features/medical_research/domain/services/medical_web_search_service.dart'
+    as _i62;
+import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
+    as _i11;
+import '../../features/medical_research/infrastructure/medical_research_service.dart'
+    as _i162;
+import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
+    as _i59;
+import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
+    as _i61;
+import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
+    as _i63;
+import '../../features/medications/application/medications_cubit.dart' as _i66;
+import '../../features/medications/domain/repositories/medication_repository.dart'
+    as _i64;
+import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
+    as _i65;
+import '../../features/meditation/application/meditation_cubit.dart' as _i163;
+import '../../features/meditation/domain/repositories/meditation_repository.dart'
+    as _i68;
+import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
+    as _i124;
+import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
+    as _i141;
+import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
+    as _i143;
+import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
+    as _i85;
+import '../../features/meditation/domain/usecases/start_session_usecase.dart'
+    as _i92;
+import '../../features/meditation/infrastructure/datasources/meditation_local_datasource.dart'
+    as _i67;
+import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
+    as _i69;
+import '../../features/network/governance/domain/repositories/governance_repository.dart'
+    as _i145;
+import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
+    as _i144;
+import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
+    as _i146;
+import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
+    as _i43;
+import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
+    as _i42;
+import '../../features/network/incentives/infrastructure/repositories/incentive_repository_impl.dart'
+    as _i44;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i81;
+import '../../features/onboarding/application/sync_cubit.dart' as _i175;
+import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
+    as _i164;
+import '../../features/onboarding/infrastructure/onboarding_repository_impl.dart'
+    as _i165;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i196;
+import '../../features/reports/domain/repositories/report_repository.dart'
+    as _i86;
+import '../../features/reports/domain/services/report_generation_service.dart'
+    as _i167;
+import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
+    as _i87;
+import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+    as _i168;
+import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
+    as _i70;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i193;
+import '../../features/settings/data/datasources/settings_local_datasource.dart'
+    as _i91;
+import '../../features/settings/data/repositories/llm_settings_repository_impl.dart'
+    as _i161;
+import '../../features/settings/domain/repositories/llm_settings_repository.dart'
+    as _i160;
+import '../../features/settings/domain/services/device_capability_service.dart'
+    as _i19;
+import '../../features/sync/application/sync_cubit.dart' as _i136;
+import '../../features/sync/domain/repositories/sync_repository.dart' as _i93;
+import '../../features/sync/domain/services/distributed_storage_service.dart'
+    as _i130;
+import '../../features/sync/domain/services/node_discovery_service.dart'
+    as _i75;
+import '../../features/sync/domain/services/sync_service.dart' as _i95;
+import '../../features/sync/domain/usecases/distributed_cache_usecase.dart'
+    as _i186;
+import '../../features/sync/infrastructure/datasources/filecoin_datasource.dart'
+    as _i29;
+import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
+    as _i45;
+import '../../features/sync/infrastructure/repositories/sync_repository_impl.dart'
+    as _i94;
+import '../../features/sync/infrastructure/services/fhir_client.dart' as _i27;
+import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i131;
+import '../../features/sync/infrastructure/services/node_discovery_service.dart'
+    as _i76;
+import '../../features/sync/infrastructure/services/sync_service_impl.dart'
+    as _i96;
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i176;
+import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
+    as _i97;
+import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
+    as _i98;
+import '../../features/user_profile/domain/services/user_profile_service.dart'
+    as _i100;
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+    as _i99;
+import '../../features/vitals/application/vitals_cubit.dart' as _i105;
+import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+    as _i103;
+import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+    as _i104;
+import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i177;
+import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
+    as _i106;
+import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
+    as _i138;
+import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
+    as _i171;
+import '../../features/voice_chat/infrastructure/datasources/chat_ai_datasource.dart'
+    as _i16;
+import '../../features/voice_chat/infrastructure/repositories/voice_chat_repository_impl.dart'
+    as _i107;
+import '../services/aicore_service.dart' as _i3;
+import '../services/asr/asr_service.dart' as _i7;
+import '../services/audio/audio_player_service.dart' as _i8;
+import '../services/device_capability_service.dart' as _i20;
+import '../services/privacy_anonymizer.dart' as _i82;
+import 'calendar_module.dart' as _i199;
+import 'database_module.dart' as _i202;
+import 'fhir_module.dart' as _i203;
+import 'memory_module.dart' as _i201;
+import 'network_module.dart' as _i200;
+import 'service_module.dart' as _i198;
+
+const String _mobile = 'mobile';
+const String _desktop = 'desktop';
+const String _test = 'test';
+
+extension GetItInjectableX on _i1.GetIt {
+// initializes the registration of main-scope dependencies inside of GetIt
+  Future<_i1.GetIt> init({
+    String? environment,
+    _i2.EnvironmentFilter? environmentFilter,
+  }) async {
+    final gh = _i2.GetItHelper(
+      this,
+      environment,
+      environmentFilter,
+    );
+    final serviceModule = _$ServiceModule();
+    final calendarModule = _$CalendarModule();
+    final networkModule = _$NetworkModule();
+    final memoryModule = _$MemoryModule();
+    final databaseModule = _$DatabaseModule();
+    final fhirModule = _$FhirModule();
+    gh.lazySingleton<_i3.AIService>(() => _i3.AIService());
+    gh.lazySingleton<_i4.AboutLocalDataSource>(
+        () => _i4.AboutLocalDataSource());
+    gh.lazySingleton<_i3.AgentMemoryService>(() => _i3.AgentMemoryService());
+    gh.lazySingleton<_i5.AllergyService>(() => _i5.AllergyService());
+    gh.lazySingleton<_i6.AppointmentService>(() => _i6.AppointmentService());
+    gh.lazySingleton<_i7.AsrService>(() => _i7.AsrService());
+    gh.lazySingleton<_i8.AudioService>(() => _i8.AudioService());
+    gh.lazySingleton<_i9.BiometricService>(() => _i9.BiometricService());
+    gh.lazySingleton<_i10.BleWrapper>(() => _i10.BleWrapper());
+    gh.lazySingleton<_i11.BotBypassHandler>(() => _i11.BotBypassHandler());
+    gh.factory<_i12.CalendarApiDatasource>(() => _i12.CalendarApiDatasource(
+        deviceCalendarPlugin: gh<_i13.DeviceCalendarPlugin>()));
+    gh.lazySingleton<_i14.CalendarRepository>(
+        () => _i15.CalendarRepositoryImpl(gh<_i12.CalendarApiDatasource>()));
+    gh.lazySingleton<_i16.ChatAiDatasource>(() => _i16.ChatAiDatasource(
+          gh<_i3.AIService>(),
+          gh<_i7.AsrService>(),
+          gh<_i3.AgentMemoryService>(),
+        ));
+    gh.lazySingleton<_i17.Client>(() => serviceModule.httpClient);
+    gh.lazySingleton<_i18.DashboardLocalDataSource>(
+        () => _i18.DashboardLocalDataSource());
+    gh.lazySingleton<_i13.DeviceCalendarPlugin>(
+        () => calendarModule.deviceCalendarPlugin);
+    gh.lazySingleton<_i19.DeviceCapabilityService>(
+        () => _i19.DeviceCapabilityService());
+    gh.lazySingleton<_i20.DeviceCapabilityService>(
+        () => _i20.DeviceCapabilityService());
+    gh.lazySingleton<_i21.Dio>(() => networkModule.dio);
+    gh.lazySingleton<_i22.EmailRepository>(() => _i23.EmailRepositoryImpl(
+          client: gh<_i17.Client>(),
+          deviceCalendarPlugin: gh<_i13.DeviceCalendarPlugin>(),
+        ));
+    gh.lazySingleton<_i24.EmbeddingsAdapter>(
+        () => memoryModule.embeddingsAdapter);
+    gh.lazySingleton<_i25.EncryptionService>(
+        () => databaseModule.walletEncryptionService);
+    gh.lazySingleton<_i26.EncryptionService>(() => _i26.EncryptionService());
+    gh.lazySingleton<_i27.FhirClient>(
+        () => fhirModule.fhirClient(gh<_i17.Client>()));
+    gh.lazySingleton<_i28.FilePickerService>(
+        () => _i28.FilePickerServiceImpl());
+    gh.lazySingleton<_i29.FilecoinDatasource>(() => _i29.FilecoinDatasource());
+    gh.lazySingleton<_i30.FlutterAppAuth>(() => serviceModule.appAuth);
+    gh.lazySingleton<_i31.FlutterGemmaWrapper>(
+        () => _i31.FlutterGemmaWrapper());
+    gh.lazySingleton<_i32.FlutterSecureStorage>(() => serviceModule.storage);
+    gh.lazySingleton<_i33.GeminiModelWrapper>(
+        () => _i33.GeminiModelWrapper(gh<_i34.GenerativeModel>()));
+    gh.lazySingleton<_i35.HealthDataImportService>(
+        () => _i35.HealthDataImportService());
+    gh.lazySingleton<_i36.HealthDataSensorDataSource>(
+        () => _i36.HealthDataSensorDataSource());
+    gh.lazySingleton<_i37.HealthSharingRemoteDataSource>(
+        () => _i37.HealthSharingRemoteDataSource());
+    gh.factory<_i38.HealthSummaryDatasource>(
+        () => _i38.HealthSummaryDatasource());
+    gh.lazySingleton<_i39.IAboutRepository>(() => _i40.AboutRepositoryImpl());
+    gh.lazySingleton<_i41.ImagePickerService>(
+        () => _i41.ImagePickerServiceImpl());
+    gh.lazySingleton<_i42.IncentiveDatasource>(
+        () => _i42.IncentiveDatasource());
+    gh.lazySingleton<_i43.IncentiveRepository>(
+        () => _i44.IncentiveRepositoryImpl(gh<_i42.IncentiveDatasource>()));
+    gh.lazySingleton<_i45.IpfsDatasource>(
+        () => _i45.IpfsDatasource(gh<_i21.Dio>()));
+    await gh.factoryAsync<_i46.Isar>(
+      () => databaseModule.isar,
+      preResolve: true,
+    );
+    gh.lazySingletonAsync<_i47.LicenseRegistryLocalDataSource>(() {
+      final i = _i47.LicenseRegistryLocalDataSource(gh<_i46.Isar>());
+      return i.load().then((_) => i);
+    });
+    gh.lazySingletonAsync<_i48.LicenseVerifier>(() async =>
+        _i48.LicenseVerifier(
+            await getAsync<_i47.LicenseRegistryLocalDataSource>()));
+    gh.lazySingleton<_i49.LlmAdapter>(
+      () => _i50.OpenaiCompatibleAdapter(),
+      instanceName: 'openai',
+    );
+    gh.lazySingleton<_i49.LlmAdapter>(
+      () => _i51.FlutterGemmaAdapter(wrapper: gh<_i31.FlutterGemmaWrapper>()),
+      instanceName: 'gemma',
+    );
+    gh.lazySingleton<_i52.LocalLlmService>(() => _i52.LocalLlmService());
+    gh.lazySingleton<_i53.LocalModelLocalDataSource>(
+        () => _i53.LocalModelLocalDataSource());
+    gh.lazySingleton<_i54.MedicalContextProvider>(
+        () => networkModule.medicalContextProvider);
+    gh.factory<_i55.MedicalKnowledgeRepository>(
+      () => _i56.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
+    );
+    gh.factory<_i55.MedicalKnowledgeRepository>(
+      () => _i57.JsonMedicalKnowledgeRepository(),
+      registerFor: {
+        _desktop,
+        _test,
+      },
+    );
+    gh.lazySingleton<_i58.MedicalScraperService>(
+        () => _i59.MedicalScraperServiceImpl(
+              gh<_i21.Dio>(),
+              gh<_i11.BotBypassHandler>(),
+            ));
+    gh.lazySingleton<_i60.MedicalStandardsService>(() =>
+        _i61.MedicalStandardsServiceImpl(gh<_i54.MedicalContextProvider>()));
+    gh.lazySingleton<_i62.MedicalWebSearchService>(
+        () => _i63.MedicalWebSearchServiceImpl(gh<_i21.Dio>()));
+    gh.lazySingleton<_i64.MedicationRepository>(
+        () => _i65.IsarMedicationRepository(gh<_i46.Isar>()));
+    gh.factory<_i66.MedicationsCubit>(
+        () => _i66.MedicationsCubit(gh<_i64.MedicationRepository>()));
+    gh.lazySingleton<_i67.MeditationLocalDataSource>(
+        () => _i67.MeditationLocalDataSource());
+    gh.lazySingleton<_i68.MeditationRepository>(() =>
+        _i69.MeditationRepositoryImpl(gh<_i67.MeditationLocalDataSource>()));
+    await gh.lazySingletonAsync<_i24.MemoryGraph>(
+      () => memoryModule.memoryGraph(
+        gh<_i46.Isar>(),
+        gh<_i24.EmbeddingsAdapter>(),
+      ),
+      preResolve: true,
+    );
+    gh.lazySingleton<_i70.MockReportGenerationService>(
+      () => _i70.MockReportGenerationService(),
+      instanceName: 'mock',
+    );
+    gh.lazySingleton<_i71.ModelDownloadService>(
+        () => _i71.ModelDownloadService());
+    gh.lazySingleton<_i72.NfcHandler>(
+        () => _i72.NfcHandler(channel: gh<_i73.MethodChannel>()));
+    gh.lazySingleton<_i74.NfcSharingService>(
+        () => _i74.NfcSharingService(gh<_i72.NfcHandler>()));
+    gh.lazySingleton<_i75.NodeDiscoveryService>(
+        () => _i76.NodeDiscoveryService());
+    gh.lazySingleton<_i77.OAuthLocalDataSource>(
+        () => _i77.OAuthLocalDataSource(gh<_i32.FlutterSecureStorage>()));
+    gh.lazySingleton<_i78.OAuthRepository>(() => _i79.OAuthRepositoryImpl(
+          gh<_i77.OAuthLocalDataSource>(),
+          gh<_i21.Dio>(),
+          gh<_i30.FlutterAppAuth>(),
+        ));
+    gh.lazySingleton<_i80.OcrService>(() => _i80.MlKitOcrService());
+    gh.factory<_i81.OnboardingCubit>(() => _i81.OnboardingCubit());
+    gh.lazySingleton<_i82.PromptScrubber>(
+        () => _i82.PromptScrubber(gh<_i46.Isar>()));
+    gh.lazySingleton<_i83.RatingRepository>(
+        () => _i84.IsarRatingRepository(gh<_i46.Isar>()));
+    gh.lazySingleton<_i85.RecommendScriptUseCase>(
+        () => _i85.RecommendScriptUseCase(gh<_i68.MeditationRepository>()));
+    gh.lazySingleton<_i86.ReportRepository>(
+        () => _i87.IsarReportRepository(gh<_i46.Isar>()));
+    gh.lazySingleton<_i88.SecondOpinionRepository>(
+        () => _i89.IsarSecondOpinionRepository(gh<_i46.Isar>()));
+    gh.lazySingleton<_i90.SensorHealthDataSource>(
+        () => _i90.SensorHealthDataSourceImpl());
+    gh.lazySingleton<_i91.SettingsLocalDataSource>(
+        () => _i91.SettingsLocalDataSource(gh<_i46.Isar>()));
+    gh.lazySingleton<_i92.StartSessionUseCase>(
+        () => _i92.StartSessionUseCase(gh<_i68.MeditationRepository>()));
+    gh.lazySingleton<_i93.SyncRepository>(() => _i94.SyncRepositoryImpl(
+          gh<_i27.FhirClient>(),
+          gh<_i46.Isar>(),
+          gh<_i32.FlutterSecureStorage>(),
+          gh<_i75.NodeDiscoveryService>(),
+        ));
+    gh.lazySingleton<_i54.SyncService>(() => networkModule.syncService);
+    gh.lazySingleton<_i95.SyncService>(() => _i96.SyncServiceImpl(
+          gh<_i93.SyncRepository>(),
+          gh<_i54.SyncService>(),
+        ));
+    gh.lazySingleton<_i97.UserProfileLocalDataSource>(
+        () => _i97.UserProfileLocalDataSource(gh<_i46.Isar>()));
+    gh.lazySingleton<_i98.UserProfileRepository>(
+        () => _i99.UserProfileRepositoryImpl(gh<_i46.Isar>()));
+    gh.lazySingleton<_i100.UserProfileService>(
+        () => _i100.UserProfileService(gh<_i98.UserProfileRepository>()));
+    gh.lazySingleton<_i101.VectorStoreService>(
+        () => _i102.IsarVectorStoreService(
+              gh<_i24.MemoryGraph>(),
+              gh<_i55.MedicalKnowledgeRepository>(),
+            ));
+    gh.lazySingleton<_i103.VitalSignRepository>(
+        () => _i104.VitalSignRepositoryImpl(gh<_i46.Isar>()));
+    gh.factory<_i105.VitalsCubit>(
+        () => _i105.VitalsCubit(gh<_i103.VitalSignRepository>()));
+    gh.lazySingleton<_i106.VoiceChatRepository>(
+        () => _i107.VoiceChatRepositoryImpl(gh<_i16.ChatAiDatasource>()));
+    gh.lazySingleton<_i108.VouchRepository>(
+        () => _i109.IsarVouchRepository(gh<_i46.Isar>()));
+    gh.lazySingleton<_i25.WalletService>(() => databaseModule.walletService(
+          gh<_i46.Isar>(),
+          gh<_i25.EncryptionService>(),
+        ));
+    gh.lazySingleton<_i110.WifiDirectService>(() => _i110.WifiDirectService());
+    gh.factory<_i111.AboutCubit>(
+        () => _i111.AboutCubit(gh<_i39.IAboutRepository>()));
+    gh.lazySingleton<_i112.AboutRemoteDataSource>(
+        () => _i112.AboutRemoteDataSource(gh<_i21.Dio>()));
+    gh.lazySingleton<_i113.AllergyRepository>(
+        () => _i114.IsarAllergyRepository(gh<_i46.Isar>()));
+    gh.lazySingleton<_i115.AppointmentRepository>(
+        () => _i116.IsarAppointmentRepository(gh<_i46.Isar>()));
+    gh.factory<_i117.AppointmentsCubit>(
+        () => _i117.AppointmentsCubit(gh<_i115.AppointmentRepository>()));
+    gh.lazySingleton<_i118.AuthRepository>(
+        () => _i119.AuthRepositoryImpl(gh<_i46.Isar>()));
+    gh.lazySingleton<_i120.AuthService>(
+        () => _i120.AuthServiceImpl(gh<_i26.EncryptionService>()));
+    gh.lazySingleton<_i121.BleSharingService>(
+        () => _i121.BleSharingService(gh<_i10.BleWrapper>()));
+    gh.lazySingleton<_i122.CancelSharingUseCase>(
+        () => _i122.CancelSharingUseCase(
+              gh<_i121.BleSharingService>(),
+              gh<_i74.NfcSharingService>(),
+              gh<_i110.WifiDirectService>(),
+            ));
+    gh.lazySingleton<_i123.ChatMessageLocalDataSource>(
+        () => _i123.ChatMessageLocalDataSource(gh<_i46.Isar>()));
+    gh.lazySingleton<_i124.CompleteSessionUseCase>(
+        () => _i124.CompleteSessionUseCase(gh<_i68.MeditationRepository>()));
+    gh.factory<_i125.ConnectProviderUseCase>(() => _i125.ConnectProviderUseCase(
+          gh<_i78.OAuthRepository>(),
+          gh<_i98.UserProfileRepository>(),
+        ));
+    gh.lazySingleton<_i126.DashboardRepository>(
+        () => _i127.DashboardRepositoryImpl(
+              gh<_i103.VitalSignRepository>(),
+              gh<_i64.MedicationRepository>(),
+              gh<_i86.ReportRepository>(),
+            ));
+    gh.factory<_i128.DeleteAppointmentUseCase>(() =>
+        _i128.DeleteAppointmentUseCase(gh<_i115.AppointmentRepository>()));
+    gh.factory<_i129.DisconnectProviderUseCase>(
+        () => _i129.DisconnectProviderUseCase(
+              gh<_i78.OAuthRepository>(),
+              gh<_i98.UserProfileRepository>(),
+            ));
+    gh.lazySingleton<_i130.DistributedStorageService>(() => _i131.IpfsService(
+          gh<_i45.IpfsDatasource>(),
+          gh<_i29.FilecoinDatasource>(),
+        ));
+    gh.lazySingleton<_i132.DoctorProfileRepository>(
+        () => _i133.IsarDoctorProfileRepository(gh<_i46.Isar>()));
+    gh.factoryAsync<_i134.DoctorVerificationCubit>(
+        () async => _i134.DoctorVerificationCubit(
+              gh<_i132.DoctorProfileRepository>(),
+              gh<_i83.RatingRepository>(),
+              await getAsync<_i48.LicenseVerifier>(),
+            ));
+    gh.factory<_i135.EmailCitasCubit>(() => _i135.EmailCitasCubit(
+          gh<_i22.EmailRepository>(),
+          gh<_i115.AppointmentRepository>(),
+        ));
+    gh.factory<_i136.FhirSyncCubit>(() => _i136.FhirSyncCubit(
+          gh<_i95.SyncService>(),
+          gh<_i75.NodeDiscoveryService>(),
+        ));
+    gh.lazySingleton<_i90.FileHealthDataSource>(
+        () => _i90.FileHealthDataSourceImpl(
+              gh<_i28.FilePickerService>(),
+              gh<_i80.OcrService>(),
+            ));
+    gh.factory<_i137.GetAllAppointmentsUseCase>(() =>
+        _i137.GetAllAppointmentsUseCase(gh<_i115.AppointmentRepository>()));
+    gh.factory<_i138.GetChatHistoryUseCase>(
+        () => _i138.GetChatHistoryUseCase(gh<_i106.VoiceChatRepository>()));
+    gh.factory<_i139.GetConnectionsUseCase>(
+        () => _i139.GetConnectionsUseCase(gh<_i78.OAuthRepository>()));
+    gh.factory<_i140.GetDashboardStatsUseCase>(
+        () => _i140.GetDashboardStatsUseCase(gh<_i126.DashboardRepository>()));
+    gh.lazySingleton<_i141.GetProgressUseCase>(
+        () => _i141.GetProgressUseCase(gh<_i68.MeditationRepository>()));
+    gh.factory<_i142.GetRecentActivityUseCase>(
+        () => _i142.GetRecentActivityUseCase(gh<_i126.DashboardRepository>()));
+    gh.lazySingleton<_i143.GetScriptsUseCase>(
+        () => _i143.GetScriptsUseCase(gh<_i68.MeditationRepository>()));
+    gh.lazySingleton<_i144.GovernanceIpfsDatasource>(
+        () => _i144.GovernanceIpfsDatasource(gh<_i45.IpfsDatasource>()));
+    gh.lazySingleton<_i145.GovernanceRepository>(() =>
+        _i146.GovernanceRepositoryImpl(gh<_i144.GovernanceIpfsDatasource>()));
+    gh.lazySingleton<_i147.HealthDataFileDataSource>(
+        () => _i147.HealthDataFileDataSource(
+              gh<_i28.FilePickerService>(),
+              gh<_i80.OcrService>(),
+            ));
+    gh.lazySingleton<_i148.HealthDataRepository>(
+        () => _i148.HealthDataRepositoryImpl(
+              gh<_i90.SensorHealthDataSource>(),
+              gh<_i90.FileHealthDataSource>(),
+            ));
+    gh.factory<_i149.HealthImportCubit>(() => _i149.HealthImportCubit(
+          gh<_i35.HealthDataImportService>(),
+          gh<_i103.VitalSignRepository>(),
+        ));
+    gh.lazySingleton<_i150.HealthRecordRepository>(
+        () => _i151.HealthRecordRepositoryImpl(gh<_i46.Isar>()));
+    gh.lazySingleton<_i152.HealthSharingLocalDataSource>(
+        () => _i152.HealthSharingLocalDataSource(gh<_i46.Isar>()));
+    gh.lazySingleton<_i153.HomeRepository>(() => _i154.HomeRepositoryImpl(
+          gh<_i103.VitalSignRepository>(),
+          gh<_i115.AppointmentRepository>(),
+          gh<_i64.MedicationRepository>(),
+        ));
+    gh.factory<_i155.ImportCalendarUseCase>(() => _i155.ImportCalendarUseCase(
+          gh<_i14.CalendarRepository>(),
+          gh<_i115.AppointmentRepository>(),
+          gh<_i98.UserProfileRepository>(),
+        ));
+    gh.lazySingleton<_i49.LlmAdapter>(
+      () => _i156.GeminiLlmAdapter(
+        scrubber: gh<_i82.PromptScrubber>(),
+        userProfileRepository: gh<_i98.UserProfileRepository>(),
+        modelWrapper: gh<_i33.GeminiModelWrapper>(),
+      ),
+      instanceName: 'gemini',
+    );
+    gh.factory<_i49.LlmAdapter>(
+      () => _i157.MockLlmAdapter(gh<_i82.PromptScrubber>()),
+      instanceName: 'mock',
+    );
+    gh.lazySingleton<_i158.LlmService>(() => _i159.GemmaLlmService(
+          gh<_i101.VectorStoreService>(),
+          gh<_i98.UserProfileRepository>(),
+          gh<_i49.LlmAdapter>(instanceName: 'gemma'),
+        ));
+    gh.lazySingleton<_i160.LlmSettingsRepository>(() =>
+        _i161.LlmSettingsRepositoryImpl(gh<_i91.SettingsLocalDataSource>()));
+    gh.lazySingleton<_i162.MedicalResearchService>(
+        () => _i162.MedicalResearchService(
+              gh<_i62.MedicalWebSearchService>(),
+              gh<_i58.MedicalScraperService>(),
+            ));
+    gh.factory<_i163.MeditationCubit>(() => _i163.MeditationCubit(
+          gh<_i85.RecommendScriptUseCase>(),
+          gh<_i92.StartSessionUseCase>(),
+          gh<_i124.CompleteSessionUseCase>(),
+          gh<_i141.GetProgressUseCase>(),
+          gh<_i8.AudioService>(),
+        ));
+    gh.lazySingleton<_i164.OnboardingRepository>(
+        () => _i165.OnboardingRepositoryImpl(gh<_i98.UserProfileRepository>()));
+    gh.lazySingleton<_i166.PatientContextIndexer>(
+      () => _i166.PatientContextIndexer(
+        gh<_i46.Isar>(),
+        gh<_i101.VectorStoreService>(),
+        gh<_i150.HealthRecordRepository>(),
+        gh<_i64.MedicationRepository>(),
+        gh<_i113.AllergyRepository>(),
+        gh<_i103.VitalSignRepository>(),
+        gh<_i115.AppointmentRepository>(),
+      ),
+      dispose: (i) => i.dispose(),
+    );
+    gh.lazySingleton<_i167.ReportGenerationService>(
+        () => _i168.GemmaReportGenerationService(
+              gh<_i49.LlmAdapter>(instanceName: 'gemma'),
+              gh<_i101.VectorStoreService>(),
+              gh<_i98.UserProfileRepository>(),
+              gh<_i82.PromptScrubber>(),
+            ));
+    gh.factory<_i169.SaveAppointmentUseCase>(
+        () => _i169.SaveAppointmentUseCase(gh<_i115.AppointmentRepository>()));
+    gh.factory<_i170.SecondOpinionCubit>(
+        () => _i170.SecondOpinionCubit(gh<_i88.SecondOpinionRepository>()));
+    gh.factory<_i171.SendMessageUseCase>(
+        () => _i171.SendMessageUseCase(gh<_i106.VoiceChatRepository>()));
+    gh.lazySingleton<_i172.SmartSearchUseCase>(
+        () => _i172.SmartSearchUseCase(gh<_i101.VectorStoreService>()));
+    gh.lazySingleton<_i173.StartListeningUseCase>(
+        () => _i173.StartListeningUseCase(
+              gh<_i121.BleSharingService>(),
+              gh<_i74.NfcSharingService>(),
+              gh<_i110.WifiDirectService>(),
+            ));
+    gh.lazySingleton<_i174.StartSharingUseCase>(() => _i174.StartSharingUseCase(
+          gh<_i121.BleSharingService>(),
+          gh<_i74.NfcSharingService>(),
+          gh<_i110.WifiDirectService>(),
+        ));
+    gh.factory<_i175.SyncCubit>(() => _i175.SyncCubit(
+          gh<_i54.SyncService>(),
+          gh<_i101.VectorStoreService>(),
+        ));
+    gh.factory<_i176.UserProfileCubit>(
+        () => _i176.UserProfileCubit(gh<_i98.UserProfileRepository>()));
+    gh.factory<_i177.VoiceChatCubit>(() => _i177.VoiceChatCubit(
+          gh<_i171.SendMessageUseCase>(),
+          gh<_i138.GetChatHistoryUseCase>(),
+          gh<_i106.VoiceChatRepository>(),
+          gh<_i8.AudioService>(),
+        ));
+    gh.factory<_i178.VouchCubit>(
+        () => _i178.VouchCubit(gh<_i108.VouchRepository>()));
+    gh.factory<_i179.AllergiesCubit>(
+        () => _i179.AllergiesCubit(gh<_i113.AllergyRepository>()));
+    gh.factory<_i180.AuthCubit>(() => _i180.AuthCubit(
+          gh<_i118.AuthRepository>(),
+          gh<_i26.EncryptionService>(),
+          gh<_i9.BiometricService>(),
+        ));
+    gh.factory<_i181.AuthCubit>(() => _i181.AuthCubit(gh<_i120.AuthService>()));
+    gh.lazySingleton<_i182.BadgeCalculator>(() => _i182.BadgeCalculator(
+          gh<_i132.DoctorProfileRepository>(),
+          gh<_i83.RatingRepository>(),
+          gh<_i108.VouchRepository>(),
+        ));
+    gh.factory<_i183.BadgeCubit>(
+        () => _i183.BadgeCubit(gh<_i182.BadgeCalculator>()));
+    gh.factory<_i184.CalendarImportCubit>(() => _i184.CalendarImportCubit(
+          gh<_i14.CalendarRepository>(),
+          gh<_i155.ImportCalendarUseCase>(),
+        ));
+    gh.factory<_i185.DashboardCubit>(() => _i185.DashboardCubit(
+          gh<_i140.GetDashboardStatsUseCase>(),
+          gh<_i142.GetRecentActivityUseCase>(),
+        ));
+    gh.lazySingleton<_i186.DistributedCacheUsecase>(() =>
+        _i186.DistributedCacheUsecase(gh<_i130.DistributedStorageService>()));
+    gh.factory<_i187.EpsConnectionCubit>(() => _i187.EpsConnectionCubit(
+          gh<_i139.GetConnectionsUseCase>(),
+          gh<_i125.ConnectProviderUseCase>(),
+          gh<_i129.DisconnectProviderUseCase>(),
+        ));
+    gh.factory<_i188.GetHealthSummaryUseCase>(
+        () => _i188.GetHealthSummaryUseCase(gh<_i153.HomeRepository>()));
+    gh.factory<_i189.HealthRecordCubit>(() => _i189.HealthRecordCubit(
+          gh<_i150.HealthRecordRepository>(),
+          gh<_i28.FilePickerService>(),
+          gh<_i41.ImagePickerService>(),
+          gh<_i80.OcrService>(),
+          gh<_i101.VectorStoreService>(),
+        ));
+    gh.factory<_i190.HomeCubit>(() => _i190.HomeCubit(
+          gh<_i188.GetHealthSummaryUseCase>(),
+          gh<_i153.HomeRepository>(),
+        ));
+    gh.lazySingleton<_i191.LlmAdapterFactory>(
+        () => _i191.LlmAdapterFactory(gh<_i160.LlmSettingsRepository>()));
+    gh.lazySingleton<_i158.LlmService>(
+      () => _i192.RagLlmService(
+        gh<_i101.VectorStoreService>(),
+        gh<_i162.MedicalResearchService>(),
+        gh<_i98.UserProfileRepository>(),
+        gh<_i49.LlmAdapter>(instanceName: 'gemma'),
+      ),
+      instanceName: 'rag',
+    );
+    gh.factory<_i193.LlmSettingsCubit>(() => _i193.LlmSettingsCubit(
+          gh<_i160.LlmSettingsRepository>(),
+          gh<_i19.DeviceCapabilityService>(),
+          gh<_i49.LlmAdapter>(instanceName: 'gemma'),
+        ));
+    gh.lazySingleton<_i194.MedicalIndexingService>(
+        () => _i194.MedicalIndexingService(
+              gh<_i55.MedicalKnowledgeRepository>(),
+              gh<_i101.VectorStoreService>(),
+              gh<_i166.PatientContextIndexer>(),
+            ));
+    gh.factory<_i195.MedicalResearchCubit>(() => _i195.MedicalResearchCubit(
+          gh<_i162.MedicalResearchService>(),
+          gh<_i60.MedicalStandardsService>(),
+        ));
+    gh.factory<_i196.ReportBloc>(() => _i196.ReportBloc(
+          gh<_i86.ReportRepository>(),
+          gh<_i167.ReportGenerationService>(),
+        ));
+    gh.factory<_i197.SharingCubit>(() => _i197.SharingCubit(
+          bleService: gh<_i121.BleSharingService>(),
+          nfcService: gh<_i74.NfcSharingService>(),
+          wifiService: gh<_i110.WifiDirectService>(),
+          startSharingUseCase: gh<_i174.StartSharingUseCase>(),
+          startListeningUseCase: gh<_i173.StartListeningUseCase>(),
+          cancelSharingUseCase: gh<_i122.CancelSharingUseCase>(),
+          walletService: gh<_i25.WalletService>(),
+          walletEncryption: gh<_i25.EncryptionService>(),
+        ));
+    return this;
+  }
+}
+
+class _$ServiceModule extends _i198.ServiceModule {}
+
+class _$CalendarModule extends _i199.CalendarModule {}
+
+class _$NetworkModule extends _i200.NetworkModule {}
+
+class _$MemoryModule extends _i201.MemoryModule {}
+
+class _$DatabaseModule extends _i202.DatabaseModule {}
+
+class _$FhirModule extends _i203.FhirModule {}

--- a/lib/core/di/service_module.dart
+++ b/lib/core/di/service_module.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:http/http.dart' as http;
-import 'package:device_calendar/device_calendar.dart';
 import 'package:injectable/injectable.dart';
 
 @module
@@ -14,7 +13,4 @@ abstract class ServiceModule {
 
   @lazySingleton
   http.Client get httpClient => http.Client();
-
-  @lazySingleton
-  DeviceCalendarPlugin get deviceCalendarPlugin => DeviceCalendarPlugin();
 }

--- a/lib/features/sync/application/sync_cubit.dart
+++ b/lib/features/sync/application/sync_cubit.dart
@@ -2,8 +2,8 @@ import 'dart:async';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import '../domain/services/sync_service.dart';
+import '../domain/services/node_discovery_service.dart';
 import '../domain/entities/sync_node.dart';
-import '../infrastructure/services/node_discovery_service.dart';
 import 'sync_state.dart';
 
 @injectable
@@ -24,23 +24,12 @@ class FhirSyncCubit extends Cubit<SyncState> {
 
   void _listenToDiscoveredNodes() {
     _nodesSubscription?.cancel();
-    _nodesSubscription = _nodeDiscoveryService.discoveredNodes.listen((bonsoirNodes) {
-      final syncNodes = bonsoirNodes.map((node) => SyncNode(
-        id: node.attributes['nodeId'] ?? node.name,
-        name: node.name,
-        host: node.hostname ?? 'unknown',
-        port: node.port,
-      )).toList();
+    _nodesSubscription = _nodeDiscoveryService.discoveredNodes.listen((syncNodes) {
       emit(state.copyWith(discoveredNodes: syncNodes));
     });
 
     // Initial nodes
-    final initialNodes = _nodeDiscoveryService.currentNodes.map((node) => SyncNode(
-      id: node.attributes['nodeId'] ?? node.name,
-      name: node.name,
-      host: node.hostname ?? 'unknown',
-      port: node.port,
-    )).toList();
+    final initialNodes = _nodeDiscoveryService.currentNodes;
     if (initialNodes.isNotEmpty) {
       emit(state.copyWith(discoveredNodes: initialNodes));
     }

--- a/lib/features/sync/domain/services/distributed_storage_service.dart
+++ b/lib/features/sync/domain/services/distributed_storage_service.dart
@@ -1,0 +1,10 @@
+import 'dart:typed_data';
+
+/// Interface for distributed storage operations (IPFS/Filecoin).
+abstract class DistributedStorageService {
+  /// Caches data on distributed storage and returns its CID.
+  Future<String> cacheData(Uint8List data, {bool backupToFilecoin = false});
+
+  /// Retrieves data from distributed storage and verifies its integrity.
+  Future<Uint8List> getData(String cid, String expectedHash);
+}

--- a/lib/features/sync/domain/services/node_discovery_service.dart
+++ b/lib/features/sync/domain/services/node_discovery_service.dart
@@ -1,0 +1,16 @@
+import '../entities/sync_node.dart';
+
+/// Interface for discovering OrionHealth nodes on the local network.
+abstract class NodeDiscoveryService {
+  /// Stream of discovered nodes.
+  Stream<List<SyncNode>> get discoveredNodes;
+
+  /// Returns the current list of discovered nodes.
+  List<SyncNode> get currentNodes;
+
+  /// Starts advertising this node and browsing for others.
+  Future<void> start(String nodeId, int port);
+
+  /// Stops advertising and discovery.
+  Future<void> stop();
+}

--- a/lib/features/sync/domain/usecases/distributed_cache_usecase.dart
+++ b/lib/features/sync/domain/usecases/distributed_cache_usecase.dart
@@ -1,30 +1,30 @@
 import 'dart:typed_data';
 import 'package:injectable/injectable.dart';
-import '../../infrastructure/services/ipfs_service.dart';
+import '../services/distributed_storage_service.dart';
 
 @lazySingleton
 class DistributedCacheUsecase {
-  final IpfsService _ipfsService;
+  final DistributedStorageService _storageService;
 
-  DistributedCacheUsecase(this._ipfsService);
+  DistributedCacheUsecase(this._storageService);
 
-  /// Caches a medical standard chunk on IPFS.
+  /// Caches a medical standard chunk on distributed storage.
   Future<String?> cacheStandard(Uint8List data) async {
     try {
-      return await _ipfsService.cacheData(data);
+      return await _storageService.cacheData(data);
     } catch (e) {
-      // Gracefully degrade if IPFS is unavailable
+      // Gracefully degrade if distributed storage is unavailable
       print('Distributed cache failed: $e. Falling back to direct storage/download.');
       return null;
     }
   }
 
-  /// Retrieves a medical standard from IPFS with fallback.
+  /// Retrieves a medical standard from distributed storage with fallback.
   Future<Uint8List> getStandard(String cid, String expectedHash, Future<Uint8List> Function() fallback) async {
     try {
-      return await _ipfsService.getData(cid, expectedHash);
+      return await _storageService.getData(cid, expectedHash);
     } catch (e) {
-      print('IPFS retrieval failed: $e. Using fallback.');
+      print('Distributed storage retrieval failed: $e. Using fallback.');
       return await fallback();
     }
   }

--- a/lib/features/sync/infrastructure/repositories/sync_repository_impl.dart
+++ b/lib/features/sync/infrastructure/repositories/sync_repository_impl.dart
@@ -9,6 +9,7 @@ import 'package:isar/isar.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../domain/entities/sync_node.dart';
 import '../../domain/repositories/sync_repository.dart';
+import '../../domain/services/node_discovery_service.dart';
 import '../../../user_profile/domain/entities/user_profile.dart';
 import '../../../medications/domain/entities/medication.dart' as app_med;
 import '../../../allergies/domain/entities/allergy.dart';
@@ -16,7 +17,6 @@ import '../../../vitals/domain/entities/vital_sign.dart' as app_vital;
 import '../services/fhir_client.dart';
 import '../services/fhir_mapper.dart';
 import '../services/rda_parser.dart';
-import '../services/node_discovery_service.dart';
 
 @LazySingleton(as: SyncRepository)
 class SyncRepositoryImpl implements SyncRepository {
@@ -53,11 +53,13 @@ class SyncRepositoryImpl implements SyncRepository {
         : null;
   }
 
+  @override
   Future<void> setLastSyncTime(DateTime time) async {
     final prefs = await SharedPreferences.getInstance();
     await prefs.setInt(_lastSyncKey, time.millisecondsSinceEpoch);
   }
 
+  @override
   Future<void> syncPatient(
     String patientId,
     String token,
@@ -77,6 +79,7 @@ class SyncRepositoryImpl implements SyncRepository {
     }
   }
 
+  @override
   Future<void> syncRda(String patientId, String token) async {
     try {
       final rdaBundle = await _fhirClient.getRDA(patientId, token);
@@ -178,14 +181,7 @@ class SyncRepositoryImpl implements SyncRepository {
 
   @override
   List<SyncNode> getDiscoveredNodes() {
-    return _discoveryService.currentNodes
-        .map((node) => SyncNode(
-              id: node.attributes['nodeId'] ?? node.name,
-              name: node.name,
-              host: node.hostname ?? 'unknown',
-              port: node.port,
-            ))
-        .toList();
+    return _discoveryService.currentNodes;
   }
 
   @override

--- a/lib/features/sync/infrastructure/services/ipfs_service.dart
+++ b/lib/features/sync/infrastructure/services/ipfs_service.dart
@@ -1,17 +1,19 @@
 import 'dart:typed_data';
 import 'package:crypto/crypto.dart';
 import 'package:injectable/injectable.dart';
+import '../../domain/services/distributed_storage_service.dart';
 import '../datasources/ipfs_datasource.dart';
 import '../datasources/filecoin_datasource.dart';
 
-@lazySingleton
-class IpfsService {
+@LazySingleton(as: DistributedStorageService)
+class IpfsService implements DistributedStorageService {
   final IpfsDatasource _ipfsDatasource;
   final FilecoinDatasource _filecoinDatasource;
 
   IpfsService(this._ipfsDatasource, this._filecoinDatasource);
 
   /// Caches data on IPFS and pins it. Optionally backs up to Filecoin.
+  @override
   Future<String> cacheData(Uint8List data, {bool backupToFilecoin = false}) async {
     final cid = await _ipfsDatasource.add(data);
     await _ipfsDatasource.pin(cid);
@@ -24,6 +26,7 @@ class IpfsService {
   }
 
   /// Retrieves data from IPFS and verifies integrity.
+  @override
   Future<Uint8List> getData(String cid, String expectedHash) async {
     final data = await _ipfsDatasource.get(cid);
 

--- a/lib/features/sync/infrastructure/services/node_discovery_service.dart
+++ b/lib/features/sync/infrastructure/services/node_discovery_service.dart
@@ -1,22 +1,28 @@
 import 'dart:async';
 import 'package:bonsoir/bonsoir.dart';
 import 'package:injectable/injectable.dart';
+import '../../domain/entities/sync_node.dart';
+import '../../domain/services/node_discovery_service.dart' as domain;
 
 /// Service for discovering OrionHealth nodes on the local network using mDNS.
-@lazySingleton
-class NodeDiscoveryService {
+@LazySingleton(as: domain.NodeDiscoveryService)
+class NodeDiscoveryService implements domain.NodeDiscoveryService {
   static const String _serviceType = '_orion-sync._tcp';
 
   BonsoirBroadcast? _broadcast;
   BonsoirDiscovery? _discovery;
 
-  final _discoveredNodesController = StreamController<List<BonsoirService>>.broadcast();
-  final Map<String, BonsoirService> _nodes = {};
+  final _discoveredNodesController = StreamController<List<SyncNode>>.broadcast();
+  final Map<String, SyncNode> _nodes = {};
 
-  Stream<List<BonsoirService>> get discoveredNodes => _discoveredNodesController.stream;
-  List<BonsoirService> get currentNodes => _nodes.values.toList();
+  @override
+  Stream<List<SyncNode>> get discoveredNodes => _discoveredNodesController.stream;
+
+  @override
+  List<SyncNode> get currentNodes => _nodes.values.toList();
 
   /// Starts advertising this node and browsing for others.
+  @override
   Future<void> start(String nodeId, int port) async {
     // 1. Broadcast our presence
     final service = BonsoirService(
@@ -39,7 +45,8 @@ class NodeDiscoveryService {
           event.service.resolve(resolver);
         }
       } else if (event is BonsoirDiscoveryServiceResolvedEvent) {
-        _nodes[event.service.name] = event.service;
+        final syncNode = _mapToSyncNode(event.service);
+        _nodes[event.service.name] = syncNode;
         _notify();
       } else if (event is BonsoirDiscoveryServiceLostEvent) {
         _nodes.remove(event.service.name);
@@ -55,10 +62,20 @@ class NodeDiscoveryService {
   }
 
   /// Stops advertising and discovery.
+  @override
   Future<void> stop() async {
     await _broadcast?.stop();
     await _discovery?.stop();
     _nodes.clear();
     _notify();
+  }
+
+  SyncNode _mapToSyncNode(BonsoirService node) {
+    return SyncNode(
+      id: node.attributes['nodeId'] ?? node.name,
+      name: node.name,
+      host: node.hostname ?? 'unknown',
+      port: node.port,
+    );
   }
 }

--- a/test/features/sync/application/fhir_sync_cubit_test.dart
+++ b/test/features/sync/application/fhir_sync_cubit_test.dart
@@ -1,0 +1,81 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/sync/application/sync_cubit.dart';
+import 'package:orionhealth_health/features/sync/application/sync_state.dart';
+import 'package:orionhealth_health/features/sync/domain/entities/sync_node.dart';
+import 'package:orionhealth_health/features/sync/domain/services/sync_service.dart';
+import 'package:orionhealth_health/features/sync/domain/services/node_discovery_service.dart';
+
+class MockSyncService extends Mock implements SyncService {}
+class MockNodeDiscoveryService extends Mock implements NodeDiscoveryService {}
+
+void main() {
+  late FhirSyncCubit cubit;
+  late MockSyncService mockSyncService;
+  late MockNodeDiscoveryService mockNodeDiscoveryService;
+  late StreamController<List<SyncNode>> nodesController;
+
+  setUp(() {
+    mockSyncService = MockSyncService();
+    mockNodeDiscoveryService = MockNodeDiscoveryService();
+    nodesController = StreamController<List<SyncNode>>.broadcast();
+
+    when(() => mockSyncService.getLastSyncTime()).thenAnswer((_) async => null);
+    when(() => mockNodeDiscoveryService.discoveredNodes).thenAnswer((_) => nodesController.stream);
+    when(() => mockNodeDiscoveryService.currentNodes).thenReturn([]);
+
+    cubit = FhirSyncCubit(mockSyncService, mockNodeDiscoveryService);
+  });
+
+  tearDown(() {
+    nodesController.close();
+    cubit.close();
+  });
+
+  test('initial state is correct', () {
+    expect(cubit.state, const SyncState());
+  });
+
+  test('loads last sync time on initialization', () async {
+    final lastSync = DateTime(2023, 1, 1);
+    when(() => mockSyncService.getLastSyncTime()).thenAnswer((_) async => lastSync);
+
+    // Re-initialize to trigger constructor logic with the new mock value
+    cubit = FhirSyncCubit(mockSyncService, mockNodeDiscoveryService);
+
+    await Future.delayed(Duration.zero);
+    expect(cubit.state.lastSyncTime, lastSync);
+  });
+
+  test('updates discovered nodes when service emits new nodes', () async {
+    final nodes = [
+      const SyncNode(id: '1', name: 'Node 1', host: '192.168.1.1', port: 8080),
+    ];
+
+    nodesController.add(nodes);
+
+    await Future.delayed(Duration.zero);
+    expect(cubit.state.discoveredNodes, nodes);
+  });
+
+  test('performSync updates status to success on completion', () async {
+    when(() => mockSyncService.performFullSync()).thenAnswer((_) async {});
+    final lastSync = DateTime.now();
+    when(() => mockSyncService.getLastSyncTime()).thenAnswer((_) async => lastSync);
+
+    await cubit.performSync();
+
+    expect(cubit.state.status, SyncStatus.success);
+    expect(cubit.state.lastSyncTime, lastSync);
+  });
+
+  test('performSync updates status to failure on error', () async {
+    when(() => mockSyncService.performFullSync()).thenThrow(Exception('Sync failed'));
+
+    await cubit.performSync();
+
+    expect(cubit.state.status, SyncStatus.failure);
+    expect(cubit.state.errorMessage, 'Exception: Sync failed');
+  });
+}

--- a/test/features/sync/domain/usecases/distributed_cache_usecase_test.dart
+++ b/test/features/sync/domain/usecases/distributed_cache_usecase_test.dart
@@ -1,91 +1,64 @@
 import 'dart:typed_data';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/sync/domain/services/distributed_storage_service.dart';
 import 'package:orionhealth_health/features/sync/domain/usecases/distributed_cache_usecase.dart';
-import 'package:orionhealth_health/features/sync/infrastructure/services/ipfs_service.dart';
 
-class MockIpfsService extends Mock implements IpfsService {}
+class MockDistributedStorageService extends Mock implements DistributedStorageService {}
 
 void main() {
   late DistributedCacheUsecase usecase;
-  late MockIpfsService mockIpfsService;
+  late MockDistributedStorageService mockStorageService;
 
   setUp(() {
-    mockIpfsService = MockIpfsService();
-    usecase = DistributedCacheUsecase(mockIpfsService);
+    mockStorageService = MockDistributedStorageService();
+    usecase = DistributedCacheUsecase(mockStorageService);
   });
 
-  final testData = Uint8List.fromList([1, 2, 3, 4, 5]);
-  const testCid = 'QmTest123';
+  group('cacheStandard', () {
+    test('returns CID on success', () async {
+      final data = Uint8List.fromList([1, 2, 3]);
+      const cid = 'QmTest';
+      when(() => mockStorageService.cacheData(data)).thenAnswer((_) async => cid);
 
-  group('DistributedCacheUsecase', () {
-    group('cacheStandard', () {
-      test('should return CID when IPFS caching succeeds', () async {
-        when(() => mockIpfsService.cacheData(testData))
-            .thenAnswer((_) async => testCid);
+      final result = await usecase.cacheStandard(data);
 
-        final result = await usecase.cacheStandard(testData);
-
-        expect(result, testCid);
-        verify(() => mockIpfsService.cacheData(testData)).called(1);
-      });
-
-      test('should return null when IPFS caching fails', () async {
-        when(() => mockIpfsService.cacheData(testData))
-            .thenThrow(Exception('IPFS unavailable'));
-
-        final result = await usecase.cacheStandard(testData);
-
-        expect(result, isNull);
-        verify(() => mockIpfsService.cacheData(testData)).called(1);
-      });
+      expect(result, cid);
+      verify(() => mockStorageService.cacheData(data)).called(1);
     });
 
-    group('getStandard', () {
-      const expectedHash = 'abc123hash';
-      final fallbackData = Uint8List.fromList([10, 11, 12]);
+    test('returns null on failure', () async {
+      final data = Uint8List.fromList([1, 2, 3]);
+      when(() => mockStorageService.cacheData(data)).thenThrow(Exception('Storage error'));
 
-      test('should return data from IPFS when retrieval succeeds', () async {
-        when(() => mockIpfsService.getData(testCid, expectedHash))
-            .thenAnswer((_) async => testData);
+      final result = await usecase.cacheStandard(data);
 
-        final result = await usecase.getStandard(
-          testCid,
-          expectedHash,
-          () async => fallbackData,
-        );
+      expect(result, isNull);
+    });
+  });
 
-        expect(result, testData);
-        verify(() => mockIpfsService.getData(testCid, expectedHash)).called(1);
-      });
+  group('getStandard', () {
+    test('returns data from storage on success', () async {
+      final data = Uint8List.fromList([1, 2, 3]);
+      const cid = 'QmTest';
+      const hash = 'hash';
+      when(() => mockStorageService.getData(cid, hash)).thenAnswer((_) async => data);
 
-      test('should return fallback data when IPFS retrieval fails', () async {
-        when(() => mockIpfsService.getData(testCid, expectedHash))
-            .thenThrow(Exception('IPFS retrieval failed'));
+      final result = await usecase.getStandard(cid, hash, () async => Uint8List(0));
 
-        final result = await usecase.getStandard(
-          testCid,
-          expectedHash,
-          () async => fallbackData,
-        );
+      expect(result, data);
+      verify(() => mockStorageService.getData(cid, hash)).called(1);
+    });
 
-        expect(result, fallbackData);
-        verify(() => mockIpfsService.getData(testCid, expectedHash)).called(1);
-      });
+    test('returns fallback data on storage failure', () async {
+      final fallbackData = Uint8List.fromList([4, 5, 6]);
+      const cid = 'QmTest';
+      const hash = 'hash';
+      when(() => mockStorageService.getData(cid, hash)).thenThrow(Exception('Storage error'));
 
-      test('should propagate fallback exceptions', () async {
-        when(() => mockIpfsService.getData(testCid, expectedHash))
-            .thenThrow(Exception('IPFS retrieval failed'));
+      final result = await usecase.getStandard(cid, hash, () async => fallbackData);
 
-        expect(
-          () => usecase.getStandard(
-            testCid,
-            expectedHash,
-            () async => throw Exception('Fallback also failed'),
-          ),
-          throwsA(isA<Exception>()),
-        );
-      });
+      expect(result, fallbackData);
     });
   });
 }

--- a/test/features/sync/infrastructure/repositories/sync_repository_impl_test.dart
+++ b/test/features/sync/infrastructure/repositories/sync_repository_impl_test.dart
@@ -1,11 +1,11 @@
-import 'package:bonsoir/bonsoir.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:isar/isar.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/sync/domain/entities/sync_node.dart';
 import 'package:orionhealth_health/features/sync/infrastructure/services/fhir_client.dart';
-import 'package:orionhealth_health/features/sync/infrastructure/repositories/sync_repository.dart';
-import 'package:orionhealth_health/features/sync/infrastructure/services/node_discovery_service.dart';
+import 'package:orionhealth_health/features/sync/infrastructure/repositories/sync_repository_impl.dart';
+import 'package:orionhealth_health/features/sync/domain/services/node_discovery_service.dart';
 import 'package:orionhealth_health/features/sync/domain/repositories/sync_repository.dart';
 import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
 import 'package:orionhealth_health/features/medications/domain/entities/medication.dart';
@@ -17,7 +17,6 @@ import 'dart:io';
 class MockFhirClient extends Mock implements FhirClient {}
 class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
 class MockNodeDiscoveryService extends Mock implements NodeDiscoveryService {}
-class MockBonsoirService extends Mock implements BonsoirService {}
 
 void main() {
   late SyncRepository syncRepository;
@@ -97,15 +96,16 @@ void main() {
     });
 
     test('getDiscoveredNodes returns mapped nodes from discovery service', () async {
-      final mockNode = MockBonsoirService();
-      when(() => mockNode.name).thenReturn('Node1');
-      when(() => mockNode.hostname).thenReturn('192.168.1.5');
-      when(() => mockNode.port).thenReturn(9124);
-      when(() => mockNode.attributes).thenReturn({'nodeId': 'id123'});
+      const mockNode = SyncNode(
+        id: 'id123',
+        name: 'Node1',
+        host: '192.168.1.5',
+        port: 9124,
+      );
 
       when(() => mockDiscoveryService.currentNodes).thenReturn([mockNode]);
 
-      final result = await syncRepository.getDiscoveredNodes();
+      final result = syncRepository.getDiscoveredNodes();
 
       expect(result.length, 1);
       expect(result.first.id, 'id123');


### PR DESCRIPTION
This PR completes the Clean Architecture transition for the sync feature.

Key changes:
- Created domain interfaces in `lib/features/sync/domain/services/` to abstract node discovery and distributed storage.
- Refactored `FhirSyncCubit` to use these domain interfaces, removing dependencies on infrastructure-specific types (like `BonsoirService`).
- Standardized dependency injection by consolidating common service registrations (HTTP client, calendar plugin) and using them in feature modules.
- Renamed and updated the infrastructure repository implementation to align with domain requirements.
- Added and fixed unit tests to ensure architectural integrity and functional correctness.

Fixes #825

---
*PR created automatically by Jules for task [8208657904933650499](https://jules.google.com/task/8208657904933650499) started by @iberi22*