### PR TITLE
fix sync: unused import, print→logger, unnecessary cast+assertion

### DIFF
--- a/lib/features/sync/application/sync_cubit.dart
+++ b/lib/features/sync/application/sync_cubit.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:injectable/injectable.dart';
 import '../domain/services/sync_service.dart';
 import '../domain/services/node_discovery_service.dart';
-import '../domain/entities/sync_node.dart';
 import 'sync_state.dart';
 
 @injectable

--- a/lib/features/sync/domain/usecases/distributed_cache_usecase.dart
+++ b/lib/features/sync/domain/usecases/distributed_cache_usecase.dart
@@ -1,5 +1,6 @@
 import 'dart:typed_data';
 import 'package:injectable/injectable.dart';
+import 'package:orionhealth_health/core/services/app_logger.dart';
 import '../services/distributed_storage_service.dart';
 
 @lazySingleton
@@ -14,7 +15,7 @@ class DistributedCacheUsecase {
       return await _storageService.cacheData(data);
     } catch (e) {
       // Gracefully degrade if distributed storage is unavailable
-      print('Distributed cache failed: $e. Falling back to direct storage/download.');
+      AppLogger.e('DistributedCacheUsecase', 'Distributed cache failed. Falling back to direct storage/download.', error: e);
       return null;
     }
   }
@@ -24,7 +25,7 @@ class DistributedCacheUsecase {
     try {
       return await _storageService.getData(cid, expectedHash);
     } catch (e) {
-      print('Distributed storage retrieval failed: $e. Using fallback.');
+      AppLogger.e('DistributedCacheUsecase', 'Distributed storage retrieval failed. Using fallback.', error: e);
       return await fallback();
     }
   }

--- a/lib/features/sync/infrastructure/infrastructure.dart
+++ b/lib/features/sync/infrastructure/infrastructure.dart
@@ -1,6 +1,8 @@
 /// Infrastructure layer for sync feature.
 ///
 /// Exports infrastructure implementations.
+library;
+
 export 'datasources/filecoin_datasource.dart';
 export 'datasources/ipfs_datasource.dart';
 export 'repositories/sync_repository_impl.dart';

--- a/lib/features/sync/infrastructure/repositories/sync_repository_impl.dart
+++ b/lib/features/sync/infrastructure/repositories/sync_repository_impl.dart
@@ -6,6 +6,7 @@ library;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:injectable/injectable.dart';
 import 'package:isar/isar.dart';
+import 'package:orionhealth_health/core/services/app_logger.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import '../../domain/entities/sync_node.dart';
 import '../../domain/repositories/sync_repository.dart';
@@ -75,7 +76,7 @@ class SyncRepositoryImpl implements SyncRepository {
         await _isar.userProfiles.put(updatedProfile);
       });
     } catch (e) {
-      print('Error syncing patient: $e');
+      AppLogger.e('SyncRepositoryImpl', 'Error syncing patient', error: e);
     }
   }
 
@@ -175,7 +176,7 @@ class SyncRepositoryImpl implements SyncRepository {
         }
       });
     } catch (e) {
-      print('Error syncing RDA: $e');
+      AppLogger.e('SyncRepositoryImpl', 'Error syncing RDA', error: e);
     }
   }
 

--- a/lib/features/sync/infrastructure/services/rda_parser.dart
+++ b/lib/features/sync/infrastructure/services/rda_parser.dart
@@ -123,7 +123,7 @@ class RdaParser {
   /// Extract a human-readable display from a reference
   static String? _extractDisplay(dynamic reference) {
     if (reference == null || reference is! Map) return 'Unknown';
-    final ref = reference as Map;
+    final ref = reference;
     if (ref['display'] != null) return ref['display'] as String;
     if (ref['text'] != null) return ref['text'] as String;
     if (ref['reference'] != null) return ref['reference'] as String;
@@ -184,7 +184,7 @@ class RdaParser {
           final given = (first['given'] as List?)?.join(' ') ?? '';
           final family = first['family'] as String? ?? '';
           patientName = '$given $family'.trim();
-          if (patientName!.isEmpty) patientName = null;
+          if (patientName.isEmpty) patientName = null;
         }
         break;
       }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1286,10 +1286,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1309,10 +1309,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1962,10 +1962,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:


### PR DESCRIPTION
This PR fixes several static analysis issues in the sync feature:
1. Removes an unused import in `FhirSyncCubit`.
2. Migrates `print` statements to `AppLogger` in `DistributedCacheUsecase` and `SyncRepositoryImpl` for better observability.
3. Fixes an `unnecessary_cast` and `unnecessary_non_null_assertion` in `RdaParser`.
4. Adds the `library;` directive to `infrastructure.dart` to fix `dangling_library_doc_comments`.
All changes have been verified with `flutter analyze`.

Fixes #914

---
*PR created automatically by Jules for task [16123363850183491649](https://jules.google.com/task/16123363850183491649) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error handling during sync and distributed cache operations.
  * Sync and cache failures are now recorded through the app’s logging system instead of appearing as console output.
  * Made parsing more resilient for certain reference and patient-name edge cases, helping avoid unexpected sync issues.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->