### PR TITLE
fix: rebuild injection.config.dart and resolve build blockers

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -15,7 +15,7 @@ import 'package:flutter_appauth/flutter_appauth.dart' as _i34;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i36;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:google_generative_ai/google_generative_ai.dart' as _i38;
-import 'package:health_wallet/health_wallet.dart' as _i29;
+import 'package:health_wallet/health_wallet.dart' as _i30;
 import 'package:http/http.dart' as _i21;
 import 'package:injectable/injectable.dart' as _i2;
 import 'package:isar/isar.dart' as _i54;
@@ -24,140 +24,140 @@ import 'package:just_audio/just_audio.dart' as _i9;
 import 'package:medical_standards/medical_standards.dart' as _i62;
 import 'package:shared_preferences/shared_preferences.dart' as _i45;
 
-import '../../features/about/application/about_cubit.dart' as _i118;
+import '../../features/about/application/about_cubit.dart' as _i122;
 import '../../features/about/data/datasources/about_local_datasource.dart'
     as _i4;
 import '../../features/about/data/datasources/about_remote_datasource.dart'
-    as _i119;
+    as _i123;
 import '../../features/about/domain/repositories/i_about_repository.dart'
     as _i47;
 import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
     as _i48;
-import '../../features/allergies/application/allergies_cubit.dart' as _i192;
-import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i193;
+import '../../features/allergies/application/allergies_cubit.dart' as _i195;
+import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i196;
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i120;
+    as _i124;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i5;
 import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
-    as _i121;
+    as _i125;
 import '../../features/appointments/application/appointments_cubit.dart'
-    as _i124;
+    as _i128;
 import '../../features/appointments/application/bloc/appointment_bloc.dart'
-    as _i194;
+    as _i197;
 import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i122;
+    as _i126;
 import '../../features/appointments/domain/services/appointment_service.dart'
     as _i6;
 import '../../features/appointments/domain/usecases/delete_appointment_usecase.dart'
-    as _i136;
+    as _i140;
 import '../../features/appointments/domain/usecases/get_all_appointments_usecase.dart'
-    as _i145;
+    as _i150;
 import '../../features/appointments/domain/usecases/save_appointment_usecase.dart'
-    as _i179;
+    as _i184;
 import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
-    as _i123;
-import '../../features/auth/application/auth_cubit.dart' as _i196;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i195;
-import '../../features/auth/domain/auth_service.dart' as _i127;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i125;
+    as _i127;
+import '../../features/auth/application/auth_cubit.dart' as _i199;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i198;
+import '../../features/auth/domain/auth_service.dart' as _i131;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i129;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
-    as _i126;
+    as _i130;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i11;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i30;
+    as _i29;
 import '../../features/calendar_import/application/calendar_import_cubit.dart'
-    as _i199;
+    as _i202;
 import '../../features/calendar_import/domain/repositories/calendar_repository.dart'
     as _i18;
 import '../../features/calendar_import/domain/services/calendar_parser_service.dart'
     as _i16;
 import '../../features/calendar_import/domain/usecases/import_calendar_usecase.dart'
-    as _i164;
+    as _i169;
 import '../../features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart'
     as _i14;
 import '../../features/calendar_import/infrastructure/repositories/calendar_repository_impl.dart'
     as _i19;
 import '../../features/calendar_import/infrastructure/services/calendar_parser_service_impl.dart'
     as _i17;
-import '../../features/dashboard/application/dashboard_cubit.dart' as _i200;
+import '../../features/dashboard/application/dashboard_cubit.dart' as _i203;
 import '../../features/dashboard/data/datasources/dashboard_local_datasource.dart'
-    as _i133;
+    as _i137;
 import '../../features/dashboard/data/datasources/dashboard_remote_datasource.dart'
     as _i22;
 import '../../features/dashboard/data/repositories/dashboard_repository_impl.dart'
-    as _i135;
+    as _i139;
 import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
-    as _i134;
+    as _i138;
 import '../../features/dashboard/domain/usecases/get_dashboard_stats_usecase.dart'
-    as _i148;
+    as _i153;
 import '../../features/dashboard/domain/usecases/get_recent_activity_usecase.dart'
-    as _i150;
+    as _i155;
 import '../../features/doctor_verification/application/badge_cubit.dart'
-    as _i198;
+    as _i201;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
-    as _i142;
+    as _i146;
 import '../../features/doctor_verification/application/second_opinion_cubit.dart'
-    as _i180;
+    as _i185;
 import '../../features/doctor_verification/application/vouch_cubit.dart'
-    as _i191;
+    as _i194;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
-    as _i140;
+    as _i144;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
     as _i90;
 import '../../features/doctor_verification/domain/repositories/second_opinion_repository.dart'
     as _i96;
 import '../../features/doctor_verification/domain/repositories/vouch_repository.dart'
-    as _i115;
+    as _i119;
 import '../../features/doctor_verification/domain/services/badge_calculator.dart'
-    as _i197;
+    as _i200;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
     as _i56;
 import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
     as _i55;
 import '../../features/doctor_verification/infrastructure/repositories/isar_doctor_profile_repository.dart'
-    as _i141;
+    as _i145;
 import '../../features/doctor_verification/infrastructure/repositories/isar_rating_repository.dart'
     as _i91;
 import '../../features/doctor_verification/infrastructure/repositories/isar_second_opinion_repository.dart'
     as _i97;
 import '../../features/doctor_verification/infrastructure/repositories/isar_vouch_repository.dart'
-    as _i116;
+    as _i120;
 import '../../features/email-citas/application/bloc/email_citas_bloc.dart'
-    as _i143;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i144;
+    as _i147;
+import '../../features/email-citas/application/email_citas_cubit.dart' as _i148;
 import '../../features/email-citas/domain/repositories/email_repository.dart'
     as _i26;
 import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
-    as _i101;
+    as _i103;
 import '../../features/email-citas/infrastructure/repositories/email_repository_impl.dart'
     as _i27;
 import '../../features/eps_connection/application/bloc/eps_connection_bloc.dart'
-    as _i202;
+    as _i205;
 import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
-    as _i203;
+    as _i206;
 import '../../features/eps_connection/data/datasources/oauth_local_datasource.dart'
     as _i85;
 import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
     as _i86;
 import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
-    as _i132;
+    as _i136;
 import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
-    as _i137;
+    as _i141;
 import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
-    as _i147;
+    as _i152;
 import '../../features/eps_connection/infrastructure/oauth_repository.dart'
     as _i87;
 import '../../features/health_data_import/application/bloc/health_import_bloc.dart'
-    as _i158;
+    as _i163;
 import '../../features/health_data_import/application/health_import_cubit.dart'
-    as _i159;
+    as _i164;
 import '../../features/health_data_import/data/datasources/health_data_file_datasource.dart'
-    as _i155;
+    as _i160;
 import '../../features/health_data_import/data/datasources/health_data_sensor_datasource.dart'
     as _i40;
 import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i156;
+    as _i161;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i39;
 import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
@@ -165,13 +165,13 @@ import '../../features/health_data_import/domain/usecases/health_import_usecases
 import '../../features/health_data_import/infrastructure/data_source.dart'
     as _i98;
 import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i157;
