### PR TITLE
Add domain entities to calendar_import feature

### DIFF
--- a/lib/features/calendar_import/application/calendar_import_cubit.dart
+++ b/lib/features/calendar_import/application/calendar_import_cubit.dart
@@ -3,43 +3,11 @@ import 'package:injectable/injectable.dart';
 
 import '../../appointments/domain/entities/appointment.dart';
 import '../domain/entities/calendar_event.dart';
+import '../domain/entities/calendar_import_state.dart';
 import '../domain/repositories/calendar_repository.dart';
 import '../domain/usecases/import_calendar_usecase.dart';
 
-// ---------------------------------------------------------------------------
-// State
-// ---------------------------------------------------------------------------
-
-abstract class CalendarImportState {
-  const CalendarImportState();
-}
-
-class CalendarImportInitial extends CalendarImportState {
-  const CalendarImportInitial();
-}
-
-class CalendarImportLoading extends CalendarImportState {
-  const CalendarImportLoading();
-}
-
-class CalendarImportLoaded extends CalendarImportState {
-  final List<Appointment> foundAppointments;
-  const CalendarImportLoaded(this.foundAppointments);
-}
-
-class CalendarImportSuccess extends CalendarImportState {
-  final int importedCount;
-  const CalendarImportSuccess(this.importedCount);
-}
-
-class CalendarImportError extends CalendarImportState {
-  final String message;
-  const CalendarImportError(this.message);
-}
-
-class CalendarImportPermissionDenied extends CalendarImportState {
-  const CalendarImportPermissionDenied();
-}
+export '../domain/entities/calendar_import_state.dart';
 
 // ---------------------------------------------------------------------------
 // Cubit

--- a/lib/features/calendar_import/domain/entities/calendar_import_state.dart
+++ b/lib/features/calendar_import/domain/entities/calendar_import_state.dart
@@ -1,0 +1,32 @@
+import '../../../appointments/domain/entities/appointment.dart';
+
+abstract class CalendarImportState {
+  const CalendarImportState();
+}
+
+class CalendarImportInitial extends CalendarImportState {
+  const CalendarImportInitial();
+}
+
+class CalendarImportLoading extends CalendarImportState {
+  const CalendarImportLoading();
+}
+
+class CalendarImportLoaded extends CalendarImportState {
+  final List<Appointment> foundAppointments;
+  const CalendarImportLoaded(this.foundAppointments);
+}
+
+class CalendarImportSuccess extends CalendarImportState {
+  final int importedCount;
+  const CalendarImportSuccess(this.importedCount);
+}
+
+class CalendarImportError extends CalendarImportState {
+  final String message;
+  const CalendarImportError(this.message);
+}
+
+class CalendarImportPermissionDenied extends CalendarImportState {
+  const CalendarImportPermissionDenied();
+}

--- a/test/features/calendar_import/application/calendar_import_state_test.dart
+++ b/test/features/calendar_import/application/calendar_import_state_test.dart
@@ -1,5 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
-import 'package:orionhealth_health/features/calendar_import/application/calendar_import_cubit.dart';
+import 'package:orionhealth_health/features/calendar_import/domain/entities/calendar_import_state.dart';
 import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
 
 void main() {


### PR DESCRIPTION
This PR addresses the gap in the `calendar_import` feature's domain layer by moving the `CalendarImportState` and its associated subclasses from the application layer (Cubit) to the domain layer (`lib/features/calendar_import/domain/entities/`).

Key changes:
- Created `lib/features/calendar_import/domain/entities/calendar_import_state.dart`.
- Refactored `lib/features/calendar_import/application/calendar_import_cubit.dart` to use the new domain entities.
- Updated `test/features/calendar_import/application/calendar_import_state_test.dart` for consistency.
- Verified that all changes adhere to the project's Clean Architecture standards and pass static analysis.

Fixes #893

---
*PR created automatically by Jules for task [2967030756505029860](https://jules.google.com/task/2967030756505029860) started by @iberi22*