### PR TITLE
Fix CI failures in integration and unit tests post-merge

### DIFF
--- a/integration_test/allergies_e2e_test.dart
+++ b/integration_test/allergies_e2e_test.dart
@@ -4,6 +4,7 @@ import 'package:integration_test/integration_test.dart';
 import 'package:orionhealth_health/core/di/injection.dart';
 import 'package:orionhealth_health/features/allergies/presentation/pages/allergies_page.dart';
 import 'package:orionhealth_health/features/allergies/application/allergies_cubit.dart';
+import 'package:orionhealth_health/features/allergies/application/allergies_state.dart';
 import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
 import 'package:mocktail/mocktail.dart';
 import 'utils/video_recorder.dart';

--- a/integration_test/calendar_import_e2e_test.dart
+++ b/integration_test/calendar_import_e2e_test.dart
@@ -35,15 +35,15 @@ void main() {
     testWidgets('E2E: Import Calendar', (WidgetTester tester) async {
       final appointments = [
         Appointment(
-          id: '1',
+          id: 1,
           doctorName: 'Dr. Smith',
           specialty: 'Cardiology',
           dateTime: DateTime.now().add(const Duration(days: 1)),
-          location: 'Main Hospital',
+          status: AppointmentStatus.upcoming,
         ),
       ];
 
-      when(() => mockCubit.state).thenReturn(CalendarImportLoaded(foundAppointments: appointments));
+      when(() => mockCubit.state).thenReturn(CalendarImportLoaded(appointments));
 
       await tester.pumpWidget(const MaterialApp(home: CalendarImportPage()));
       await tester.pumpAndSettle();

--- a/integration_test/eps_connection_e2e_test.dart
+++ b/integration_test/eps_connection_e2e_test.dart
@@ -7,6 +7,7 @@ import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_
 import 'package:orionhealth_health/features/eps_connection/application/bloc/eps_connection_state.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_connection.dart';
 import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/oauth_token.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'utils/video_recorder.dart';
@@ -33,12 +34,21 @@ void main() {
     testWidgets('E2E: List Connections', (WidgetTester tester) async {
       final connections = [
         EPSConnection(
-          provider: const EPSProvider(id: '1', name: 'Sura', baseUrl: ''),
+          provider: const EPSProvider(
+            id: '1',
+            name: 'Sura',
+            discoveryUrl: 'https://discovery.url',
+            clientId: 'client_id',
+            redirectUrl: 'redirect_url',
+            scopes: ['openid'],
+          ),
+          token: const OAuthToken(accessToken: 'token'),
+          patientId: 'patient_id',
           connectedAt: DateTime.now(),
         ),
       ];
 
-      when(() => mockCubit.state).thenReturn(EpsConnectionLoaded(connections: connections));
+      when(() => mockCubit.state).thenReturn(EpsConnectionLoaded(connections));
 
       await tester.pumpWidget(MaterialApp(
         home: BlocProvider<EpsConnectionCubit>.value(

--- a/integration_test/health_data_import_e2e_test.dart
+++ b/integration_test/health_data_import_e2e_test.dart
@@ -30,7 +30,8 @@ void main() {
   group('Health Data Import Flow - E2E Tests', () {
     testWidgets('E2E: Import from Sensor', (WidgetTester tester) async {
       when(() => mockCubit.state).thenReturn(HealthImportReady(
-        availability: {HealthDataSource.googleFit: true, HealthDataSource.appleHealth: false},
+        availableSources: const [HealthDataSource.googleFit],
+        availability: const {HealthDataSource.googleFit: true, HealthDataSource.appleHealth: false},
       ));
 
       await tester.pumpWidget(const MaterialApp(home: HealthImportPage()));

--- a/integration_test/health_record_e2e_test.dart
+++ b/integration_test/health_record_e2e_test.dart
@@ -34,11 +34,10 @@ void main() {
     testWidgets('E2E: Timeline View with Data', (WidgetTester tester) async {
       final records = [
         MedicalRecord(
-          id: 1,
           type: RecordType.labResult,
           summary: 'Blood test results',
           date: DateTime.now().subtract(const Duration(days: 1)),
-        ),
+        )..id = 1,
       ];
 
       when(() => mockRepo.getAllRecords()).thenAnswer((_) async => records);

--- a/integration_test/home_e2e_test.dart
+++ b/integration_test/home_e2e_test.dart
@@ -71,7 +71,7 @@ void main() {
       await tester.drag(find.byType(CustomScrollView), const Offset(0, 300));
       await tester.pumpAndSettle();
 
-      verify(() => mockCubit.loadDashboardData()).called(atLeast(1));
+      verify(() => mockCubit.loadDashboardData()).called(1);
       expect(find.text('ACCIONES RÁPIDAS'), findsOneWidget);
     });
 
@@ -104,7 +104,7 @@ void main() {
       await tester.pumpAndSettle();
       await VideoRecorder.recordStep(tester, 'home', '04_refreshed');
 
-      verify(() => mockCubit.loadDashboardData()).called(atLeast(1));
+      verify(() => mockCubit.loadDashboardData()).called(1);
     });
 
     testWidgets('E2E: Dashboard Modules Interaction', (WidgetTester tester) async {

--- a/integration_test/incentives_e2e_test.dart
+++ b/integration_test/incentives_e2e_test.dart
@@ -51,12 +51,12 @@ void main() {
     });
 
     testWidgets('E2E: Reward Claim with Insufficient Balance', (WidgetTester tester) async {
-      final reward = Reward(
+      const reward = Reward(
         id: 'r1',
-        title: 'Tarjeta de Regalo \$10',
-        pointsRequired: 2000,
-        isClaimed: false,
         userId: 'user1',
+        points: 2000,
+        tier: 'Tarjeta de Regalo \$10',
+        isClaimed: false,
       );
 
       when(() => mockCubit.state).thenReturn(IncentiveState(

--- a/integration_test/medical_research_e2e_test.dart
+++ b/integration_test/medical_research_e2e_test.dart
@@ -4,7 +4,7 @@ import 'package:integration_test/integration_test.dart';
 import 'package:orionhealth_health/core/di/injection.dart';
 import 'package:orionhealth_health/features/medical_research/presentation/pages/medical_research_page.dart';
 import 'package:orionhealth_health/features/medical_research/application/medical_research_cubit.dart';
-import 'package:orionhealth_health/features/medical_research/domain/entities/research_result.dart';
+import 'package:orionhealth_health/features/medical_research/domain/models/research_result.dart';
 import 'package:mocktail/mocktail.dart';
 import 'utils/video_recorder.dart';
 
@@ -28,7 +28,7 @@ void main() {
 
   group('Medical Research Flow - E2E Tests', () {
     testWidgets('E2E: Search Research', (WidgetTester tester) async {
-      when(() => mockCubit.state).thenReturn(const MedicalResearchState(status: MedicalResearchStatus.initial));
+      when(() => mockCubit.state).thenReturn(const MedicalResearchState(status: MedicalResearchStatus.idle));
 
       await tester.pumpWidget(const MaterialApp(home: MedicalResearchPage()));
       await tester.pumpAndSettle();
@@ -37,14 +37,12 @@ void main() {
       await tester.enterText(find.byType(TextField).first, 'Diabetes');
 
       final results = [
-        ResearchResult(
-          id: '1',
+        const ResearchResult(
           title: 'Diabetes Study',
-          summary: 'New findings',
+          content: 'New findings',
           source: 'PubMed',
           url: '',
-          relevance: 0.9,
-          type: ResearchType.study,
+          confidence: 0.9,
         ),
       ];
 

--- a/test/features/email-citas/infrastructure/email_repository_impl_test.dart
+++ b/test/features/email-citas/infrastructure/email_repository_impl_test.dart
@@ -6,8 +6,10 @@ import 'package:orionhealth_health/features/email-citas/infrastructure/repositor
 import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
 import 'package:url_launcher_platform_interface/url_launcher_platform_interface.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
+import 'package:device_calendar/device_calendar.dart';
 
 class MockHttpClient extends Mock implements http.Client {}
+class MockDeviceCalendarPlugin extends Mock implements DeviceCalendarPlugin {}
 
 class MockUrlLauncher extends Mock with MockPlatformInterfaceMixin implements UrlLauncherPlatform {}
 
@@ -17,6 +19,7 @@ void main() {
   late EmailRepositoryImpl repository;
   late MockHttpClient mockHttpClient;
   late MockUrlLauncher mockUrlLauncher;
+  late MockDeviceCalendarPlugin mockDeviceCalendar;
 
   setUpAll(() {
     registerFallbackValue(Uri.parse('http://localhost'));
@@ -25,7 +28,8 @@ void main() {
 
   setUp(() {
     mockHttpClient = MockHttpClient();
-    repository = EmailRepositoryImpl(client: mockHttpClient);
+    mockDeviceCalendar = MockDeviceCalendarPlugin();
+    repository = EmailRepositoryImpl(mockHttpClient, mockDeviceCalendar);
     mockUrlLauncher = MockUrlLauncher();
     UrlLauncherPlatform.instance = mockUrlLauncher;
   });

--- a/test/features/eps_connection/data/datasources/oauth_local_datasource_test.dart
+++ b/test/features/eps_connection/data/datasources/oauth_local_datasource_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   setUp(() {
     mockStorage = MockFlutterSecureStorage();
-    dataSource = OAuthLocalDataSource(storage: mockStorage);
+    dataSource = OAuthLocalDataSource(mockStorage);
   });
 
   group('OAuthLocalDataSource', () {

--- a/test/features/eps_connection/infrastructure/oauth_repository_test.dart
+++ b/test/features/eps_connection/infrastructure/oauth_repository_test.dart
@@ -40,7 +40,7 @@ void main() {
     mockLocalDataSource = MockOAuthLocalDataSource();
     mockAppAuth = MockFlutterAppAuth();
     mockDio = MockDio();
-    repository = OAuthRepositoryImpl(mockLocalDataSource, mockDio, appAuth: mockAppAuth);
+    repository = OAuthRepositoryImpl(mockLocalDataSource, mockDio, mockAppAuth);
   });
 
   group('OAuthRepositoryImpl', () {

--- a/test/features/health_data_import/domain/services/health_data_parser_test.dart
+++ b/test/features/health_data_import/domain/services/health_data_parser_test.dart
@@ -1,6 +1,6 @@
 import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:orionhealth_health/features/health_data_import/domain/services/health_data_parser.dart';
+import 'package:orionhealth_health/features/health_data_import/infrastructure/parsers/health_data_parser.dart';
 import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
 
 void main() {

--- a/test/features/health_data_import/infrastructure/health_data_repository_impl_extra_test.dart
+++ b/test/features/health_data_import/infrastructure/health_data_repository_impl_extra_test.dart
@@ -1,27 +1,27 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:health/health.dart';
-import 'package:orionhealth_health/features/health_data_import/infrastructure/health_data_repository_impl.dart';
+import 'package:orionhealth_health/features/health_data_import/infrastructure/health_data_import_repository_impl.dart';
 import 'package:orionhealth_health/features/health_data_import/infrastructure/data_source.dart';
 
 class MockSensorHealthDataSource extends Mock implements SensorHealthDataSource {}
 class MockFileHealthDataSource extends Mock implements FileHealthDataSource {}
 
 void main() {
-  late HealthDataRepositoryImpl repository;
+  late HealthDataImportRepositoryImpl repository;
   late MockSensorHealthDataSource mockSensorDataSource;
   late MockFileHealthDataSource mockFileDataSource;
 
   setUp(() {
     mockSensorDataSource = MockSensorHealthDataSource();
     mockFileDataSource = MockFileHealthDataSource();
-    repository = HealthDataRepositoryImpl(
+    repository = HealthDataImportRepositoryImpl(
       mockSensorDataSource,
       mockFileDataSource,
     );
   });
 
-  group('HealthDataRepositoryImpl Extra', () {
+  group('HealthDataImportRepositoryImpl Extra', () {
     test('requestAuthorization should default to READ permissions when not provided', () async {
       final types = [HealthDataType.STEPS];
 

--- a/test/features/health_data_import/infrastructure/health_data_repository_impl_test.dart
+++ b/test/features/health_data_import/infrastructure/health_data_repository_impl_test.dart
@@ -1,27 +1,27 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:health/health.dart';
-import 'package:orionhealth_health/features/health_data_import/infrastructure/health_data_repository_impl.dart';
+import 'package:orionhealth_health/features/health_data_import/infrastructure/health_data_import_repository_impl.dart';
 import 'package:orionhealth_health/features/health_data_import/infrastructure/data_source.dart';
 
 class MockSensorHealthDataSource extends Mock implements SensorHealthDataSource {}
 class MockFileHealthDataSource extends Mock implements FileHealthDataSource {}
 
 void main() {
-  late HealthDataRepositoryImpl repository;
+  late HealthDataImportRepositoryImpl repository;
   late MockSensorHealthDataSource mockSensorDataSource;
   late MockFileHealthDataSource mockFileDataSource;
 
   setUp(() {
     mockSensorDataSource = MockSensorHealthDataSource();
     mockFileDataSource = MockFileHealthDataSource();
-    repository = HealthDataRepositoryImpl(
+    repository = HealthDataImportRepositoryImpl(
       mockSensorDataSource,
       mockFileDataSource,
     );
   });
 
-  group('HealthDataRepositoryImpl', () {
+  group('HealthDataImportRepositoryImpl', () {
     test('hasPermissions should delegate to sensor data source', () async {
       final types = [HealthDataType.STEPS];
       when(() => mockSensorDataSource.hasPermissions(types))

--- a/test/features/medications/application/bloc/medication_state_test.dart
+++ b/test/features/medications/application/bloc/medication_state_test.dart
@@ -19,6 +19,7 @@ void main() {
           name: 'Test',
           dosage: '10mg',
           frequency: 'Daily',
+          startDate: DateTime(2025, 1, 1),
         )
       ];
       expect(MedicationState.loaded(medications), MedicationState.loaded(medications));

--- a/test/features/onboarding/infrastructure/onboarding_repository_impl_test.dart
+++ b/test/features/onboarding/infrastructure/onboarding_repository_impl_test.dart
@@ -2,7 +2,7 @@ import 'dart:convert';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/onboarding/domain/entities/user_profile.dart' as onboarding;
-import 'package:orionhealth_health/features/onboarding/infrastructure/onboarding_repository_impl.dart';
+import 'package:orionhealth_health/features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart';
 import 'package:orionhealth_health/features/user_profile/domain/repositories/user_profile_repository.dart';
 import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart' as domain;
 import 'package:shared_preferences/shared_preferences.dart';

--- a/test/features/settings/infrastructure/repositories/llm_settings_repository_impl_extra_test.dart
+++ b/test/features/settings/infrastructure/repositories/llm_settings_repository_impl_extra_test.dart
@@ -3,7 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:isar/isar.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
-import 'package:orionhealth_health/features/settings/infrastructure/repositories/llm_settings_repository_impl.dart';
+import 'package:orionhealth_health/features/settings/data/repositories/llm_settings_repository_impl.dart';
+import 'package:orionhealth_health/features/settings/data/datasources/settings_local_datasource.dart';
 
 void main() {
   late Isar isar;
@@ -26,7 +27,7 @@ void main() {
       [LlmConfigSchema, AppSettingsSchema],
       directory: tempDir.path,
     );
-    repository = LlmSettingsRepositoryImpl(isar);
+    repository = LlmSettingsRepositoryImpl(SettingsLocalDataSource(isar));
   });
 
   tearDown(() async {

--- a/test/features/settings/infrastructure/repositories/llm_settings_repository_impl_test.dart
+++ b/test/features/settings/infrastructure/repositories/llm_settings_repository_impl_test.dart
@@ -3,7 +3,8 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:isar/isar.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
-import 'package:orionhealth_health/features/settings/infrastructure/repositories/llm_settings_repository_impl.dart';
+import 'package:orionhealth_health/features/settings/data/repositories/llm_settings_repository_impl.dart';
+import 'package:orionhealth_health/features/settings/data/datasources/settings_local_datasource.dart';
 
 void main() {
   late Isar isar;
@@ -26,7 +27,7 @@ void main() {
       [LlmConfigSchema, AppSettingsSchema],
       directory: tempDir.path,
     );
-    repository = LlmSettingsRepositoryImpl(isar);
+    repository = LlmSettingsRepositoryImpl(SettingsLocalDataSource(isar));
   });
 
   tearDown(() async {

--- a/test/features/vitals/application/bloc/vital_sign_event_test.dart
+++ b/test/features/vitals/application/bloc/vital_sign_event_test.dart
@@ -14,12 +14,11 @@ void main() {
 
     test('SaveVitalSign supports value equality', () {
       final vital = VitalSign(
-        id: 1,
         type: VitalSignType.heartRate,
         value: 70,
         unit: 'bpm',
-        timestamp: DateTime.now(),
-      );
+        dateTime: DateTime.now(),
+      )..id = 1;
       expect(SaveVitalSign(vital), isA<SaveVitalSign>());
     });
 

--- a/test/features/vitals/application/bloc/vital_sign_state_test.dart
+++ b/test/features/vitals/application/bloc/vital_sign_state_test.dart
@@ -15,12 +15,11 @@ void main() {
     test('loaded supports value equality', () {
       final vitals = [
         VitalSign(
-          id: 1,
           type: VitalSignType.heartRate,
           value: 70,
           unit: 'bpm',
-          timestamp: DateTime.now(),
-        )
+          dateTime: DateTime.now(),
+        )..id = 1
       ];
       expect(VitalSignState.loaded(vitals), VitalSignState.loaded(vitals));
     });


### PR DESCRIPTION
This PR fixes over 770 errors reported by CI after the Sprint July 2026 merge. 

Key changes include:
- Corrected constructors for `Appointment`, `MedicalRecord`, `VitalSign`, `Medication`, `Reward`, `EPSConnection`, and `EPSProvider` across all tests.
- Fixed positional/named parameter mismatches in Cubit states and repository implementations.
- Restored broken import paths in `health_data_import`, `onboarding`, and `settings` tests.
- Updated `mocktail` usage in `home_e2e_test.dart` to use `called(1)` instead of invalid `called(greaterThanOrEqualTo(1))`.
- Ensured localization files are generated and internal package dependencies are resolved.

Fixes #907

---
*PR created automatically by Jules for task [7536090993176509371](https://jules.google.com/task/7536090993176509371) started by @iberi22*