+    as _i162;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i206;
+    as _i208;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i160;
+    as _i165;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i161;
+    as _i166;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i32;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
@@ -184,23 +184,23 @@ import '../../features/health_sharing/data/datasources/health_sharing_local_data
 import '../../features/health_sharing/data/datasources/health_sharing_remote_datasource.dart'
     as _i42;
 import '../../features/health_sharing/domain/usecases/cancel_sharing_usecase.dart'
-    as _i129;
+    as _i133;
 import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
-    as _i183;
+    as _i188;
 import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
-    as _i184;
+    as _i189;
 import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
-    as _i128;
+    as _i132;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i12;
 import '../../features/health_sharing/infrastructure/nfc_handler.dart' as _i80;
 import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
     as _i82;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i117;
-import '../../features/home/application/home_cubit.dart' as _i207;
-import '../../features/home/domain/repositories/home_repository.dart' as _i162;
+    as _i121;
+import '../../features/home/application/home_cubit.dart' as _i209;
+import '../../features/home/domain/repositories/home_repository.dart' as _i167;
 import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
-    as _i205;
+    as _i207;
 import '../../features/home/infrastructure/datasources/health_summary_datasource.dart'
     as _i43;
 import '../../features/home/infrastructure/datasources/home_local_datasource.dart'
@@ -208,43 +208,43 @@ import '../../features/home/infrastructure/datasources/home_local_datasource.dar
 import '../../features/home/infrastructure/datasources/home_remote_datasource.dart'
     as _i46;
 import '../../features/home/infrastructure/repositories/home_repository_impl.dart'
-    as _i163;
+    as _i168;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i182;
+    as _i187;
 import '../../features/local_agent/data/datasources/chat_message_local_datasource.dart'
-    as _i130;
+    as _i134;
 import '../../features/local_agent/data/datasources/local_model_local_datasource.dart'
     as _i61;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i63;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i57;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i108;
+    as _i112;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
     as _i58;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i35;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i165;
+    as _i171;
 import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i37;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i166;
+    as _i170;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
     as _i59;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i168;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i167;
+    as _i174;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i173;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
-    as _i209;
+    as _i210;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i65;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i64;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i65;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i109;
+    as _i113;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i208;
+    as _i172;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i60;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
@@ -252,7 +252,7 @@ import '../../features/local_agent/infrastructure/services/medical_indexing_serv
 import '../../features/local_agent/infrastructure/services/model_download_service.dart'
     as _i79;
 import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i176;
+    as _i181;
 import '../../features/medical_research/application/medical_research_cubit.dart'
     as _i212;
 import '../../features/medical_research/domain/services/medical_scraper_service.dart'
@@ -264,7 +264,7 @@ import '../../features/medical_research/domain/services/medical_web_search_servi
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i13;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i171;
+    as _i176;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i67;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
@@ -272,35 +272,35 @@ import '../../features/medical_research/infrastructure/medical_standards_service
 import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
     as _i71;
 import '../../features/medications/application/bloc/medication_bloc.dart'
-    as _i172;
+    as _i177;
 import '../../features/medications/application/medications_cubit.dart' as _i74;
 import '../../features/medications/domain/repositories/medication_repository.dart'
     as _i72;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
     as _i73;
-import '../../features/meditation/application/meditation_cubit.dart' as _i173;
+import '../../features/meditation/application/meditation_cubit.dart' as _i178;
 import '../../features/meditation/domain/repositories/meditation_repository.dart'
     as _i76;
 import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
-    as _i131;
+    as _i135;
 import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
-    as _i149;
+    as _i154;
 import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
-    as _i151;
+    as _i156;
 import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
     as _i92;
 import '../../features/meditation/domain/usecases/start_session_usecase.dart'
-    as _i100;
+    as _i102;
 import '../../features/meditation/infrastructure/datasources/meditation_local_datasource.dart'
     as _i75;
 import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
     as _i77;
 import '../../features/network/governance/domain/repositories/governance_repository.dart'
-    as _i153;
+    as _i158;
 import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
-    as _i152;
+    as _i157;
 import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
-    as _i154;
+    as _i159;
 import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
     as _i51;
 import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
@@ -308,84 +308,84 @@ import '../../features/network/incentives/infrastructure/datasources/incentive_d
 import '../../features/network/incentives/infrastructure/repositories/incentive_repository_impl.dart'
     as _i52;
 import '../../features/onboarding/application/onboarding_cubit.dart' as _i213;
-import '../../features/onboarding/application/sync_cubit.dart' as _i185;
+import '../../features/onboarding/application/sync_cubit.dart' as _i190;
 import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i174;
+    as _i179;
 import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
-    as _i175;
+    as _i180;
 import '../../features/reports/application/bloc/report_bloc.dart' as _i214;
 import '../../features/reports/domain/repositories/report_repository.dart'
     as _i93;
 import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i177;
+    as _i182;
 import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i94;
 import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i178;
+    as _i183;
 import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i78;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i210;
-import '../../features/settings/data/datasources/settings_local_datasource.dart'
-    as _i99;
-import '../../features/settings/data/repositories/llm_settings_repository_impl.dart'
-    as _i170;
-import '../../features/settings/domain/repositories/llm_settings_repository.dart'
-    as _i169;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i175;
+import '../../features/settings/domain/repositories/settings_repository.dart'
+    as _i100;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i24;
-import '../../features/sync/application/sync_cubit.dart' as _i204;
-import '../../features/sync/domain/repositories/sync_repository.dart' as _i102;
+    as _i23;
+import '../../features/settings/infrastructure/datasources/settings_local_datasource.dart'
+    as _i99;
+import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
+    as _i101;
+import '../../features/sync/application/sync_cubit.dart' as _i149;
+import '../../features/sync/domain/repositories/sync_repository.dart' as _i104;
 import '../../features/sync/domain/services/distributed_storage_service.dart'
-    as _i138;
+    as _i142;
 import '../../features/sync/domain/services/node_discovery_service.dart'
     as _i83;
-import '../../features/sync/domain/services/sync_service.dart' as _i186;
+import '../../features/sync/domain/services/sync_service.dart' as _i106;
 import '../../features/sync/domain/usecases/distributed_cache_usecase.dart'
-    as _i201;
+    as _i204;
 import '../../features/sync/infrastructure/datasources/filecoin_datasource.dart'
     as _i33;
 import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
     as _i53;
 import '../../features/sync/infrastructure/repositories/sync_repository_impl.dart'
-    as _i103;
+    as _i105;
 import '../../features/sync/infrastructure/services/fhir_client.dart' as _i31;
-import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i139;
+import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i143;
 import '../../features/sync/infrastructure/services/node_discovery_service.dart'
     as _i84;
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
-    as _i187;
-import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i188;
-import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
-    as _i104;
-import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i105;
-import '../../features/user_profile/domain/services/user_profile_service.dart'
     as _i107;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
