### PR TITLE
Add unit tests for core and feature services

### DIFF
--- a/test/core/services/app_logger_test.dart
+++ b/test/core/services/app_logger_test.dart
@@ -1,0 +1,68 @@
+import 'dart:async';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/services/app_logger.dart';
+
+void main() {
+  group('AppLogger', () {
+    test('d logs message', () {
+      final logs = <String>[];
+      runZoned(
+        () => AppLogger.d('TAG', 'debug message'),
+        zoneValues: {},
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, message) {
+            logs.add(message);
+          },
+        ),
+      );
+      expect(logs, contains('[TAG] DEBUG: debug message'));
+    });
+
+    test('i logs message', () {
+      final logs = <String>[];
+      runZoned(
+        () => AppLogger.i('TAG', 'info message'),
+        zoneValues: {},
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, message) {
+            logs.add(message);
+          },
+        ),
+      );
+      expect(logs, contains('[TAG] INFO: info message'));
+    });
+
+    test('w logs message', () {
+      final logs = <String>[];
+      runZoned(
+        () => AppLogger.w('TAG', 'warning message'),
+        zoneValues: {},
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, message) {
+            logs.add(message);
+          },
+        ),
+      );
+      expect(logs, contains('[TAG] WARN: warning message'));
+    });
+
+    test('e logs message with error and stacktrace', () {
+      final logs = <String>[];
+      final error = Exception('test error');
+      final stackTrace = StackTrace.current;
+
+      runZoned(
+        () => AppLogger.e('TAG', 'error message', error: error, stackTrace: stackTrace),
+        zoneValues: {},
+        zoneSpecification: ZoneSpecification(
+          print: (self, parent, zone, message) {
+            logs.add(message);
+          },
+        ),
+      );
+
+      expect(logs, contains('[TAG] ERROR: error message | Exception: test error'));
+      expect(logs, contains(stackTrace.toString()));
+    });
+  });
+}

--- a/test/core/services/secure_storage_service_test.dart
+++ b/test/core/services/secure_storage_service_test.dart
@@ -1,0 +1,123 @@
+import 'dart:convert';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/core/services/secure_storage_service.dart';
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  late MockFlutterSecureStorage mockStorage;
+  late SecureStorageServiceImpl service;
+
+  setUp(() {
+    mockStorage = MockFlutterSecureStorage();
+    service = SecureStorageServiceImpl(storage: mockStorage);
+  });
+
+  group('SecureStorageServiceImpl', () {
+    test('write calls storage.write', () async {
+      when(() => mockStorage.write(key: any(named: 'key'), value: any(named: 'value')))
+          .thenAnswer((_) async {});
+
+      await service.write('testKey', 'testValue');
+
+      verify(() => mockStorage.write(key: 'testKey', value: 'testValue')).called(1);
+    });
+
+    test('read calls storage.read', () async {
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => 'testValue');
+
+      final result = await service.read('testKey');
+
+      expect(result, 'testValue');
+      verify(() => mockStorage.read(key: 'testKey')).called(1);
+    });
+
+    test('delete calls storage.delete', () async {
+      when(() => mockStorage.delete(key: any(named: 'key')))
+          .thenAnswer((_) async {});
+
+      await service.delete('testKey');
+
+      verify(() => mockStorage.delete(key: 'testKey')).called(1);
+    });
+
+    test('deleteAll calls storage.deleteAll', () async {
+      when(() => mockStorage.deleteAll())
+          .thenAnswer((_) async {});
+
+      await service.deleteAll();
+
+      verify(() => mockStorage.deleteAll()).called(1);
+    });
+
+    test('containsKey calls storage.containsKey', () async {
+      when(() => mockStorage.containsKey(key: any(named: 'key')))
+          .thenAnswer((_) async => true);
+
+      final result = await service.containsKey('testKey');
+
+      expect(result, true);
+      verify(() => mockStorage.containsKey(key: 'testKey')).called(1);
+    });
+
+    test('writeSecure calls storage.write with hashed key', () async {
+      when(() => mockStorage.write(key: any(named: 'key'), value: any(named: 'value')))
+          .thenAnswer((_) async {});
+
+      await service.writeSecure('auth', 'token', 'secret');
+
+      verify(() => mockStorage.write(
+            key: any(named: 'key', that: startsWith('auth:')),
+            value: 'secret',
+          )).called(1);
+    });
+
+    test('readSecure calls storage.read with hashed key', () async {
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => 'secret');
+
+      final result = await service.readSecure('auth', 'token');
+
+      expect(result, 'secret');
+      verify(() => mockStorage.read(
+            key: any(named: 'key', that: startsWith('auth:')),
+          )).called(1);
+    });
+
+    test('writeJson serializes and calls write', () async {
+      when(() => mockStorage.write(key: any(named: 'key'), value: any(named: 'value')))
+          .thenAnswer((_) async {});
+      final data = {'id': 1, 'name': 'test'};
+
+      await service.writeJson('config', data);
+
+      verify(() => mockStorage.write(
+            key: 'config',
+            value: jsonEncode(data),
+          )).called(1);
+    });
+
+    test('readJson deserializes and returns map', () async {
+      final data = {'id': 1, 'name': 'test'};
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => jsonEncode(data));
+
+      final result = await service.readJson('config');
+
+      expect(result, data);
+      verify(() => mockStorage.read(key: 'config')).called(1);
+    });
+
+    test('readJson returns null if value is null', () async {
+      when(() => mockStorage.read(key: any(named: 'key')))
+          .thenAnswer((_) async => null);
+
+      final result = await service.readJson('config');
+
+      expect(result, null);
+    });
+  });
+}

