### PR TITLE
Add Bloc/Cubit Unit Tests for Multiple Features

### DIFF
--- a/test/features/allergies/application/bloc/allergy_event_test.dart
+++ b/test/features/allergies/application/bloc/allergy_event_test.dart
@@ -1,0 +1,20 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/allergies/application/bloc/allergy_bloc.dart';
+import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
+
+void main() {
+  group('AllergyEvent', () {
+    test('LoadAllergies supports value equality', () {
+      expect(LoadAllergies(), isA<LoadAllergies>());
+    });
+
+    test('SaveAllergy supports value equality', () {
+      final allergy = Allergy(id: 1, allergen: 'Peanuts');
+      expect(SaveAllergy(allergy), isA<SaveAllergy>());
+    });
+
+    test('DeleteAllergy supports value equality', () {
+      expect(DeleteAllergy(1), isA<DeleteAllergy>());
+    });
+  });
+}

--- a/test/features/allergies/application/bloc/allergy_state_test.dart
+++ b/test/features/allergies/application/bloc/allergy_state_test.dart
@@ -1,0 +1,24 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/allergies/application/bloc/allergy_bloc.dart';
+import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
+
+void main() {
+  group('AllergyState', () {
+    test('initial supports value equality', () {
+      expect(const AllergyState.initial(), const AllergyState.initial());
+    });
+
+    test('loading supports value equality', () {
+      expect(const AllergyState.loading(), const AllergyState.loading());
+    });
+
+    test('loaded supports value equality', () {
+      final allergies = [Allergy(id: 1, allergen: 'Peanuts')];
+      expect(AllergyState.loaded(allergies), AllergyState.loaded(allergies));
+    });
+
+    test('error supports value equality', () {
+      expect(const AllergyState.error('error'), const AllergyState.error('error'));
+    });
+  });
+}

--- a/test/features/appointments/application/bloc/appointment_event_test.dart
+++ b/test/features/appointments/application/bloc/appointment_event_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/appointments/application/bloc/appointment_bloc.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+
+void main() {
+  group('AppointmentEvent', () {
+    test('LoadAppointments supports value equality', () {
+      expect(LoadAppointments(), isA<LoadAppointments>());
+    });
+
+    test('SaveAppointment supports value equality', () {
+      final appointment = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardiology',
+        dateTime: DateTime.now(),
+        status: AppointmentStatus.upcoming,
+      );
+      expect(SaveAppointment(appointment), isA<SaveAppointment>());
+    });
+
+    test('DeleteAppointment supports value equality', () {
+      expect(DeleteAppointment(1), isA<DeleteAppointment>());
+    });
+  });
+}

--- a/test/features/appointments/application/bloc/appointment_state_test.dart
+++ b/test/features/appointments/application/bloc/appointment_state_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/appointments/application/bloc/appointment_bloc.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+
+void main() {
+  group('AppointmentState', () {
+    test('initial supports value equality', () {
+      expect(const AppointmentState.initial(), const AppointmentState.initial());
+    });
+
+    test('loading supports value equality', () {
+      expect(const AppointmentState.loading(), const AppointmentState.loading());
+    });
+
+    test('loaded supports value equality', () {
+      final appointments = <Appointment>[
+        Appointment(
+          doctorName: 'Dr. Smith',
+          specialty: 'Cardiology',
+          dateTime: DateTime.now(),
+          status: AppointmentStatus.upcoming,
+        )
+      ];
+      expect(AppointmentState.loaded(appointments), AppointmentState.loaded(appointments));
+    });
+
+    test('error supports value equality', () {
+      expect(const AppointmentState.error('error'), const AppointmentState.error('error'));
+    });
+  });
+}