-    as _i106;
-import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i189;
-import '../../features/vitals/application/vitals_cubit.dart' as _i112;
-import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i110;
-import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i191;
+import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
+    as _i108;
+import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
+    as _i109;
+import '../../features/user_profile/domain/services/user_profile_service.dart'
     as _i111;
-import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i190;
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+    as _i110;
+import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i192;
+import '../../features/vitals/application/vitals_cubit.dart' as _i116;
+import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+    as _i114;
+import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+    as _i115;
+import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i193;
 import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
-    as _i113;
+    as _i117;
 import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
-    as _i146;
+    as _i151;
 import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
-    as _i181;
+    as _i186;
 import '../../features/voice_chat/infrastructure/datasources/chat_ai_datasource.dart'
     as _i20;
 import '../../features/voice_chat/infrastructure/repositories/voice_chat_repository_impl.dart'
-    as _i114;
+    as _i118;
 import '../services/aicore_service.dart' as _i3;
 import '../services/asr/asr_service.dart' as _i7;
 import '../services/audio/audio_player_service.dart' as _i8;
 import '../services/audio/audio_recorder_service.dart' as _i10;
-import '../services/device_capability_service.dart' as _i23;
+import '../services/device_capability_service.dart' as _i24;
 import '../services/privacy_anonymizer.dart' as _i89;
 import 'database_module.dart' as _i219;
 import 'fhir_module.dart' as _i220;
@@ -452,9 +452,9 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.lazySingleton<_i28.EmbeddingsAdapter>(
         () => memoryModule.embeddingsAdapter);
