### PR TITLE
Replace print() with logger and fix dead code in AudioService

### DIFF
--- a/lib/core/services/audio/audio_player_service.dart
+++ b/lib/core/services/audio/audio_player_service.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter/foundation.dart';
 import 'package:injectable/injectable.dart';
 import 'package:just_audio/just_audio.dart';
+import 'package:orionhealth_health/core/services/app_logger.dart';
 import 'package:orionhealth_health/core/services/audio/audio_recorder_service.dart';
 import 'package:orionhealth_health/core/services/tts/tts_adapter.dart';
 import 'package:orionhealth_health/core/services/tts/sherpa_onnx_adapter.dart';
@@ -15,13 +16,11 @@ class AudioService extends AudioPlayerService {
   late final AudioRecorderService _recorder;
   final StreamController<AudioState> _audioStateController =
       StreamController<AudioState>.broadcast();
-  final StreamController<double> _volumeController =
-      StreamController<double>.broadcast();
 
   AudioService({super.player, AudioRecorderService? recorder})
     : _recorder = recorder ?? AudioRecorderService();
 
-  Stream<double> get currentVolumeStream => _volumeController.stream;
+  Stream<double> get currentVolumeStream => _recorder.currentVolumeStream;
   Stream<AudioState> get stateStream => _audioStateController.stream;
 
   SherpaOnnxTTSAdapter? _tts;
@@ -50,7 +49,7 @@ class AudioService extends AudioPlayerService {
       await _tts!.initialize();
       _ttsInitialized = true;
     } catch (e) {
-      if (kDebugMode) print('TTS init failed: $e — using playAudioBytes fallback');
+      AppLogger.e('AudioService', 'TTS init failed — using playAudioBytes fallback', error: e);
       _ttsInitialized = false;
     }
   }
@@ -92,7 +91,6 @@ class AudioService extends AudioPlayerService {
   void dispose() {
     _recorder.dispose();
     _audioStateController.close();
-    _volumeController.close();
     super.dispose();
   }
 }

--- a/lib/core/utils/loading_manager.dart
+++ b/lib/core/utils/loading_manager.dart
@@ -1,6 +1,6 @@
 import 'dart:async';
-import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
+import 'package:orionhealth_health/core/services/app_logger.dart';
 
 /// Centralized loading state management for the Orion app
 class LoadingManager extends ChangeNotifier {
@@ -47,9 +47,7 @@ class LoadingManager extends ChangeNotifier {
 
     _notifyListeners();
 
-    if (kDebugMode) {
-      print('LoadingManager: Started loading for $operation');
-    }
+    AppLogger.d('LoadingManager', 'Started loading for $operation');
   }
 
   /// Stop loading for an operation
@@ -63,12 +61,11 @@ class LoadingManager extends ChangeNotifier {
 
       _notifyListeners();
 
-      if (kDebugMode) {
-        final duration = DateTime.now().difference(currentState.startTime);
-        print(
-          'LoadingManager: Stopped loading for $operation (${duration.inMilliseconds}ms)',
-        );
-      }
+      final duration = DateTime.now().difference(currentState.startTime);
+      AppLogger.d(
+        'LoadingManager',
+        'Stopped loading for $operation (${duration.inMilliseconds}ms)',
+      );
     }
   }
 
@@ -79,9 +76,7 @@ class LoadingManager extends ChangeNotifier {
       _loadingStates[operation] = currentState.copyWith(message: message);
       _notifyListeners();
 
-      if (kDebugMode) {
-        print('LoadingManager: Updated message for $operation: $message');
-      }
+      AppLogger.d('LoadingManager', 'Updated message for $operation: $message');
     }
   }
 
@@ -90,9 +85,7 @@ class LoadingManager extends ChangeNotifier {
     _loadingStates.clear();
     _notifyListeners();
 
-    if (kDebugMode) {
-      print('LoadingManager: Cleared all loading states');
-    }
+    AppLogger.d('LoadingManager', 'Cleared all loading states');
   }
 
   /// Remove a specific loading state
@@ -100,9 +93,7 @@ class LoadingManager extends ChangeNotifier {
     _loadingStates.remove(operation);
     _notifyListeners();
 
-    if (kDebugMode) {
-      print('LoadingManager: Removed loading state for $operation');
-    }
+    AppLogger.d('LoadingManager', 'Removed loading state for $operation');
   }
 
   /// Execute an operation with automatic loading management
@@ -118,9 +109,10 @@ class LoadingManager extends ChangeNotifier {
       final result = await task();
       stopLoading(operation);
 
-      if (successMessage != null && kDebugMode) {
-        print(
-          'LoadingManager: $operation completed successfully - $successMessage',
+      if (successMessage != null) {
+        AppLogger.i(
+          'LoadingManager',
+          '$operation completed successfully - $successMessage',
         );
       }
 
@@ -128,8 +120,8 @@ class LoadingManager extends ChangeNotifier {
     } catch (error) {
       stopLoading(operation);
 
-      if (errorMessage != null && kDebugMode) {
-        print('LoadingManager: $operation failed - $errorMessage: $error');
+      if (errorMessage != null) {
+        AppLogger.e('LoadingManager', '$operation failed - $errorMessage', error: error);
       }
 
       rethrow;

--- a/lib/features/onboarding/main_preview.dart
+++ b/lib/features/onboarding/main_preview.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:orionhealth_health/core/di/injection.dart';
+import 'package:orionhealth_health/core/services/app_logger.dart';
 import 'package:orionhealth_health/core/theme/cyber_theme.dart';
 import 'package:orionhealth_health/features/onboarding/presentation/pages/onboarding_main_page.dart';
 import 'package:isar_agent_memory/isar_agent_memory.dart';
@@ -21,7 +22,7 @@ class OnboardingPreview extends StatelessWidget {
       theme: CyberTheme.darkTheme,
       home: OnboardingMainPage(
         onFinish: () {
-          print('Onboarding Finished');
+          AppLogger.i('OnboardingPreview', 'Onboarding Finished');
         },
       ),
     );


### PR DESCRIPTION
This change migrates `print()` statements to the centralized `AppLogger` in `loading_manager.dart`, `main_preview.dart` (onboarding), and `audio_player_service.dart`. It also cleans up dead code in `AudioService` by removing an unused `StreamController` for volume and instead proxying the stream from `AudioRecorderService`, which is more efficient and follows the existing architecture. Unit tests were run and passed to ensure no regressions were introduced.

Fixes #935

---
*PR created automatically by Jules for task [327551159718594385](https://jules.google.com/task/327551159718594385) started by @iberi22*