--- a/test/features/auth/application/auth_state_test.dart
+++ b/test/features/auth/application/auth_state_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/auth/application/auth_state.dart';
+
+void main() {
+  group('AuthState', () {
+    test('supports value equality', () {
+      expect(
+        const AuthState(),
+        const AuthState(),
+      );
+    });
+
+    test('props are correct', () {
+      final now = DateTime.now();
+      final state = AuthState(
+        status: AuthStatus.authenticated,
+        error: 'error',
+        isPinSet: true,
+        isBiometricAvailable: true,
+        lastAuthTime: now,
+      );
+
+      expect(
+        state.props,
+        [AuthStatus.authenticated, 'error', true, true, now],
+      );
+    });
+
+    test('copyWith works correctly', () {
+      final now = DateTime.now();
+      const state = AuthState();
+      final newState = state.copyWith(
+        status: AuthStatus.authenticated,
+        error: 'error',
+        isPinSet: true,
+        isBiometricAvailable: true,
+        lastAuthTime: now,
+      );
+
+      expect(newState.status, AuthStatus.authenticated);
+      expect(newState.error, 'error');
+      expect(newState.isPinSet, true);
+      expect(newState.isBiometricAvailable, true);
+      expect(newState.lastAuthTime, now);
+    });
+
+    test('copyWith null values doesn\'t change state if not specified', () {
+      const state = AuthState(status: AuthStatus.authenticated, isPinSet: true);
+      final newState = state.copyWith();
+
+      expect(newState.status, AuthStatus.authenticated);
+      expect(newState.isPinSet, true);
+    });
+  });
+}

--- a/test/features/email-citas/application/bloc/email_citas_bloc_test.dart
+++ b/test/features/email-citas/application/bloc/email_citas_bloc_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/email-citas/application/bloc/email_citas_bloc.dart';
+import 'package:orionhealth_health/features/email-citas/application/bloc/email_citas_event.dart';
+import 'package:orionhealth_health/features/email-citas/application/email_citas_state.dart';
+import 'package:orionhealth_health/features/email-citas/domain/repositories/email_repository.dart';
+import 'package:orionhealth_health/features/email-citas/domain/usecases/email_citas_usecases.dart';
+import 'package:orionhealth_health/features/appointments/domain/repositories/appointment_repository.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+
+class MockConnectEmailProviderUseCase extends Mock implements ConnectEmailProviderUseCase {}
+class MockSyncEmailAppointmentsUseCase extends Mock implements SyncEmailAppointmentsUseCase {}
+class MockEmailRepository extends Mock implements EmailRepository {}
+class MockAppointmentRepository extends Mock implements AppointmentRepository {}
+class FakeAppointment extends Fake implements Appointment {}
+
+void main() {
+  late EmailCitasBloc bloc;
+  late MockConnectEmailProviderUseCase mockConnectUseCase;
+  late MockSyncEmailAppointmentsUseCase mockSyncUseCase;
+  late MockEmailRepository mockEmailRepository;
+  late MockAppointmentRepository mockAppointmentRepository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeAppointment());
+  });
+
+  setUp(() {
+    mockConnectUseCase = MockConnectEmailProviderUseCase();
+    mockSyncUseCase = MockSyncEmailAppointmentsUseCase();
+    mockEmailRepository = MockEmailRepository();
+    mockAppointmentRepository = MockAppointmentRepository();
+    bloc = EmailCitasBloc(
+      mockConnectUseCase,
+      mockSyncUseCase,
+      mockEmailRepository,
+      mockAppointmentRepository,
+    );
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('EmailCitasBloc', () {
+    test('initial state should be EmailCitasInitial', () {
+      expect(bloc.state, const EmailCitasInitial());
+    });
+
+    test('ConnectGmail emits error if usecase fails', () async {
+      when(() => mockConnectUseCase(any())).thenAnswer((_) async => false);
+
+      final expectation = expectLater(
+        bloc.stream,
+        emitsInOrder([
+          const EmailCitasError('No se pudo abrir la página de conexión de Gmail'),
+        ]),
+      );
+
+      bloc.add(const ConnectGmail());
+      await expectation;
+    });
+
+    test('ConnectOutlook emits error if usecase fails', () async {
+      when(() => mockConnectUseCase(any())).thenAnswer((_) async => false);
+
+      final expectation = expectLater(
+        bloc.stream,
+        emitsInOrder([
+          const EmailCitasError('No se pudo abrir la página de conexión de Outlook'),
+        ]),
+      );
+
+      bloc.add(const ConnectOutlook());
+      await expectation;
+    });
+
+    test('HandleOAuthRedirect sets state and triggers sync', () async {
+      when(() => mockConnectUseCase(any())).thenAnswer((_) async => true);
+      when(() => mockSyncUseCase(any(), any())).thenAnswer((_) async => []);
+
+      bloc.add(const ConnectGmail()); // Set pending provider
+
+      final uri = Uri.parse('orionhealth://oauth2redirect?code=test_code');
+
+      final expectation = expectLater(
+        bloc.stream,
+        emitsInOrder([
+          const EmailCitasConnected(isGmailConnected: true),
+          const EmailCitasLoading(),
+          const EmailCitasSyncSuccess(),
+          const EmailCitasConnected(isGmailConnected: true),
+        ]),
+      );
+
+      bloc.add(HandleOAuthRedirect(uri));
+      await expectation;
+    });
+
+    test('SyncAppointments saves appointments and syncs to calendar', () async {
+      final tAppointment = Appointment(
+        doctorName: 'Dr. Test',
+        specialty: 'Test',
+        dateTime: DateTime.now(),
+        status: AppointmentStatus.upcoming,
+      );
+
+      when(() => mockConnectUseCase(any())).thenAnswer((_) async => true);
+      when(() => mockSyncUseCase(any(), any())).thenAnswer((_) async => [tAppointment]);
+      when(() => mockAppointmentRepository.saveAppointment(any())).thenAnswer((_) async => 1);
+      when(() => mockEmailRepository.syncToNativeCalendar(any())).thenAnswer((_) async => true);
+
+      bloc.add(const ConnectGmail());
+      bloc.add(HandleOAuthRedirect(Uri.parse('orionhealth://oauth2redirect?code=code')));
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(const EmailCitasSyncSuccess()),
+      );
+
+      verify(() => mockAppointmentRepository.saveAppointment(any())).called(1);
+      verify(() => mockEmailRepository.syncToNativeCalendar(any())).called(1);
+    });
+  });
+}

