### PR TITLE
Fix invalid_annotation_target in api_audit_log.dart

### DIFF
--- a/lib/core/domain/entities/api_audit_log.dart
+++ b/lib/core/domain/entities/api_audit_log.dart
@@ -45,7 +45,6 @@ class ApiAuditLog {
   }
 
   @override
-  @ignore
   bool operator ==(Object other) =>
       identical(this, other) ||
       other is ApiAuditLog &&
@@ -57,7 +56,6 @@ class ApiAuditLog {
           piiFound == other.piiFound;
 
   @override
-  @ignore
   int get hashCode =>
       timestamp.hashCode ^
       apiName.hashCode ^


### PR DESCRIPTION
Fixed the `invalid_annotation_target` lint error in `lib/core/domain/entities/api_audit_log.dart` by removing the `@ignore` annotation from `operator ==` and `hashCode`. These annotations were incorrectly applied to a method and were redundant for the getter, according to Isar's documentation and project conventions. Unintended side effects in `pubspec.lock` were reverted. The changes were verified with `flutter analyze` and existing unit tests.

Fixes #936

---
*PR created automatically by Jules for task [14679344799182555687](https://jules.google.com/task/14679344799182555687) started by @iberi22*