--- a/test/features/calendar_import/infrastructure/services/calendar_parser_service_impl_test.dart
+++ b/test/features/calendar_import/infrastructure/services/calendar_parser_service_impl_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/calendar_import/domain/entities/calendar_event.dart';
+import 'package:orionhealth_health/features/calendar_import/infrastructure/services/calendar_parser_service_impl.dart';
+
+void main() {
+  late CalendarParserServiceImpl service;
+
+  setUp(() {
+    service = CalendarParserServiceImpl();
+  });
+
+  group('CalendarParserServiceImpl', () {
+    test('parseIcs delegates to CalendarParser', () {
+      const ics = '''
+BEGIN:VCALENDAR
+VERSION:2.0
+BEGIN:VEVENT
+SUMMARY:Cita con Dr. House
+DTSTART:20231027T100000Z
+DESCRIPTION:Chequeo general
+END:VEVENT
+END:VCALENDAR
+''';
+      final results = service.parseIcs(ics);
+      expect(results.length, 1);
+      expect(results[0].title, 'Cita con Dr. House');
+    });
+
+    test('parseCsv delegates to CalendarParser', () {
+      const csv = '''
+Subject,Start Date,Start Time,Description
+Cita con Dra. Grey,2023-10-27,09:00:00,Cirugía
+''';
+      final results = service.parseCsv(csv);
+      expect(results.length, 1);
+      expect(results[0].title, 'Cita con Dra. Grey');
+    });
+  });
+}