--- a/test/features/email-citas/application/bloc/email_citas_event_test.dart
+++ b/test/features/email-citas/application/bloc/email_citas_event_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/email-citas/application/bloc/email_citas_event.dart';
+
+void main() {
+  group('EmailCitasEvent', () {
+    test('ConnectGmail supports value equality', () {
+      expect(const ConnectGmail(), const ConnectGmail());
+    });
+
+    test('ConnectOutlook supports value equality', () {
+      expect(const ConnectOutlook(), const ConnectOutlook());
+    });
+
+    test('HandleOAuthRedirect supports value equality', () {
+      final uri = Uri.parse('https://example.com');
+      expect(HandleOAuthRedirect(uri), HandleOAuthRedirect(uri));
+    });
+
+    test('ManualSync supports value equality', () {
+      expect(const ManualSync(), const ManualSync());
+    });
+
+    test('SyncAppointments supports value equality', () {
+      expect(const SyncAppointments('code'), const SyncAppointments('code'));
+    });
+  });
+}

--- a/test/features/eps_connection/application/bloc/eps_connection_bloc_test.dart
+++ b/test/features/eps_connection/application/bloc/eps_connection_bloc_test.dart
@@ -1,0 +1,92 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_bloc.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_event.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_state.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/connect_provider_usecase.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/disconnect_provider_usecase.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/get_connections_usecase.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+
+class MockGetConnectionsUseCase extends Mock implements GetConnectionsUseCase {}
+class MockConnectProviderUseCase extends Mock implements ConnectProviderUseCase {}
+class MockDisconnectProviderUseCase extends Mock implements DisconnectProviderUseCase {}
+class FakeEPSProvider extends Fake implements EPSProvider {}
+
+void main() {
+  late EpsConnectionBloc bloc;
+  late MockGetConnectionsUseCase mockGetConnections;
+  late MockConnectProviderUseCase mockConnectProvider;
+  late MockDisconnectProviderUseCase mockDisconnectProvider;
+
+  setUpAll(() {
+    registerFallbackValue(FakeEPSProvider());
+  });
+
+  setUp(() {
+    mockGetConnections = MockGetConnectionsUseCase();
+    mockConnectProvider = MockConnectProviderUseCase();
+    mockDisconnectProvider = MockDisconnectProviderUseCase();
+    bloc = EpsConnectionBloc(
+      mockGetConnections,
+      mockConnectProvider,
+      mockDisconnectProvider,
+    );
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('EpsConnectionBloc', () {
+    test('initial state is EpsConnectionInitial', () {
+      expect(bloc.state, const EpsConnectionInitial());
+    });
+
+    test('LoadConnections emits [Loading, Loaded] on success', () async {
+      when(() => mockGetConnections()).thenAnswer((_) async => []);
+
+      final expected = [
+        const EpsConnectionLoading(),
+        const EpsConnectionLoaded([]),
+      ];
+
+      expectLater(bloc.stream, emitsInOrder(expected));
+      bloc.add(const LoadConnections());
+    });
+
+    test('LoadConnections emits [Loading, Error] on failure', () async {
+      when(() => mockGetConnections()).thenThrow(Exception('failure'));
+
+      final expected = [
+        const EpsConnectionLoading(),
+        isA<EpsConnectionError>(),
+      ];
+
+      expectLater(bloc.stream, emitsInOrder(expected));
+      bloc.add(const LoadConnections());
+    });
+
+    test('ConnectProvider calls usecase and reloads', () async {
+      final provider = EPSProvider(
+        id: '1',
+        name: 'Test',
+        discoveryUrl: '',
+        clientId: '',
+        redirectUrl: '',
+        scopes: [],
+      );
+      when(() => mockConnectProvider(any())).thenAnswer((_) async => {});
+      when(() => mockGetConnections()).thenAnswer((_) async => []);
+
+      bloc.add(ConnectProvider(provider));
+
+      await expectLater(
+        bloc.stream,
+        emitsThrough(const EpsConnectionLoaded([])),
+      );
+
+      verify(() => mockConnectProvider(provider)).called(1);
+    });
+  });
+}

--- a/test/features/eps_connection/application/bloc/eps_connection_cubit_test.dart
+++ b/test/features/eps_connection/application/bloc/eps_connection_cubit_test.dart
@@ -1,0 +1,91 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_cubit.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_state.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/connect_provider_usecase.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/disconnect_provider_usecase.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/usecases/get_connections_usecase.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+
+class MockGetConnectionsUseCase extends Mock implements GetConnectionsUseCase {}
+class MockConnectProviderUseCase extends Mock implements ConnectProviderUseCase {}
+class MockDisconnectProviderUseCase extends Mock implements DisconnectProviderUseCase {}
+class FakeEPSProvider extends Fake implements EPSProvider {}
+
+void main() {
+  late EpsConnectionCubit cubit;
+  late MockGetConnectionsUseCase mockGetConnections;
+  late MockConnectProviderUseCase mockConnectProvider;
+  late MockDisconnectProviderUseCase mockDisconnectProvider;
+
+  setUpAll(() {
+    registerFallbackValue(FakeEPSProvider());
+  });
+
+  setUp(() {
+    mockGetConnections = MockGetConnectionsUseCase();
+    mockConnectProvider = MockConnectProviderUseCase();
+    mockDisconnectProvider = MockDisconnectProviderUseCase();
+
+    // Stub initial load call in constructor
+    when(() => mockGetConnections()).thenAnswer((_) async => []);
+
+    cubit = EpsConnectionCubit(
+      mockGetConnections,
+      mockConnectProvider,
+      mockDisconnectProvider,
+    );
+  });
+
+  tearDown(() {
+    cubit.close();
+  });
+
+  group('EpsConnectionCubit', () {
+    test('initial state is EpsConnectionLoaded after constructor load', () async {
+      // Since it calls loadConnections in constructor
+      await Future.delayed(Duration.zero);
+      expect(cubit.state, const EpsConnectionLoaded([]));
+    });
+
+    test('loadConnections emits [Loading, Loaded] on success', () async {
+      when(() => mockGetConnections()).thenAnswer((_) async => []);
+
+      final expected = [
+        const EpsConnectionLoading(),
+        const EpsConnectionLoaded([]),
+      ];
+
+      expectLater(cubit.stream, emitsInOrder(expected));
+      await cubit.loadConnections();
+    });
+
+    test('connect calls usecase and reloads', () async {
+      final provider = EPSProvider(
+        id: '1',
+        name: 'Test',
+        discoveryUrl: '',
+        clientId: '',
+        redirectUrl: '',
+        scopes: [],
+      );
+      when(() => mockConnectProvider(any())).thenAnswer((_) async => {});
+      when(() => mockGetConnections()).thenAnswer((_) async => []);
+
+      await cubit.connect(provider);
+
+      verify(() => mockConnectProvider(provider)).called(1);
+      expect(cubit.state, const EpsConnectionLoaded([]));
+    });
+
+    test('disconnect calls usecase and reloads', () async {
+      when(() => mockDisconnectProvider(any())).thenAnswer((_) async => {});
+      when(() => mockGetConnections()).thenAnswer((_) async => []);
+
+      await cubit.disconnect('123');
+
+      verify(() => mockDisconnectProvider('123')).called(1);
+      expect(cubit.state, const EpsConnectionLoaded([]));
+    });
+  });
+}

--- a/test/features/eps_connection/application/bloc/eps_connection_event_test.dart
+++ b/test/features/eps_connection/application/bloc/eps_connection_event_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_event.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+
+void main() {
+  group('EpsConnectionEvent', () {
+    test('LoadConnections supports value equality', () {
+      expect(const LoadConnections(), const LoadConnections());
+    });
+
+    test('ConnectProvider supports value equality', () {
+      final provider = EPSProvider(
+        id: '1',
+        name: 'Test',
+        discoveryUrl: '',
+        clientId: '',
+        redirectUrl: '',
+        scopes: [],
+      );
+      expect(ConnectProvider(provider), ConnectProvider(provider));
+    });
+
+    test('DisconnectProvider supports value equality', () {
+      expect(const DisconnectProvider('1'), const DisconnectProvider('1'));
+    });
+  });
+}

--- a/test/features/eps_connection/application/bloc/eps_connection_state_test.dart
+++ b/test/features/eps_connection/application/bloc/eps_connection_state_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_state.dart';
+
+void main() {
+  group('EpsConnectionState', () {
+    test('EpsConnectionInitial supports value equality', () {
+      expect(const EpsConnectionInitial(), const EpsConnectionInitial());
+    });
+
+    test('EpsConnectionLoading supports value equality', () {
+      expect(const EpsConnectionLoading(), const EpsConnectionLoading());
+    });
+
+    test('EpsConnectionLoaded supports value equality', () {
+      expect(const EpsConnectionLoaded([]), const EpsConnectionLoaded([]));
+    });
+
+    test('EpsConnectionError supports value equality', () {
+      expect(const EpsConnectionError('msg'), const EpsConnectionError('msg'));
+    });
+  });
+}

--- a/test/features/health_data_import/application/bloc/health_import_bloc_test.dart
+++ b/test/features/health_data_import/application/bloc/health_import_bloc_test.dart
@@ -1,0 +1,81 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_data_import/application/bloc/health_import_bloc.dart';
+import 'package:orionhealth_health/features/health_data_import/application/bloc/health_import_event.dart';
+import 'package:orionhealth_health/features/health_data_import/application/health_import_state.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/services/health_data_import_service.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/usecases/health_import_usecases.dart';
+import 'package:orionhealth_health/features/vitals/domain/repositories/vital_sign_repository.dart';
+
+class MockGetAvailableSourcesUseCase extends Mock implements GetAvailableSourcesUseCase {}
+class MockRequestHealthAuthUseCase extends Mock implements RequestHealthAuthUseCase {}
+class MockHealthDataImportService extends Mock implements HealthDataImportService {}
+class MockVitalSignRepository extends Mock implements VitalSignRepository {}
+
+void main() {
+  late HealthImportBloc bloc;
+  late MockGetAvailableSourcesUseCase mockGetAvailableSources;
+  late MockRequestHealthAuthUseCase mockRequestHealthAuth;
+  late MockHealthDataImportService mockImportService;
+  late MockVitalSignRepository mockVitalSignRepository;
+
+  setUp(() {
+    mockGetAvailableSources = MockGetAvailableSourcesUseCase();
+    mockRequestHealthAuth = MockRequestHealthAuthUseCase();
+    mockImportService = MockHealthDataImportService();
+    mockVitalSignRepository = MockVitalSignRepository();
+
+    bloc = HealthImportBloc(
+      mockGetAvailableSources,
+      mockRequestHealthAuth,
+      mockImportService,
+      mockVitalSignRepository,
+    );
+  });
+
+  tearDown(() {
+    bloc.close();
+  });
+
+  group('HealthImportBloc', () {
+    test('initial state is HealthImportInitial', () {
+      expect(bloc.state, const HealthImportInitial());
+    });
+
+    test('CheckAvailableSources emits [Loading, Ready] on success', () async {
+      when(() => mockGetAvailableSources()).thenAnswer((_) async => [HealthDataSource.googleFit]);
+
+      final expected = [
+        const HealthImportLoading(),
+        const HealthImportReady(
+          availableSources: [HealthDataSource.googleFit],
+          availability: {
+            HealthDataSource.googleFit: true,
+            HealthDataSource.appleHealth: false,
+            HealthDataSource.samsungHealth: false,
+          },
+        ),
+      ];
+
+      expectLater(bloc.stream, emitsInOrder(expected));
+      bloc.add(const CheckAvailableSources());
+    });
+
+    test('ImportFromSource emits error if auth fails', () async {
+      when(() => mockRequestHealthAuth(any())).thenAnswer((_) async => false);
+
+      final expected = [
+        const HealthImportAuthenticating(HealthDataSource.googleFit),
+        const HealthImportError('Authorization denied. Please grant permission to access health data.'),
+      ];
+
+      expectLater(bloc.stream, emitsInOrder(expected));
+      bloc.add(const ImportFromSource(HealthDataSource.googleFit));
+    });
+
+    test('ResetImport emits HealthImportInitial', () async {
+      bloc.add(const ResetImport());
+      await expectLater(bloc.stream, emits(const HealthImportInitial()));
+    });
+  });
+}

--- a/test/features/health_data_import/application/bloc/health_import_event_test.dart
+++ b/test/features/health_data_import/application/bloc/health_import_event_test.dart
@@ -1,0 +1,22 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_data_import/application/bloc/health_import_event.dart';
+import 'package:orionhealth_health/features/health_data_import/application/health_import_state.dart';
+
+void main() {
+  group('HealthImportEvent', () {
+    test('CheckAvailableSources supports value equality', () {
+      expect(const CheckAvailableSources(), const CheckAvailableSources());
+    });
+
+    test('ImportFromSource supports value equality', () {
+      expect(
+        const ImportFromSource(HealthDataSource.googleFit),
+        const ImportFromSource(HealthDataSource.googleFit),
+      );
+    });
+
+    test('ResetImport supports value equality', () {
+      expect(const ResetImport(), const ResetImport());
+    });
+  });
+}

--- a/test/features/health_data_import/application/health_import_state_test.dart
+++ b/test/features/health_data_import/application/health_import_state_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_data_import/application/health_import_state.dart';
+
+void main() {
+  group('HealthImportState', () {
+    test('HealthImportInitial supports value equality', () {
+      expect(const HealthImportInitial(), const HealthImportInitial());
+    });
+
+    test('HealthImportLoading supports value equality', () {
+      expect(const HealthImportLoading(), const HealthImportLoading());
+    });
+
+    test('HealthImportReady supports value equality', () {
+      const state = HealthImportReady(
+        availableSources: [HealthDataSource.googleFit],
+        availability: {HealthDataSource.googleFit: true},
+      );
+      expect(state, state);
+    });
+
+    test('HealthImportAuthenticating supports value equality', () {
+      expect(
+        const HealthImportAuthenticating(HealthDataSource.googleFit),
+        const HealthImportAuthenticating(HealthDataSource.googleFit),
+      );
+    });
+
+    test('HealthImportImporting supports value equality', () {
+      const state = HealthImportImporting(
+        source: HealthDataSource.googleFit,
+        currentStep: 'Step 1',
+        totalSteps: 5,
+        currentStepNum: 1,
+        importedCount: 0,
+      );
+      expect(state, state);
+      expect(state.progress, 0.2);
+    });
+
+    test('HealthImportSuccess supports value equality', () {
+      const state = HealthImportSuccess(
+        importedCount: 10,
+        source: HealthDataSource.googleFit,
+      );
+      expect(state, state);
+    });
+
+    test('HealthImportError supports value equality', () {
+      expect(const HealthImportError('error'), const HealthImportError('error'));
+    });
+  });
+}

--- a/test/features/medications/application/bloc/medication_event_test.dart
+++ b/test/features/medications/application/bloc/medication_event_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/medications/application/bloc/medication_bloc.dart';
+import 'package:orionhealth_health/features/medications/domain/entities/medication.dart';
+
+void main() {
+  group('MedicationEvent', () {
+    test('LoadMedications supports value equality', () {
+      expect(LoadMedications(), isA<LoadMedications>());
+    });
+
+    test('SaveMedication supports value equality', () {
+      final medication = Medication(
+        id: 1,
+        name: 'Test',
+        dosage: '10mg',
+        frequency: 'Daily',
+      );
+      expect(SaveMedication(medication), isA<SaveMedication>());
+    });
+
+    test('DeleteMedication supports value equality', () {
+      expect(DeleteMedication(1), isA<DeleteMedication>());
+    });
+  });
+}

--- a/test/features/medications/application/bloc/medication_state_test.dart
+++ b/test/features/medications/application/bloc/medication_state_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/medications/application/bloc/medication_bloc.dart';
+import 'package:orionhealth_health/features/medications/domain/entities/medication.dart';
+
+void main() {
+  group('MedicationState', () {
+    test('initial supports value equality', () {
+      expect(const MedicationState.initial(), const MedicationState.initial());
+    });
+
+    test('loading supports value equality', () {
+      expect(const MedicationState.loading(), const MedicationState.loading());
+    });
+
+    test('loaded supports value equality', () {
+      final medications = [
+        Medication(
+          id: 1,
+          name: 'Test',
+          dosage: '10mg',
+          frequency: 'Daily',
+        )
+      ];
+      expect(MedicationState.loaded(medications), MedicationState.loaded(medications));
+    });
+
+    test('error supports value equality', () {
+      expect(const MedicationState.error('error'), const MedicationState.error('error'));
+    });
+  });
+}

--- a/test/features/vitals/application/bloc/vital_sign_event_test.dart
+++ b/test/features/vitals/application/bloc/vital_sign_event_test.dart
@@ -1,0 +1,30 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/vitals/application/bloc/vital_sign_bloc.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+
+void main() {
+  group('VitalSignEvent', () {
+    test('LoadVitalSigns supports value equality', () {
+      expect(LoadVitalSigns(), isA<LoadVitalSigns>());
+    });
+
+    test('LoadLatestVitals supports value equality', () {
+      expect(LoadLatestVitals(), isA<LoadLatestVitals>());
+    });
+
+    test('SaveVitalSign supports value equality', () {
+      final vital = VitalSign(
+        id: 1,
+        type: VitalSignType.heartRate,
+        value: 70,
+        unit: 'bpm',
+        timestamp: DateTime.now(),
+      );
+      expect(SaveVitalSign(vital), isA<SaveVitalSign>());
+    });
+
+    test('SaveVitalSigns supports value equality', () {
+      expect(SaveVitalSigns([]), isA<SaveVitalSigns>());
+    });
+  });
+}

--- a/test/features/vitals/application/bloc/vital_sign_state_test.dart
+++ b/test/features/vitals/application/bloc/vital_sign_state_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/vitals/application/bloc/vital_sign_bloc.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+
+void main() {
+  group('VitalSignState', () {
+    test('initial supports value equality', () {
+      expect(const VitalSignState.initial(), const VitalSignState.initial());
+    });
+
+    test('loading supports value equality', () {
+      expect(const VitalSignState.loading(), const VitalSignState.loading());
+    });
+
+    test('loaded supports value equality', () {
+      final vitals = [
+        VitalSign(
+          id: 1,
+          type: VitalSignType.heartRate,
+          value: 70,
+          unit: 'bpm',
+          timestamp: DateTime.now(),
+        )
+      ];
+      expect(VitalSignState.loaded(vitals), VitalSignState.loaded(vitals));
+    });
+
+    test('latestLoaded supports value equality', () {
+      expect(const VitalSignState.latestLoaded({}), const VitalSignState.latestLoaded({}));
+    });
+
+    test('error supports value equality', () {
+      expect(const VitalSignState.error('error'), const VitalSignState.error('error'));
+    });
+  });
+}


### PR DESCRIPTION
This PR adds missing unit tests for Bloc and Cubit components across multiple features (Auth, Allergies, Appointments, Email-Citas, EPS Connection, Health Data Import, Medications, and Vitals). The tests cover initial states, event handling, and state transitions. Some adjustments were made to match domain entity constructors.

Fixes #839

---
*PR created automatically by Jules for task [5478932364425787651](https://jules.google.com/task/5478932364425787651) started by @iberi22*