-    gh.lazySingleton<_i29.EncryptionService>(
+    gh.lazySingleton<_i29.EncryptionService>(() => _i29.EncryptionService());
+    gh.lazySingleton<_i30.EncryptionService>(
         () => databaseModule.walletEncryptionService);
-    gh.lazySingleton<_i30.EncryptionService>(() => _i30.EncryptionService());
     gh.lazySingleton<_i31.FhirClient>(() => fhirModule.fhirClient);
     gh.lazySingleton<_i32.FilePickerService>(
         () => _i32.FilePickerServiceImpl());
@@ -477,8 +477,7 @@ extension GetItInjectableX on _i1.GetIt {
         () => _i43.HealthSummaryDatasource());
     gh.factory<_i44.HomeLocalDataSource>(
         () => _i44.HomeLocalDataSource(gh<_i45.SharedPreferences>()));
-    gh.factory<_i46.HomeRemoteDataSource>(
-        () => _i46.HomeRemoteDataSource(gh<_i25.Dio>()));
+    gh.factory<_i46.HomeRemoteDataSource>(() => _i46.HomeRemoteDataSource());
     gh.lazySingleton<_i47.IAboutRepository>(() => _i48.AboutRepositoryImpl());
     gh.lazySingleton<_i49.ImagePickerService>(
         () => _i49.ImagePickerServiceImpl());
@@ -513,15 +512,15 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i62.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
     gh.factory<_i63.MedicalKnowledgeRepository>(
-      () => _i64.JsonMedicalKnowledgeRepository(),
+      () => _i64.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
+    );
+    gh.factory<_i63.MedicalKnowledgeRepository>(
+      () => _i65.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
-    );
-    gh.factory<_i63.MedicalKnowledgeRepository>(
-      () => _i65.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
     );
     gh.lazySingleton<_i66.MedicalScraperService>(
         () => _i67.MedicalScraperServiceImpl(
@@ -583,361 +582,360 @@ extension GetItInjectableX on _i1.GetIt {
         () => _i98.SensorHealthDataSourceImpl());
     gh.lazySingleton<_i99.SettingsLocalDataSource>(
         () => _i99.SettingsLocalDataSource(gh<_i54.Isar>()));
-    gh.lazySingleton<_i100.StartSessionUseCase>(
-        () => _i100.StartSessionUseCase(gh<_i76.MeditationRepository>()));
-    gh.factory<_i101.SyncEmailAppointmentsUseCase>(
-        () => _i101.SyncEmailAppointmentsUseCase(gh<_i26.EmailRepository>()));
-    gh.lazySingleton<_i102.SyncRepository>(() => _i103.SyncRepositoryImpl(
+    gh.lazySingleton<_i100.SettingsRepository>(
+        () => _i101.SettingsRepositoryImpl(gh<_i99.SettingsLocalDataSource>()));
+    gh.lazySingleton<_i102.StartSessionUseCase>(
+        () => _i102.StartSessionUseCase(gh<_i76.MeditationRepository>()));
+    gh.factory<_i103.SyncEmailAppointmentsUseCase>(
+        () => _i103.SyncEmailAppointmentsUseCase(gh<_i26.EmailRepository>()));
+    gh.lazySingleton<_i104.SyncRepository>(() => _i105.SyncRepositoryImpl(
           gh<_i31.FhirClient>(),
           gh<_i54.Isar>(),
           gh<_i36.FlutterSecureStorage>(),
           gh<_i83.NodeDiscoveryService>(),
         ));
     gh.lazySingleton<_i62.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i104.UserProfileLocalDataSource>(
-        () => _i104.UserProfileLocalDataSource(gh<_i54.Isar>()));
-    gh.lazySingleton<_i105.UserProfileRepository>(
-        () => _i106.UserProfileRepositoryImpl(gh<_i54.Isar>()));
-    gh.lazySingleton<_i107.UserProfileService>(
-        () => _i107.UserProfileService(gh<_i105.UserProfileRepository>()));
-    gh.lazySingleton<_i108.VectorStoreService>(
-        () => _i109.IsarVectorStoreService(
+    gh.lazySingleton<_i106.SyncService>(() => _i107.SyncServiceImpl(
+          gh<_i104.SyncRepository>(),
+          gh<_i62.SyncService>(),
+        ));
+    gh.lazySingleton<_i108.UserProfileLocalDataSource>(
+        () => _i108.UserProfileLocalDataSource(gh<_i54.Isar>()));
+    gh.lazySingleton<_i109.UserProfileRepository>(
+        () => _i110.UserProfileRepositoryImpl(gh<_i54.Isar>()));
+    gh.lazySingleton<_i111.UserProfileService>(
+        () => _i111.UserProfileService(gh<_i109.UserProfileRepository>()));
+    gh.lazySingleton<_i112.VectorStoreService>(
+        () => _i113.IsarVectorStoreService(
               gh<_i28.MemoryGraph>(),
               gh<_i63.MedicalKnowledgeRepository>(),
             ));
-    gh.lazySingleton<_i110.VitalSignRepository>(
-        () => _i111.VitalSignRepositoryImpl(gh<_i54.Isar>()));
-    gh.factory<_i112.VitalsCubit>(
-        () => _i112.VitalsCubit(gh<_i110.VitalSignRepository>()));
-    gh.lazySingleton<_i113.VoiceChatRepository>(
-        () => _i114.VoiceChatRepositoryImpl(gh<_i20.ChatAiDatasource>()));
-    gh.lazySingleton<_i115.VouchRepository>(
-        () => _i116.IsarVouchRepository(gh<_i54.Isar>()));
-    gh.lazySingleton<_i29.WalletService>(() => databaseModule.walletService(
+    gh.lazySingleton<_i114.VitalSignRepository>(
+        () => _i115.VitalSignRepositoryImpl(gh<_i54.Isar>()));
+    gh.factory<_i116.VitalsCubit>(
+        () => _i116.VitalsCubit(gh<_i114.VitalSignRepository>()));
+    gh.lazySingleton<_i117.VoiceChatRepository>(
+        () => _i118.VoiceChatRepositoryImpl(gh<_i20.ChatAiDatasource>()));
+    gh.lazySingleton<_i119.VouchRepository>(
+        () => _i120.IsarVouchRepository(gh<_i54.Isar>()));
+    gh.lazySingleton<_i30.WalletService>(() => databaseModule.walletService(
           gh<_i54.Isar>(),
-          gh<_i29.EncryptionService>(),
+          gh<_i30.EncryptionService>(),
         ));
-    gh.lazySingleton<_i117.WifiDirectService>(() => _i117.WifiDirectService());
-    gh.factory<_i118.AboutCubit>(
-        () => _i118.AboutCubit(gh<_i47.IAboutRepository>()));
-    gh.lazySingleton<_i119.AboutRemoteDataSource>(
-        () => _i119.AboutRemoteDataSource(gh<_i25.Dio>()));
-    gh.lazySingleton<_i120.AllergyRepository>(
-        () => _i121.IsarAllergyRepository(gh<_i54.Isar>()));
-    gh.lazySingleton<_i122.AppointmentRepository>(
-        () => _i123.IsarAppointmentRepository(gh<_i54.Isar>()));
-    gh.factory<_i124.AppointmentsCubit>(
-        () => _i124.AppointmentsCubit(gh<_i122.AppointmentRepository>()));
-    gh.lazySingleton<_i125.AuthRepository>(
-        () => _i126.AuthRepositoryImpl(gh<_i54.Isar>()));
-    gh.lazySingleton<_i127.AuthService>(
-        () => _i127.AuthServiceImpl(gh<_i30.EncryptionService>()));
-    gh.lazySingleton<_i128.BleSharingService>(
-        () => _i128.BleSharingService(gh<_i12.BleWrapper>()));
-    gh.lazySingleton<_i129.CancelSharingUseCase>(
-        () => _i129.CancelSharingUseCase(
-              gh<_i128.BleSharingService>(),
+    gh.lazySingleton<_i121.WifiDirectService>(() => _i121.WifiDirectService());
+    gh.factory<_i122.AboutCubit>(
+        () => _i122.AboutCubit(gh<_i47.IAboutRepository>()));
+    gh.lazySingleton<_i123.AboutRemoteDataSource>(
+        () => _i123.AboutRemoteDataSource(gh<_i25.Dio>()));
+    gh.lazySingleton<_i124.AllergyRepository>(
+        () => _i125.IsarAllergyRepository(gh<_i54.Isar>()));
+    gh.lazySingleton<_i126.AppointmentRepository>(
+        () => _i127.IsarAppointmentRepository(gh<_i54.Isar>()));
+    gh.factory<_i128.AppointmentsCubit>(
+        () => _i128.AppointmentsCubit(gh<_i126.AppointmentRepository>()));
+    gh.lazySingleton<_i129.AuthRepository>(
+        () => _i130.AuthRepositoryImpl(gh<_i54.Isar>()));
+    gh.lazySingleton<_i131.AuthService>(
+        () => _i131.AuthServiceImpl(gh<_i29.EncryptionService>()));
+    gh.lazySingleton<_i132.BleSharingService>(
+        () => _i132.BleSharingService(gh<_i12.BleWrapper>()));
+    gh.lazySingleton<_i133.CancelSharingUseCase>(
+        () => _i133.CancelSharingUseCase(
+              gh<_i132.BleSharingService>(),
               gh<_i82.NfcSharingService>(),
-              gh<_i117.WifiDirectService>(),
+              gh<_i121.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i130.ChatMessageLocalDataSource>(
-        () => _i130.ChatMessageLocalDataSource(gh<_i54.Isar>()));
-    gh.lazySingleton<_i131.CompleteSessionUseCase>(
-        () => _i131.CompleteSessionUseCase(gh<_i76.MeditationRepository>()));
-    gh.factory<_i101.ConnectEmailProviderUseCase>(
-        () => _i101.ConnectEmailProviderUseCase(gh<_i26.EmailRepository>()));
-    gh.factory<_i132.ConnectProviderUseCase>(() => _i132.ConnectProviderUseCase(
+    gh.lazySingleton<_i134.ChatMessageLocalDataSource>(
+        () => _i134.ChatMessageLocalDataSource(gh<_i54.Isar>()));
+    gh.lazySingleton<_i135.CompleteSessionUseCase>(
+        () => _i135.CompleteSessionUseCase(gh<_i76.MeditationRepository>()));
+    gh.factory<_i103.ConnectEmailProviderUseCase>(
+        () => _i103.ConnectEmailProviderUseCase(gh<_i26.EmailRepository>()));
+    gh.factory<_i136.ConnectProviderUseCase>(() => _i136.ConnectProviderUseCase(
           gh<_i86.OAuthRepository>(),
-          gh<_i105.UserProfileRepository>(),
+          gh<_i109.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i133.DashboardLocalDataSource>(
-        () => _i133.DashboardLocalDataSource(gh<_i54.Isar>()));
-    gh.lazySingleton<_i134.DashboardRepository>(
-        () => _i135.DashboardRepositoryImpl(
-              gh<_i133.DashboardLocalDataSource>(),
+    gh.lazySingleton<_i137.DashboardLocalDataSource>(
+        () => _i137.DashboardLocalDataSource(gh<_i54.Isar>()));
+    gh.lazySingleton<_i138.DashboardRepository>(
+        () => _i139.DashboardRepositoryImpl(
               gh<_i22.DashboardRemoteDataSource>(),
-              gh<_i110.VitalSignRepository>(),
+              gh<_i114.VitalSignRepository>(),
               gh<_i72.MedicationRepository>(),
               gh<_i93.ReportRepository>(),
             ));
-    gh.factory<_i136.DeleteAppointmentUseCase>(() =>
-        _i136.DeleteAppointmentUseCase(gh<_i122.AppointmentRepository>()));
-    gh.factory<_i137.DisconnectProviderUseCase>(
-        () => _i137.DisconnectProviderUseCase(
+    gh.factory<_i140.DeleteAppointmentUseCase>(() =>
+        _i140.DeleteAppointmentUseCase(gh<_i126.AppointmentRepository>()));
+    gh.factory<_i141.DisconnectProviderUseCase>(
+        () => _i141.DisconnectProviderUseCase(
               gh<_i86.OAuthRepository>(),
-              gh<_i105.UserProfileRepository>(),
+              gh<_i109.UserProfileRepository>(),
             ));
-    gh.lazySingleton<_i138.DistributedStorageService>(() => _i139.IpfsService(
+    gh.lazySingleton<_i142.DistributedStorageService>(() => _i143.IpfsService(
           gh<_i53.IpfsDatasource>(),
           gh<_i33.FilecoinDatasource>(),
         ));
-    gh.lazySingleton<_i140.DoctorProfileRepository>(
-        () => _i141.IsarDoctorProfileRepository(gh<_i54.Isar>()));
-    gh.factoryAsync<_i142.DoctorVerificationCubit>(
-        () async => _i142.DoctorVerificationCubit(
-              gh<_i140.DoctorProfileRepository>(),
+    gh.lazySingleton<_i144.DoctorProfileRepository>(
+        () => _i145.IsarDoctorProfileRepository(gh<_i54.Isar>()));
+    gh.factoryAsync<_i146.DoctorVerificationCubit>(
+        () async => _i146.DoctorVerificationCubit(
+              gh<_i144.DoctorProfileRepository>(),
               gh<_i90.RatingRepository>(),
               await getAsync<_i56.LicenseVerifier>(),
             ));
-    gh.factory<_i143.EmailCitasBloc>(() => _i143.EmailCitasBloc(
-          gh<_i101.ConnectEmailProviderUseCase>(),
-          gh<_i101.SyncEmailAppointmentsUseCase>(),
+    gh.factory<_i147.EmailCitasBloc>(() => _i147.EmailCitasBloc(
+          gh<_i103.ConnectEmailProviderUseCase>(),
+          gh<_i103.SyncEmailAppointmentsUseCase>(),
           gh<_i26.EmailRepository>(),
-          gh<_i122.AppointmentRepository>(),
+          gh<_i126.AppointmentRepository>(),
         ));
-    gh.factory<_i144.EmailCitasCubit>(() => _i144.EmailCitasCubit(
+    gh.factory<_i148.EmailCitasCubit>(() => _i148.EmailCitasCubit(
           gh<_i26.EmailRepository>(),
-          gh<_i122.AppointmentRepository>(),
+          gh<_i126.AppointmentRepository>(),
+        ));
+    gh.factory<_i149.FhirSyncCubit>(() => _i149.FhirSyncCubit(
+          gh<_i106.SyncService>(),
+          gh<_i83.NodeDiscoveryService>(),
         ));
     gh.lazySingleton<_i98.FileHealthDataSource>(
         () => _i98.FileHealthDataSourceImpl(
               gh<_i32.FilePickerService>(),
               gh<_i88.OcrService>(),
             ));
-    gh.factory<_i145.GetAllAppointmentsUseCase>(() =>
-        _i145.GetAllAppointmentsUseCase(gh<_i122.AppointmentRepository>()));
+    gh.factory<_i150.GetAllAppointmentsUseCase>(() =>
+        _i150.GetAllAppointmentsUseCase(gh<_i126.AppointmentRepository>()));
     gh.factory<_i95.GetAvailableSourcesUseCase>(() =>
         _i95.GetAvailableSourcesUseCase(gh<_i39.HealthDataImportService>()));
-    gh.factory<_i146.GetChatHistoryUseCase>(
-        () => _i146.GetChatHistoryUseCase(gh<_i113.VoiceChatRepository>()));
-    gh.factory<_i147.GetConnectionsUseCase>(
-        () => _i147.GetConnectionsUseCase(gh<_i86.OAuthRepository>()));
-    gh.factory<_i148.GetDashboardStatsUseCase>(
-        () => _i148.GetDashboardStatsUseCase(gh<_i134.DashboardRepository>()));
-    gh.lazySingleton<_i149.GetProgressUseCase>(
-        () => _i149.GetProgressUseCase(gh<_i76.MeditationRepository>()));
-    gh.factory<_i150.GetRecentActivityUseCase>(
-        () => _i150.GetRecentActivityUseCase(gh<_i134.DashboardRepository>()));
-    gh.lazySingleton<_i151.GetScriptsUseCase>(
-        () => _i151.GetScriptsUseCase(gh<_i76.MeditationRepository>()));
-    gh.lazySingleton<_i152.GovernanceIpfsDatasource>(
-        () => _i152.GovernanceIpfsDatasource(gh<_i53.IpfsDatasource>()));
-    gh.lazySingleton<_i153.GovernanceRepository>(() =>
-        _i154.GovernanceRepositoryImpl(gh<_i152.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i155.HealthDataFileDataSource>(
-        () => _i155.HealthDataFileDataSource(
+    gh.factory<_i151.GetChatHistoryUseCase>(
+        () => _i151.GetChatHistoryUseCase(gh<_i117.VoiceChatRepository>()));
+    gh.factory<_i152.GetConnectionsUseCase>(
+        () => _i152.GetConnectionsUseCase(gh<_i86.OAuthRepository>()));
+    gh.factory<_i153.GetDashboardStatsUseCase>(
+        () => _i153.GetDashboardStatsUseCase(gh<_i138.DashboardRepository>()));
+    gh.lazySingleton<_i154.GetProgressUseCase>(
+        () => _i154.GetProgressUseCase(gh<_i76.MeditationRepository>()));
+    gh.factory<_i155.GetRecentActivityUseCase>(
+        () => _i155.GetRecentActivityUseCase(gh<_i138.DashboardRepository>()));
+    gh.lazySingleton<_i156.GetScriptsUseCase>(
+        () => _i156.GetScriptsUseCase(gh<_i76.MeditationRepository>()));
+    gh.lazySingleton<_i157.GovernanceIpfsDatasource>(
+        () => _i157.GovernanceIpfsDatasource(gh<_i53.IpfsDatasource>()));
+    gh.lazySingleton<_i158.GovernanceRepository>(() =>
+        _i159.GovernanceRepositoryImpl(gh<_i157.GovernanceIpfsDatasource>()));
+    gh.lazySingleton<_i160.HealthDataFileDataSource>(
+        () => _i160.HealthDataFileDataSource(
               gh<_i32.FilePickerService>(),
               gh<_i88.OcrService>(),
             ));
-    gh.lazySingleton<_i156.HealthDataImportRepository>(
-        () => _i157.HealthDataImportRepositoryImpl(
+    gh.lazySingleton<_i161.HealthDataImportRepository>(
+        () => _i162.HealthDataImportRepositoryImpl(
               gh<_i98.SensorHealthDataSource>(),
               gh<_i98.FileHealthDataSource>(),
             ));
-    gh.factory<_i158.HealthImportBloc>(() => _i158.HealthImportBloc(
+    gh.factory<_i163.HealthImportBloc>(() => _i163.HealthImportBloc(
           gh<_i95.GetAvailableSourcesUseCase>(),
           gh<_i95.RequestHealthAuthUseCase>(),
           gh<_i39.HealthDataImportService>(),
-          gh<_i110.VitalSignRepository>(),
+          gh<_i114.VitalSignRepository>(),
         ));
-    gh.factory<_i159.HealthImportCubit>(() => _i159.HealthImportCubit(
+    gh.factory<_i164.HealthImportCubit>(() => _i164.HealthImportCubit(
           gh<_i39.HealthDataImportService>(),
-          gh<_i110.VitalSignRepository>(),
+          gh<_i114.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i160.HealthRecordRepository>(
-        () => _i161.HealthRecordRepositoryImpl(gh<_i54.Isar>()));
-    gh.lazySingleton<_i162.HomeRepository>(() => _i163.HomeRepositoryImpl(
-          gh<_i110.VitalSignRepository>(),
-          gh<_i122.AppointmentRepository>(),
+    gh.lazySingleton<_i165.HealthRecordRepository>(
+        () => _i166.HealthRecordRepositoryImpl(gh<_i54.Isar>()));
+    gh.lazySingleton<_i167.HomeRepository>(() => _i168.HomeRepositoryImpl(
+          gh<_i114.VitalSignRepository>(),
+          gh<_i126.AppointmentRepository>(),
           gh<_i72.MedicationRepository>(),
           gh<_i44.HomeLocalDataSource>(),
           gh<_i46.HomeRemoteDataSource>(),
         ));
-    gh.factory<_i164.ImportCalendarUseCase>(() => _i164.ImportCalendarUseCase(
+    gh.factory<_i169.ImportCalendarUseCase>(() => _i169.ImportCalendarUseCase(
           gh<_i18.CalendarRepository>(),
-          gh<_i122.AppointmentRepository>(),
-          gh<_i105.UserProfileRepository>(),
+          gh<_i126.AppointmentRepository>(),
+          gh<_i109.UserProfileRepository>(),
         ));
+    gh.factory<_i57.LlmAdapter>(
+      () => _i170.MockLlmAdapter(gh<_i89.PromptScrubber>()),
+      instanceName: 'mock',
+    );
     gh.lazySingleton<_i57.LlmAdapter>(
-      () => _i165.GeminiLlmAdapter(
+      () => _i171.GeminiLlmAdapter(
         scrubber: gh<_i89.PromptScrubber>(),
-        userProfileRepository: gh<_i105.UserProfileRepository>(),
+        userProfileRepository: gh<_i109.UserProfileRepository>(),
         modelWrapper: gh<_i37.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
     );
-    gh.factory<_i57.LlmAdapter>(
-      () => _i166.MockLlmAdapter(gh<_i89.PromptScrubber>()),
-      instanceName: 'mock',
-    );
-    gh.lazySingleton<_i167.LlmService>(() => _i168.GemmaLlmService(
-          gh<_i108.VectorStoreService>(),
-          gh<_i105.UserProfileRepository>(),
+    gh.lazySingleton<_i172.LlmAdapterFactory>(
+        () => _i172.LlmAdapterFactory(gh<_i100.SettingsRepository>()));
+    gh.lazySingleton<_i173.LlmService>(() => _i174.GemmaLlmService(
+          gh<_i112.VectorStoreService>(),
+          gh<_i109.UserProfileRepository>(),
           gh<_i57.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.lazySingleton<_i169.LlmSettingsRepository>(() =>
-        _i170.LlmSettingsRepositoryImpl(gh<_i99.SettingsLocalDataSource>()));
-    gh.lazySingleton<_i171.MedicalResearchService>(
-        () => _i171.MedicalResearchService(
+    gh.factory<_i175.LlmSettingsCubit>(() => _i175.LlmSettingsCubit(
+          gh<_i100.SettingsRepository>(),
+          gh<_i23.DeviceCapabilityService>(),
+          gh<_i57.LlmAdapter>(instanceName: 'gemma'),
+        ));
+    gh.lazySingleton<_i176.MedicalResearchService>(
+        () => _i176.MedicalResearchService(
               gh<_i70.MedicalWebSearchService>(),
               gh<_i66.MedicalScraperService>(),
             ));
-    gh.factory<_i172.MedicationBloc>(
-        () => _i172.MedicationBloc(gh<_i72.MedicationRepository>()));
-    gh.factory<_i173.MeditationCubit>(() => _i173.MeditationCubit(
+    gh.factory<_i177.MedicationBloc>(
+        () => _i177.MedicationBloc(gh<_i72.MedicationRepository>()));
+    gh.factory<_i178.MeditationCubit>(() => _i178.MeditationCubit(
           gh<_i92.RecommendScriptUseCase>(),
-          gh<_i100.StartSessionUseCase>(),
-          gh<_i131.CompleteSessionUseCase>(),
-          gh<_i149.GetProgressUseCase>(),
+          gh<_i102.StartSessionUseCase>(),
+          gh<_i135.CompleteSessionUseCase>(),
+          gh<_i154.GetProgressUseCase>(),
           gh<_i8.AudioService>(),
         ));
-    gh.lazySingleton<_i174.OnboardingRepository>(() =>
-        _i175.OnboardingRepositoryImpl(gh<_i105.UserProfileRepository>()));
-    gh.lazySingleton<_i176.PatientContextIndexer>(
-      () => _i176.PatientContextIndexer(
+    gh.lazySingleton<_i179.OnboardingRepository>(() =>
+        _i180.OnboardingRepositoryImpl(gh<_i109.UserProfileRepository>()));
+    gh.lazySingleton<_i181.PatientContextIndexer>(
+      () => _i181.PatientContextIndexer(
         gh<_i54.Isar>(),
-        gh<_i108.VectorStoreService>(),
-        gh<_i160.HealthRecordRepository>(),
+        gh<_i112.VectorStoreService>(),
+        gh<_i165.HealthRecordRepository>(),
         gh<_i72.MedicationRepository>(),
-        gh<_i120.AllergyRepository>(),
-        gh<_i110.VitalSignRepository>(),
-        gh<_i122.AppointmentRepository>(),
+        gh<_i124.AllergyRepository>(),
+        gh<_i114.VitalSignRepository>(),
+        gh<_i126.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i177.ReportGenerationService>(
-        () => _i178.GemmaReportGenerationService(
+    gh.lazySingleton<_i182.ReportGenerationService>(
+        () => _i183.GemmaReportGenerationService(
               gh<_i57.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i108.VectorStoreService>(),
-              gh<_i105.UserProfileRepository>(),
+              gh<_i112.VectorStoreService>(),
+              gh<_i109.UserProfileRepository>(),
               gh<_i89.PromptScrubber>(),
             ));
-    gh.factory<_i179.SaveAppointmentUseCase>(
-        () => _i179.SaveAppointmentUseCase(gh<_i122.AppointmentRepository>()));
-    gh.factory<_i180.SecondOpinionCubit>(
-        () => _i180.SecondOpinionCubit(gh<_i96.SecondOpinionRepository>()));
-    gh.factory<_i181.SendMessageUseCase>(
-        () => _i181.SendMessageUseCase(gh<_i113.VoiceChatRepository>()));
-    gh.lazySingleton<_i182.SmartSearchUseCase>(
-        () => _i182.SmartSearchUseCase(gh<_i108.VectorStoreService>()));
-    gh.lazySingleton<_i183.StartListeningUseCase>(
-        () => _i183.StartListeningUseCase(
-              gh<_i128.BleSharingService>(),
+    gh.factory<_i184.SaveAppointmentUseCase>(
+        () => _i184.SaveAppointmentUseCase(gh<_i126.AppointmentRepository>()));
+    gh.factory<_i185.SecondOpinionCubit>(
+        () => _i185.SecondOpinionCubit(gh<_i96.SecondOpinionRepository>()));
+    gh.factory<_i186.SendMessageUseCase>(
+        () => _i186.SendMessageUseCase(gh<_i117.VoiceChatRepository>()));
+    gh.lazySingleton<_i187.SmartSearchUseCase>(
+        () => _i187.SmartSearchUseCase(gh<_i112.VectorStoreService>()));
+    gh.lazySingleton<_i188.StartListeningUseCase>(
+        () => _i188.StartListeningUseCase(
+              gh<_i132.BleSharingService>(),
               gh<_i82.NfcSharingService>(),
-              gh<_i117.WifiDirectService>(),
+              gh<_i121.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i184.StartSharingUseCase>(() => _i184.StartSharingUseCase(
-          gh<_i128.BleSharingService>(),
+    gh.lazySingleton<_i189.StartSharingUseCase>(() => _i189.StartSharingUseCase(
+          gh<_i132.BleSharingService>(),
           gh<_i82.NfcSharingService>(),
-          gh<_i117.WifiDirectService>(),
+          gh<_i121.WifiDirectService>(),
         ));
-    gh.factory<_i185.SyncCubit>(() => _i185.SyncCubit(
+    gh.factory<_i190.SyncCubit>(() => _i190.SyncCubit(
           gh<_i62.SyncService>(),
-          gh<_i108.VectorStoreService>(),
+          gh<_i112.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i186.SyncService>(() => _i187.SyncServiceImpl(
-          gh<_i102.SyncRepository>(),
-          gh<_i62.SyncService>(),
-        ));
-    gh.factory<_i188.UserProfileCubit>(
-        () => _i188.UserProfileCubit(gh<_i105.UserProfileRepository>()));
-    gh.factory<_i189.VitalSignBloc>(
-        () => _i189.VitalSignBloc(gh<_i110.VitalSignRepository>()));
-    gh.factory<_i190.VoiceChatCubit>(() => _i190.VoiceChatCubit(
-          gh<_i181.SendMessageUseCase>(),
-          gh<_i146.GetChatHistoryUseCase>(),
-          gh<_i113.VoiceChatRepository>(),
+    gh.factory<_i191.UserProfileCubit>(
+        () => _i191.UserProfileCubit(gh<_i109.UserProfileRepository>()));
+    gh.factory<_i192.VitalSignBloc>(
+        () => _i192.VitalSignBloc(gh<_i114.VitalSignRepository>()));
+    gh.factory<_i193.VoiceChatCubit>(() => _i193.VoiceChatCubit(
+          gh<_i186.SendMessageUseCase>(),
+          gh<_i151.GetChatHistoryUseCase>(),
+          gh<_i117.VoiceChatRepository>(),
           gh<_i8.AudioService>(),
         ));
-    gh.factory<_i191.VouchCubit>(
-        () => _i191.VouchCubit(gh<_i115.VouchRepository>()));
-    gh.factory<_i192.AllergiesCubit>(
-        () => _i192.AllergiesCubit(gh<_i120.AllergyRepository>()));
-    gh.factory<_i193.AllergyBloc>(
-        () => _i193.AllergyBloc(gh<_i120.AllergyRepository>()));
-    gh.factory<_i194.AppointmentBloc>(
-        () => _i194.AppointmentBloc(gh<_i122.AppointmentRepository>()));
-    gh.factory<_i195.AuthCubit>(() => _i195.AuthCubit(
-          gh<_i125.AuthRepository>(),
-          gh<_i30.EncryptionService>(),
+    gh.factory<_i194.VouchCubit>(
+        () => _i194.VouchCubit(gh<_i119.VouchRepository>()));
+    gh.factory<_i195.AllergiesCubit>(
+        () => _i195.AllergiesCubit(gh<_i124.AllergyRepository>()));
+    gh.factory<_i196.AllergyBloc>(
+        () => _i196.AllergyBloc(gh<_i124.AllergyRepository>()));
+    gh.factory<_i197.AppointmentBloc>(
+        () => _i197.AppointmentBloc(gh<_i126.AppointmentRepository>()));
+    gh.factory<_i198.AuthCubit>(() => _i198.AuthCubit(
+          gh<_i129.AuthRepository>(),
+          gh<_i29.EncryptionService>(),
           gh<_i11.BiometricService>(),
         ));
-    gh.factory<_i196.AuthCubit>(() => _i196.AuthCubit(gh<_i127.AuthService>()));
-    gh.lazySingleton<_i197.BadgeCalculator>(() => _i197.BadgeCalculator(
-          gh<_i140.DoctorProfileRepository>(),
+    gh.factory<_i199.AuthCubit>(() => _i199.AuthCubit(gh<_i131.AuthService>()));
+    gh.lazySingleton<_i200.BadgeCalculator>(() => _i200.BadgeCalculator(
+          gh<_i144.DoctorProfileRepository>(),
           gh<_i90.RatingRepository>(),
-          gh<_i115.VouchRepository>(),
+          gh<_i119.VouchRepository>(),
         ));
-    gh.factory<_i198.BadgeCubit>(
-        () => _i198.BadgeCubit(gh<_i197.BadgeCalculator>()));
-    gh.factory<_i199.CalendarImportCubit>(() => _i199.CalendarImportCubit(
+    gh.factory<_i201.BadgeCubit>(
+        () => _i201.BadgeCubit(gh<_i200.BadgeCalculator>()));
+    gh.factory<_i202.CalendarImportCubit>(() => _i202.CalendarImportCubit(
           gh<_i18.CalendarRepository>(),
-          gh<_i164.ImportCalendarUseCase>(),
+          gh<_i169.ImportCalendarUseCase>(),
         ));
-    gh.factory<_i200.DashboardCubit>(() => _i200.DashboardCubit(
-          gh<_i148.GetDashboardStatsUseCase>(),
-          gh<_i150.GetRecentActivityUseCase>(),
+    gh.factory<_i203.DashboardCubit>(() => _i203.DashboardCubit(
+          gh<_i153.GetDashboardStatsUseCase>(),
+          gh<_i155.GetRecentActivityUseCase>(),
         ));
-    gh.lazySingleton<_i201.DistributedCacheUsecase>(() =>
-        _i201.DistributedCacheUsecase(gh<_i138.DistributedStorageService>()));
-    gh.factory<_i202.EpsConnectionBloc>(() => _i202.EpsConnectionBloc(
-          gh<_i147.GetConnectionsUseCase>(),
-          gh<_i132.ConnectProviderUseCase>(),
-          gh<_i137.DisconnectProviderUseCase>(),
+    gh.lazySingleton<_i204.DistributedCacheUsecase>(() =>
+        _i204.DistributedCacheUsecase(gh<_i142.DistributedStorageService>()));
+    gh.factory<_i205.EpsConnectionBloc>(() => _i205.EpsConnectionBloc(
+          gh<_i152.GetConnectionsUseCase>(),
+          gh<_i136.ConnectProviderUseCase>(),
+          gh<_i141.DisconnectProviderUseCase>(),
         ));
-    gh.factory<_i203.EpsConnectionCubit>(() => _i203.EpsConnectionCubit(
-          gh<_i147.GetConnectionsUseCase>(),
-          gh<_i132.ConnectProviderUseCase>(),
-          gh<_i137.DisconnectProviderUseCase>(),
+    gh.factory<_i206.EpsConnectionCubit>(() => _i206.EpsConnectionCubit(
+          gh<_i152.GetConnectionsUseCase>(),
+          gh<_i136.ConnectProviderUseCase>(),
+          gh<_i141.DisconnectProviderUseCase>(),
         ));
-    gh.factory<_i204.FhirSyncCubit>(() => _i204.FhirSyncCubit(
-          gh<_i186.SyncService>(),
-          gh<_i83.NodeDiscoveryService>(),
-        ));
-    gh.factory<_i205.GetHealthSummaryUseCase>(
-        () => _i205.GetHealthSummaryUseCase(gh<_i162.HomeRepository>()));
-    gh.factory<_i206.HealthRecordCubit>(() => _i206.HealthRecordCubit(
-          gh<_i160.HealthRecordRepository>(),
+    gh.factory<_i207.GetHealthSummaryUseCase>(
+        () => _i207.GetHealthSummaryUseCase(gh<_i167.HomeRepository>()));
+    gh.factory<_i208.HealthRecordCubit>(() => _i208.HealthRecordCubit(
+          gh<_i165.HealthRecordRepository>(),
           gh<_i32.FilePickerService>(),
           gh<_i49.ImagePickerService>(),
           gh<_i88.OcrService>(),
-          gh<_i108.VectorStoreService>(),
+          gh<_i112.VectorStoreService>(),
         ));
-    gh.factory<_i207.HomeCubit>(() => _i207.HomeCubit(
-          gh<_i205.GetHealthSummaryUseCase>(),
-          gh<_i162.HomeRepository>(),
+    gh.factory<_i209.HomeCubit>(() => _i209.HomeCubit(
+          gh<_i207.GetHealthSummaryUseCase>(),
+          gh<_i167.HomeRepository>(),
         ));
-    gh.lazySingleton<_i208.LlmAdapterFactory>(
-        () => _i208.LlmAdapterFactory(gh<_i169.LlmSettingsRepository>()));
-    gh.lazySingleton<_i167.LlmService>(
-      () => _i209.RagLlmService(
-        gh<_i108.VectorStoreService>(),
-        gh<_i171.MedicalResearchService>(),
-        gh<_i105.UserProfileRepository>(),
+    gh.lazySingleton<_i173.LlmService>(
+      () => _i210.RagLlmService(
+        gh<_i112.VectorStoreService>(),
+        gh<_i176.MedicalResearchService>(),
+        gh<_i109.UserProfileRepository>(),
         gh<_i57.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
-    gh.factory<_i210.LlmSettingsCubit>(() => _i210.LlmSettingsCubit(
-          gh<_i169.LlmSettingsRepository>(),
-          gh<_i24.DeviceCapabilityService>(),
-          gh<_i57.LlmAdapter>(instanceName: 'gemma'),
-        ));
     gh.lazySingleton<_i211.MedicalIndexingService>(
         () => _i211.MedicalIndexingService(
               gh<_i63.MedicalKnowledgeRepository>(),
-              gh<_i108.VectorStoreService>(),
-              gh<_i176.PatientContextIndexer>(),
+              gh<_i112.VectorStoreService>(),
+              gh<_i181.PatientContextIndexer>(),
             ));
     gh.factory<_i212.MedicalResearchCubit>(() => _i212.MedicalResearchCubit(
-          gh<_i171.MedicalResearchService>(),
+          gh<_i176.MedicalResearchService>(),
           gh<_i68.MedicalStandardsService>(),
         ));
     gh.factory<_i213.OnboardingCubit>(
-        () => _i213.OnboardingCubit(gh<_i174.OnboardingRepository>()));
+        () => _i213.OnboardingCubit(gh<_i179.OnboardingRepository>()));
     gh.factory<_i214.ReportBloc>(() => _i214.ReportBloc(
           gh<_i93.ReportRepository>(),
-          gh<_i177.ReportGenerationService>(),
+          gh<_i182.ReportGenerationService>(),
         ));
     gh.factory<_i215.SharingCubit>(() => _i215.SharingCubit(
-          bleService: gh<_i128.BleSharingService>(),
+          bleService: gh<_i132.BleSharingService>(),
           nfcService: gh<_i82.NfcSharingService>(),
-          wifiService: gh<_i117.WifiDirectService>(),
-          startSharingUseCase: gh<_i184.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i183.StartListeningUseCase>(),
-          cancelSharingUseCase: gh<_i129.CancelSharingUseCase>(),
-          walletService: gh<_i29.WalletService>(),
-          walletEncryption: gh<_i29.EncryptionService>(),
+          wifiService: gh<_i121.WifiDirectService>(),
+          startSharingUseCase: gh<_i189.StartSharingUseCase>(),
+          startListeningUseCase: gh<_i188.StartListeningUseCase>(),
+          cancelSharingUseCase: gh<_i133.CancelSharingUseCase>(),
+          walletService: gh<_i30.WalletService>(),
+          walletEncryption: gh<_i30.EncryptionService>(),
         ));
     return this;
   }

--- a/lib/features/local_agent/domain/entities/medical_code.dart
+++ b/lib/features/local_agent/domain/entities/medical_code.dart
@@ -78,15 +78,18 @@ class MedicalCode extends Equatable {
   }
 
   /// All searchable text strings for embedding.
-  List<String> get allSearchableTerms => [
-        displayName,
-        ...searchTerms,
-        ?definition,
-        ?firstLineTreatment,
-        ?alternatives,
-        ?redFlags,
-        ?followUp,
-      ];
+  List<String> get allSearchableTerms {
+    final list = [
+      displayName,
+      ...searchTerms,
+    ];
+    if (definition != null) list.add(definition!);
+    if (firstLineTreatment != null) list.add(firstLineTreatment!);
+    if (alternatives != null) list.add(alternatives!);
+    if (redFlags != null) list.add(redFlags!);
+    if (followUp != null) list.add(followUp!);
+    return list;
+  }
 
   /// Single text block for vector embedding.
   String get embeddingText {

--- a/test/features/settings/infrastructure/repositories/settings_repository_impl_test.dart
+++ b/test/features/settings/infrastructure/repositories/settings_repository_impl_test.dart
@@ -3,7 +3,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:isar/isar.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';
-import 'package:orionhealth_health/features/settings/data/repositories/settings_repository_impl.dart';
+import 'package:orionhealth_health/features/settings/infrastructure/repositories/settings_repository_impl.dart';
 import 'package:orionhealth_health/features/settings/infrastructure/datasources/settings_local_datasource.dart';
 
 void main() {


### PR DESCRIPTION
Regenerated the dependency injection configuration to align with the recent settings infrastructure refactor. This involved fixing a syntax error in the medical_code entity that was preventing build_runner from completing and updating a test file with the correct import path for the relocated settings repository.

Fixes #928

---
*PR created automatically by Jules for task [7659649677381891428](https://jules.google.com/task/7659649677381891428) started by @iberi22*