--- a/test/features/email-citas/domain/services/email_service_test.dart
+++ b/test/features/email-citas/domain/services/email_service_test.dart
@@ -1,0 +1,77 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+import 'package:orionhealth_health/features/email-citas/domain/entities/email_template.dart';
+import 'package:orionhealth_health/features/email-citas/domain/services/email_service.dart';
+
+void main() {
+  late EmailService service;
+
+  setUp(() {
+    service = EmailService();
+  });
+
+  group('EmailService', () {
+    final appointment = Appointment(
+      doctorName: 'Dr. Smith',
+      specialty: 'Cardiology',
+      dateTime: DateTime(2023, 10, 27, 10, 0),
+      notes: 'Clínica: Central Park. EPS: Sura',
+      status: AppointmentStatus.upcoming,
+    );
+
+    test('interpolate correctly replaces placeholders', () {
+      const template = 'Hello {{doctor}}, your {{specialty}} appointment is on {{date}} at {{time}}. Location: {{location}}. Notes: {{notes}}';
+      final result = service.interpolate(template, appointment);
+
+      expect(result, contains('Dr. Smith'));
+      expect(result, contains('Cardiology'));
+      expect(result, contains('27/10/2023'));
+      expect(result, contains('10:00'));
+      expect(result, contains('Central Park'));
+      expect(result, contains('Clínica: Central Park. EPS: Sura'));
+    });
+
+    test('interpolate handles missing location in notes', () {
+      final appointmentNoLocation = Appointment(
+        doctorName: 'Dr. House',
+        specialty: 'Diagnostic',
+        dateTime: DateTime(2023, 10, 27, 10, 0),
+        notes: 'Just some notes',
+        status: AppointmentStatus.upcoming,
+      );
+      const template = 'Location: {{location}}';
+      final result = service.interpolate(template, appointmentNoLocation);
+
+      expect(result, 'Location: N/A');
+    });
+
+    test('isValidEmail returns true for valid emails', () {
+      expect(service.isValidEmail('test@example.com'), true);
+      expect(service.isValidEmail('user.name+tag@sub.domain.co'), true);
+    });
+
+    test('isValidEmail returns false for invalid emails', () {
+      expect(service.isValidEmail('test@example'), false);
+      expect(service.isValidEmail('testexample.com'), false);
+      expect(service.isValidEmail('@example.com'), false);
+    });
+
+    test('sendEmail returns true for valid email', () async {
+      const template = EmailTemplate(subject: 'Sub', body: 'Body');
+      final result = await service.sendEmail('test@example.com', template, appointment);
+      expect(result, true);
+    });
+
+    test('sendEmail returns false for invalid email', () async {
+      const template = EmailTemplate(subject: 'Sub', body: 'Body');
+      final result = await service.sendEmail('invalid-email', template, appointment);
+      expect(result, false);
+    });
+
+    test('sendEmail returns false for fail@example.com', () async {
+      const template = EmailTemplate(subject: 'Sub', body: 'Body');
+      final result = await service.sendEmail('fail@example.com', template, appointment);
+      expect(result, false);
+    });
+  });
+}

--- a/test/features/email-citas/domain/services/reminder_service_test.dart
+++ b/test/features/email-citas/domain/services/reminder_service_test.dart
@@ -1,0 +1,53 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+import 'package:orionhealth_health/features/email-citas/domain/services/reminder_service.dart';
+
+void main() {
+  late ReminderService service;
+
+  setUp(() {
+    service = ReminderService();
+  });
+
+  group('ReminderService', () {
+    final appointment = Appointment(
+      doctorName: 'Dr. Smith',
+      specialty: 'Cardiology',
+      dateTime: DateTime(2023, 10, 27, 10, 0),
+      status: AppointmentStatus.upcoming,
+    );
+
+    test('calculateReminderTime returns time 24 hours before by default', () {
+      final reminderTime = service.calculateReminderTime(appointment);
+      expect(reminderTime, DateTime(2023, 10, 26, 10, 0));
+    });
+
+    test('calculateReminderTime returns time with custom lead time', () {
+      final reminderTime = service.calculateReminderTime(
+        appointment,
+        leadTime: const Duration(hours: 2),
+      );
+      expect(reminderTime, DateTime(2023, 10, 27, 8, 0));
+    });
+
+    test('shouldScheduleReminder returns true if reminder time is in the future', () {
+      final futureAppointment = Appointment(
+        doctorName: 'Dr. Future',
+        specialty: 'Time Travel',
+        dateTime: DateTime.now().add(const Duration(days: 2)),
+        status: AppointmentStatus.upcoming,
+      );
+      expect(service.shouldScheduleReminder(futureAppointment), true);
+    });
+
+    test('shouldScheduleReminder returns false if reminder time is in the past', () {
+      final pastAppointment = Appointment(
+        doctorName: 'Dr. Past',
+        specialty: 'History',
+        dateTime: DateTime.now().subtract(const Duration(hours: 12)),
+        status: AppointmentStatus.upcoming,
+      );
+      expect(service.shouldScheduleReminder(pastAppointment), false);
+    });
+  });
+}

