### PR TITLE
fix pii_labels.dart lint warnings

### DIFF
--- a/lib/core/medical/pii_labels.dart
+++ b/lib/core/medical/pii_labels.dart
@@ -2,6 +2,8 @@
 // SPDX-FileCopyrightText: 2025 SouthWest AI Labs
 // Portions Ported from OpenMed: https://github.com/maziyarpanahi/openmed/blob/master/openmed/core/labels.py
 
+// ignore_for_file: constant_identifier_names
+
 /// Canonical PII/PHI label taxonomy.
 /// Ported from OpenMed (Apache 2.0).
 ///


### PR DESCRIPTION
Added `// ignore_for_file: constant_identifier_names` to `lib/core/medical/pii_labels.dart` to suppress lint warnings caused by using UPPER_SNAKE_CASE for constants. This file is a port from OpenMed and preserves its original naming conventions. Verified that `flutter analyze` no longer reports these issues and that existing tests pass.

Fixes #934

---
*PR created automatically by Jules for task [4908860396019343271](https://jules.google.com/task/4908860396019343271) started by @iberi22*