### PR TITLE
Add tests for Theme, Config, and Responsive Layout

### DIFF
--- a/test/core/config/build_config_test.dart
+++ b/test/core/config/build_config_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/config/build_config.dart';
+
+void main() {
+  group('BuildConfig', () {
+    test('default flavor should be dev', () {
+      // In tests, if not provided via --dart-define, it defaults to 'dev'
+      expect(BuildConfig.flavor, 'dev');
+      expect(BuildConfig.isDev, isTrue);
+      expect(BuildConfig.isStaging, isFalse);
+      expect(BuildConfig.isProd, isFalse);
+    });
+
+    test('isTest should be true in test environment', () {
+      expect(BuildConfig.isTest, isTrue);
+    });
+  });
+}

--- a/test/core/config/environment_test.dart
+++ b/test/core/config/environment_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/config/environment.dart';
+
+void main() {
+  group('AppEnvironment', () {
+    test('development environment properties', () {
+      const env = AppEnvironment.development;
+      expect(env.label, 'DEV');
+      expect(env.verboseLogging, isTrue);
+      expect(env.fhirBaseUrl, 'http://localhost:8080/fhir');
+      expect(env.aiBaseUrl, 'http://localhost:8000');
+      expect(env.cmsBaseUrl, 'http://localhost:3000');
+      expect(env.enableCrashReporting, isFalse);
+      expect(env.enablePerformanceMonitor, isTrue);
+      expect(env.showDebugBanner, isTrue);
+    });
+
+    test('staging environment properties', () {
+      const env = AppEnvironment.staging;
+      expect(env.label, 'STAGING');
+      expect(env.verboseLogging, isTrue);
+      expect(env.fhirBaseUrl, 'https://staging-api.orionhealth.app/fhir');
+      expect(env.aiBaseUrl, 'https://staging-ai.orionhealth.app');
+      expect(env.cmsBaseUrl, 'https://staging-api.orionhealth.app');
+      expect(env.enableCrashReporting, isFalse);
+      expect(env.enablePerformanceMonitor, isTrue);
+      expect(env.showDebugBanner, isFalse);
+    });
+
+    test('production environment properties', () {
+      const env = AppEnvironment.production;
+      expect(env.label, 'PROD');
+      expect(env.verboseLogging, isFalse);
+      expect(env.fhirBaseUrl, 'https://api.orionhealth.app/fhir');
+      expect(env.aiBaseUrl, 'https://ai.orionhealth.app');
+      expect(env.cmsBaseUrl, 'https://api.orionhealth.app');
+      expect(env.enableCrashReporting, isTrue);
+      expect(env.enablePerformanceMonitor, isFalse);
+      expect(env.showDebugBanner, isFalse);
+    });
+
+    test('current environment returns development by default in tests', () {
+      // kReleaseMode and kProfileMode are false in standard tests
+      expect(AppEnvironment.current, AppEnvironment.development);
+    });
+  });
+}

--- a/test/core/responsive/breakpoints_test.dart
+++ b/test/core/responsive/breakpoints_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/responsive/breakpoints.dart';
+
+void main() {
+  group('Breakpoints', () {
+    test('isMobile returns true for width < 600', () {
+      expect(Breakpoints.isMobile(375), isTrue);
+      expect(Breakpoints.isMobile(599), isTrue);
+      expect(Breakpoints.isMobile(600), isFalse);
+    });
+
+    test('isTablet returns true for width >= 600 and width < 1440', () {
+      expect(Breakpoints.isTablet(600), isTrue);
+      expect(Breakpoints.isTablet(1024), isTrue);
+      expect(Breakpoints.isTablet(1439), isTrue);
+      expect(Breakpoints.isTablet(599), isFalse);
+      expect(Breakpoints.isTablet(1440), isFalse);
+    });
+
+    test('isDesktop returns true for width >= 1440', () {
+      expect(Breakpoints.isDesktop(1440), isTrue);
+      expect(Breakpoints.isDesktop(1920), isTrue);
+      expect(Breakpoints.isDesktop(1439), isFalse);
+    });
+  });
+}

--- a/test/core/responsive/responsive_layout_test.dart
+++ b/test/core/responsive/responsive_layout_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/responsive/responsive_layout.dart';
+
+void main() {
+  group('ResponsiveLayout', () {
+    testWidgets('renders mobile widget on small screens', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(375, 667));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: ResponsiveLayout(
+            mobile: Text('Mobile View'),
+            desktop: Text('Desktop View'),
+          ),
+        ),
+      );
+
+      expect(find.text('Mobile View'), findsOneWidget);
+      expect(find.text('Desktop View'), findsNothing);
+
+      // Reset
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    testWidgets('renders tablet widget (or mobile fallback) on medium screens', (tester) async {
+      // Test tablet widget
+      await tester.binding.setSurfaceSize(const Size(800, 600));
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: ResponsiveLayout(
+            mobile: Text('Mobile View'),
+            tablet: Text('Tablet View'),
+            desktop: Text('Desktop View'),
+          ),
+        ),
+      );
+      expect(find.text('Tablet View'), findsOneWidget);
+
+      // Test mobile fallback
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: ResponsiveLayout(
+            mobile: Text('Mobile View'),
+            desktop: Text('Desktop View'),
+          ),
+        ),
+      );
+      expect(find.text('Mobile View'), findsOneWidget);
+
+      await tester.binding.setSurfaceSize(null);
+    });
+
+    testWidgets('renders desktop widget on large screens', (tester) async {
+      await tester.binding.setSurfaceSize(const Size(1600, 900));
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: ResponsiveLayout(
+            mobile: Text('Mobile View'),
+            desktop: Text('Desktop View'),
+          ),
+        ),
+      );
+
+      expect(find.text('Desktop View'), findsOneWidget);
+      expect(find.text('Mobile View'), findsNothing);
+
+      await tester.binding.setSurfaceSize(null);
+    });
+  });
+}