--- a/test/features/medical_research/infrastructure/adapters/medical_search_adapters_test.dart
+++ b/test/features/medical_research/infrastructure/adapters/medical_search_adapters_test.dart
@@ -1,0 +1,137 @@
+import 'package:dio/dio.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/medical_research/infrastructure/adapters/medical_search_adapters.dart';
+
+class MockDio extends Mock implements Dio {}
+
+void main() {
+  late MockDio mockDio;
+
+  setUpAll(() {
+    registerFallbackValue(RequestOptions(path: ''));
+  });
+
+  setUp(() {
+    mockDio = MockDio();
+  });
+
+  group('PubMedAdapter', () {
+    late PubMedAdapter adapter;
+
+    setUp(() {
+      adapter = PubMedAdapter(mockDio);
+    });
+
+    test('search returns results on success', () async {
+      // 1. Search for IDs
+      when(() => mockDio.get(
+            any(that: contains('esearch.fcgi')),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => Response(
+            data: {
+              'esearchresult': {
+                'idlist': ['123']
+              }
+            },
+            statusCode: 200,
+            requestOptions: RequestOptions(path: ''),
+          ));
+
+      // 2. Fetch details for IDs
+      when(() => mockDio.get(
+            any(that: contains('esummary.fcgi')),
+            queryParameters: any(named: 'queryParameters'),
+          )).thenAnswer((_) async => Response(
+            data: {
+              'result': {
+                '123': {
+                  'title': 'Test Study',
+                  'source': 'Nature',
+                  'pubdate': '2023',
+                  'authors': [
+                    {'name': 'Author A'}
+                  ]
+                }
+              }
+            },
+            statusCode: 200,
+            requestOptions: RequestOptions(path: ''),
+          ));
+
+      final results = await adapter.search('asthma');
+
+      expect(results.length, 1);
+      expect(results[0].title, 'Test Study');
+      expect(results[0].source, 'PubMed');
+      expect(results[0].url, contains('123'));
+    });
+
+    test('search returns empty list on failure', () async {
+      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+          .thenThrow(DioException(requestOptions: RequestOptions(path: '')));
+
+      final results = await adapter.search('asthma');
+
+      expect(results, isEmpty);
+    });
+  });
+
+  group('FdaAdapter', () {
+    late FdaAdapter adapter;
+
+    setUp(() {
+      adapter = FdaAdapter(mockDio);
+    });
+
+    test('search returns drug info on success', () async {
+      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+          .thenAnswer((_) async => Response(
+            data: {
+              'results': [
+                {
+                  'openfda': {
+                    'brand_name': ['Advil'],
+                    'manufacturer_name': ['Pfizer']
+                  },
+                  'indications_and_usage': ['Used for pain']
+                }
+              ]
+            },
+            statusCode: 200,
+            requestOptions: RequestOptions(path: ''),
+          ));
+
+      final results = await adapter.search('ibuprofen');
+
+      expect(results.length, 1);
+      expect(results[0].title, 'Advil');
+      expect(results[0].source, 'FDA (openFDA)');
+      expect(results[0].metadata?['manufacturer'], 'Pfizer');
+    });
+
+    test('search returns empty list on error', () async {
+      when(() => mockDio.get(any(), queryParameters: any(named: 'queryParameters')))
+          .thenThrow(DioException(requestOptions: RequestOptions(path: '')));
+
+      final results = await adapter.search('unknown');
+
+      expect(results, isEmpty);
+    });
+  });
+
+  group('WhoAdapter', () {
+    late WhoAdapter adapter;
+
+    setUp(() {
+      adapter = WhoAdapter(mockDio);
+    });
+
+    test('search returns placeholder info', () async {
+      final results = await adapter.search('diabetes');
+      expect(results.length, 1);
+      expect(results[0].source, 'WHO');
+      expect(results[0].title, contains('WHO Information on diabetes'));
+    });
+  });
+}


### PR DESCRIPTION
This PR adds unit tests for several services in the core and feature modules. 
- Core: AppLogger, SecureStorageService.
- Calendar Import: CalendarParserService.
- Email Citas: EmailService, ReminderService.
- Medical Research: PubMed, FDA, and WHO search adapters.
Existing tests for medical_research infrastructure were restored after accidental simplification to maintain test quality and coverage.

Fixes #842

---
*PR created automatically by Jules for task [11473190991376413114](https://jules.google.com/task/11473190991376413114) started by @iberi22*