### PR TITLE
fix: guard BuildContext and setState across async gaps in VitalsPage

### DIFF
--- a/lib/features/vitals/presentation/pages/vitals_page.dart
+++ b/lib/features/vitals/presentation/pages/vitals_page.dart
@@ -30,18 +30,18 @@ class _VitalsPageState extends State<VitalsPage> {
     try {
       final latest = await _repository.getLatestVitals();
       final all = await _repository.getAllVitalSigns();
+      if (!mounted) return;
       setState(() {
         _latestVitals = latest;
         _allVitals = all;
         _isLoading = false;
       });
     } catch (e) {
+      if (!mounted) return;
       setState(() => _isLoading = false);
-      if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error loading vitals: $e')),
-        );
-      }
+      ScaffoldMessenger.of(context).showSnackBar(
+        SnackBar(content: Text('Error loading vitals: $e')),
+      );
     }
   }
 
@@ -282,7 +282,7 @@ class _VitalsPageState extends State<VitalsPage> {
       builder: (context) => _AddVitalBottomSheet(
         onSave: (vital) async {
           await _repository.saveVitalSign(vital);
-          if (context.mounted) {
+          if (mounted) {
             _loadData();
           }
         },
@@ -361,12 +361,13 @@ class _AddVitalBottomSheetState extends State<_AddVitalBottomSheet> {
                 firstDate: DateTime(2000),
                 lastDate: DateTime.now().add(const Duration(days: 1)),
               );
-              if (date != null && mounted) {
+              if (date != null) {
+                if (!context.mounted) return;
                 final time = await showTimePicker(
                   context: context,
                   initialTime: TimeOfDay.fromDateTime(_selectedDateTime),
                 );
-                if (time != null) {
+                if (time != null && mounted) {
                   setState(() {
                     _selectedDateTime = DateTime(
                       date.year,


### PR DESCRIPTION
This PR addresses `use_build_context_synchronously` lint warnings and potential runtime errors in `VitalsPage` by ensuring that `BuildContext` and `State` are properly guarded after asynchronous operations (repository calls and dialog pickers).

Fixes #939

---
*PR created automatically by Jules for task [4291962517412129347](https://jules.google.com/task/4291962517412129347) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved stability when loading vital data by preventing UI updates after the screen has been closed.
  * Made error messages more reliable during failed data loads.
  * Refined the add-vital flow to avoid issues when selecting dates and times after navigation changes.
  * Ensured saved vital entries refresh the screen only when it is still active.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->