--- a/test/core/theme/app_colors_test.dart
+++ b/test/core/theme/app_colors_test.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/theme/app_colors.dart';
+
+void main() {
+  group('AppColors', () {
+    test('verify brand colors', () {
+      expect(AppColors.primary, const Color(0xFF00FF85));
+      expect(AppColors.secondary, const Color(0xFF00E0FF));
+    });
+
+    test('verify background and surface colors', () {
+      expect(AppColors.background, const Color(0xFF0A0A0A));
+      expect(AppColors.surface, const Color(0xFF1A1A1A));
+      expect(AppColors.surfaceVariant, const Color(0xFF2A2A2A));
+    });
+
+    test('verify text colors', () {
+      expect(AppColors.textPrimary, const Color(0xFFE0E0E0));
+      expect(AppColors.textSecondary, const Color(0xFF9E9E9E));
+    });
+
+    test('verify semantic colors', () {
+      expect(AppColors.error, Colors.redAccent);
+      expect(AppColors.warning, Colors.orange);
+      expect(AppColors.success, AppColors.primary);
+    });
+
+    test('verify utility colors', () {
+      expect(AppColors.glassBorder, const Color(0x1AFFFFFF));
+      expect(AppColors.glassBackground, const Color(0x0DFFFFFF));
+    });
+  });
+}

--- a/test/core/theme/app_theme_test.dart
+++ b/test/core/theme/app_theme_test.dart
@@ -1,0 +1,46 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/theme/app_theme.dart';
+import 'package:orionhealth_health/core/theme/app_colors.dart';
+
+void main() {
+  group('AppTheme', () {
+    test('darkTheme should have correct color scheme', () {
+      final theme = AppTheme.darkTheme;
+
+      expect(theme.brightness, Brightness.dark);
+      expect(theme.colorScheme.primary, AppColors.primary);
+      expect(theme.colorScheme.secondary, AppColors.secondary);
+      expect(theme.colorScheme.surface, AppColors.surface);
+      expect(theme.colorScheme.error, AppColors.error);
+      expect(theme.scaffoldBackgroundColor, AppColors.background);
+    });
+
+    test('darkTheme should have correct card theme', () {
+      final theme = AppTheme.darkTheme;
+
+      expect(theme.cardTheme.color, AppColors.surface);
+      expect(theme.cardTheme.elevation, 0);
+      expect(theme.cardTheme.shape, isA<RoundedRectangleBorder>());
+      final shape = theme.cardTheme.shape as RoundedRectangleBorder;
+      expect(shape.borderRadius, BorderRadius.circular(16.0));
+    });
+
+    test('darkTheme should have correct elevated button theme', () {
+      final theme = AppTheme.darkTheme;
+      final style = theme.elevatedButtonTheme.style;
+
+      expect(style?.backgroundColor?.resolve({}), AppColors.primary);
+      expect(style?.foregroundColor?.resolve({}), AppColors.background);
+    });
+
+    test('darkTheme should have correct input decoration theme', () {
+      final theme = AppTheme.darkTheme;
+      final inputTheme = theme.inputDecorationTheme;
+
+      expect(inputTheme.filled, isTrue);
+      expect(inputTheme.fillColor, AppColors.surface);
+      expect(inputTheme.labelStyle?.color, AppColors.textSecondary);
+    });
+  });
+}

--- a/test/core/theme/cyber_theme_test.dart
+++ b/test/core/theme/cyber_theme_test.dart
@@ -1,0 +1,23 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/theme/cyber_theme.dart';
+import 'package:orionhealth_health/core/theme/app_colors.dart';
+
+void main() {
+  group('CyberTheme', () {
+    test('verify constants match AppColors', () {
+      expect(CyberTheme.primary, AppColors.primary);
+      expect(CyberTheme.secondary, AppColors.secondary);
+      expect(CyberTheme.backgroundDark, AppColors.background);
+      expect(CyberTheme.surfaceDark, AppColors.surface);
+      expect(CyberTheme.textDark, AppColors.textPrimary);
+    });
+
+    test('darkTheme bridge returns valid ThemeData', () {
+      final theme = CyberTheme.darkTheme;
+      expect(theme, isA<ThemeData>());
+      expect(theme.brightness, Brightness.dark);
+      expect(theme.colorScheme.primary, AppColors.primary);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds unit and widget tests for core application configuration, themeing, and responsive layout components to ensure better stability and prevent regressions in these fundamental parts of the codebase.

The following files are now covered by tests:
- lib/core/config/build_config.dart
- lib/core/config/environment.dart
- lib/core/theme/app_colors.dart
- lib/core/theme/app_theme.dart
- lib/core/theme/cyber_theme.dart
- lib/core/responsive/breakpoints.dart
- lib/core/responsive/responsive_layout.dart

Tests include:
- Environment detection and property verification.
- Theme data construction and color scheme mapping.
- Boundary testing for responsive breakpoints.
- Widget tests for the ResponsiveLayout builder using different surface sizes.

Fixes #852

---
*PR created automatically by Jules for task [11208044906638277003](https://jules.google.com/task/11208044906638277003) started by @iberi22*