### PR TITLE
Fix "Argument codePoint must be a constant" in HomeModuleModel

### DIFF
--- a/lib/features/home/domain/entities/home_module.dart
+++ b/lib/features/home/domain/entities/home_module.dart
@@ -6,17 +6,28 @@ import 'package:flutter/material.dart';
 
 class HomeModule extends Equatable {
   final String title;
-  final IconData icon;
+  final int iconCode;
+  final String? iconFontFamily;
+  final String? iconFontPackage;
   final Color color;
   final String route;
 
   const HomeModule({
     required this.title,
-    required this.icon,
+    required this.iconCode,
+    this.iconFontFamily,
+    this.iconFontPackage,
     required this.color,
     required this.route,
   });
 
   @override
-  List<Object?> get props => [title, icon, color, route];
+  List<Object?> get props => [
+    title,
+    iconCode,
+    iconFontFamily,
+    iconFontPackage,
+    color,
+    route,
+  ];
 }

--- a/lib/features/home/infrastructure/models/home_module_model.dart
+++ b/lib/features/home/infrastructure/models/home_module_model.dart
@@ -7,7 +7,9 @@ import '../../domain/entities/home_module.dart';
 class HomeModuleModel extends HomeModule {
   const HomeModuleModel({
     required super.title,
-    required super.icon,
+    required super.iconCode,
+    super.iconFontFamily,
+    super.iconFontPackage,
     required super.color,
     required super.route,
   });
@@ -15,7 +17,9 @@ class HomeModuleModel extends HomeModule {
   factory HomeModuleModel.fromJson(Map<String, dynamic> json) {
     return HomeModuleModel(
       title: json['title'] as String,
-      icon: IconData(json['icon'] as int, fontFamily: 'MaterialIcons'),
+      iconCode: json['icon'] as int,
+      iconFontFamily: json['iconFontFamily'] as String?,
+      iconFontPackage: json['iconFontPackage'] as String?,
       color: Color(json['color'] as int),
       route: json['route'] as String,
     );
@@ -24,7 +28,9 @@ class HomeModuleModel extends HomeModule {
   Map<String, dynamic> toJson() {
     return {
       'title': title,
-      'icon': icon.codePoint,
+      'icon': iconCode,
+      'iconFontFamily': iconFontFamily,
+      'iconFontPackage': iconFontPackage,
       'color': color.toARGB32(),
       'route': route,
     };
@@ -33,7 +39,9 @@ class HomeModuleModel extends HomeModule {
   factory HomeModuleModel.fromEntity(HomeModule entity) {
     return HomeModuleModel(
       title: entity.title,
-      icon: entity.icon,
+      iconCode: entity.iconCode,
+      iconFontFamily: entity.iconFontFamily,
+      iconFontPackage: entity.iconFontPackage,
       color: entity.color,
       route: entity.route,
     );

--- a/lib/features/home/infrastructure/repositories/home_repository_impl.dart
+++ b/lib/features/home/infrastructure/repositories/home_repository_impl.dart
@@ -72,27 +72,35 @@ class HomeRepositoryImpl implements HomeRepository {
 
     // 3. Fallback to default modules
     final defaultModules = [
-      const HomeModuleModel(
+      HomeModuleModel(
         title: 'AI Assistant',
-        icon: Icons.psychology,
+        iconCode: Icons.psychology.codePoint,
+        iconFontFamily: Icons.psychology.fontFamily,
+        iconFontPackage: Icons.psychology.fontPackage,
         color: Colors.blue,
         route: '/chat',
       ),
-      const HomeModuleModel(
+      HomeModuleModel(
         title: 'Salud',
-        icon: Icons.favorite,
+        iconCode: Icons.favorite.codePoint,
+        iconFontFamily: Icons.favorite.fontFamily,
+        iconFontPackage: Icons.favorite.fontPackage,
         color: Colors.red,
         route: '/vitals',
       ),
-      const HomeModuleModel(
+      HomeModuleModel(
         title: 'Medicamentos',
-        icon: Icons.medication,
+        iconCode: Icons.medication.codePoint,
+        iconFontFamily: Icons.medication.fontFamily,
+        iconFontPackage: Icons.medication.fontPackage,
         color: Colors.orange,
         route: '/medications',
       ),
-      const HomeModuleModel(
+      HomeModuleModel(
         title: 'Línea de tiempo',
-        icon: Icons.timeline,
+        iconCode: Icons.timeline.codePoint,
+        iconFontFamily: Icons.timeline.fontFamily,
+        iconFontPackage: Icons.timeline.fontPackage,
         color: Colors.teal,
         route: '/timeline',
       ),

--- a/lib/features/home/presentation/widgets/module_cards.dart
+++ b/lib/features/home/presentation/widgets/module_cards.dart
@@ -55,7 +55,15 @@ class _ModuleCard extends StatelessWidget {
         child: Column(
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
-            Icon(module.icon, color: module.color, size: 32),
+            Icon(
+              IconData(
+                module.iconCode,
+                fontFamily: module.iconFontFamily ?? 'MaterialIcons',
+                fontPackage: module.iconFontPackage,
+              ),
+              color: module.color,
+              size: 32,
+            ),
             const SizedBox(height: 8),
             Text(
               module.title,

--- a/test/features/home/application/home_cubit_test.dart
+++ b/test/features/home/application/home_cubit_test.dart
@@ -41,9 +41,9 @@ void main() {
   );
 
   final tModules = [
-    const HomeModule(
+    HomeModule(
       title: 'Medications',
-      icon: Icons.medication,
+      iconCode: Icons.medication.codePoint,
       color: Colors.blue,
       route: '/medications',
     ),

--- a/test/features/home/domain/entities/home_module_test.dart
+++ b/test/features/home/domain/entities/home_module_test.dart
@@ -5,15 +5,15 @@ import 'package:orionhealth_health/features/home/domain/entities/home_module.dar
 void main() {
   group('HomeModule', () {
     test('should support value equality', () {
-      const module1 = HomeModule(
+      final module1 = HomeModule(
         title: 'Title',
-        icon: Icons.add,
+        iconCode: Icons.add.codePoint,
         color: Colors.red,
         route: '/route',
       );
-      const module2 = HomeModule(
+      final module2 = HomeModule(
         title: 'Title',
-        icon: Icons.add,
+        iconCode: Icons.add.codePoint,
         color: Colors.red,
         route: '/route',
       );
@@ -22,14 +22,23 @@ void main() {
     });
 
     test('should have correct props', () {
-      const module = HomeModule(
+      final module = HomeModule(
         title: 'Title',
-        icon: Icons.add,
+        iconCode: Icons.add.codePoint,
+        iconFontFamily: 'MaterialIcons',
+        iconFontPackage: 'package',
         color: Colors.red,
         route: '/route',
       );
 
-      expect(module.props, ['Title', Icons.add, Colors.red, '/route']);
+      expect(module.props, [
+        'Title',
+        Icons.add.codePoint,
+        'MaterialIcons',
+        'package',
+        Colors.red,
+        '/route',
+      ]);
     });
   });
 }

--- a/test/features/home/infrastructure/datasources/home_remote_datasource_test.dart
+++ b/test/features/home/infrastructure/datasources/home_remote_datasource_test.dart
@@ -11,7 +11,7 @@ void main() {
 
   setUp(() {
     mockDio = MockDio();
-    datasource = HomeRemoteDataSource(mockDio);
+    datasource = HomeRemoteDataSource();
   });
 
   group('HomeRemoteDataSource', () {

--- a/test/features/home/infrastructure/models/home_module_model_test.dart
+++ b/test/features/home/infrastructure/models/home_module_model_test.dart
@@ -1,0 +1,17 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/home/infrastructure/models/home_module_model.dart';
+
+void main() {
+  test('HomeModuleModel fromJson', () {
+    final json = {
+      'title': 'Test',
+      'icon': 0xe8b8,
+      'color': 4278190335, // 0xFF0000FF
+      'route': '/test',
+    };
+    final model = HomeModuleModel.fromJson(json);
+    expect(model.title, 'Test');
+    expect(model.iconCode, 0xe8b8);
+  });
+}

--- a/test/features/home/presentation/widgets/module_cards_test.dart
+++ b/test/features/home/presentation/widgets/module_cards_test.dart
@@ -5,15 +5,15 @@ import 'package:orionhealth_health/features/home/presentation/widgets/module_car
 
 void main() {
   final tModules = [
-    const HomeModule(
+    HomeModule(
       title: 'Module 1',
-      icon: Icons.add,
+      iconCode: Icons.add.codePoint,
       color: Colors.red,
       route: '/1',
     ),
-    const HomeModule(
+    HomeModule(
       title: 'Module 2',
-      icon: Icons.remove,
+      iconCode: Icons.remove.codePoint,
       color: Colors.blue,
       route: '/2',
     ),


### PR DESCRIPTION
The issue was caused by passing a dynamically retrieved code point from an IconData object into another IconData constructor in a way that the Flutter analyzer or compiler expected a constant. To resolve this and improve architectural consistency for serialization, I refactored the HomeModule entity and HomeModuleModel to store the icon's primitive attributes (code point, font family, and font package) instead of the IconData object itself.

Key changes:
1.  **Domain Layer:** Updated `HomeModule` to use `int iconCode`, `String? iconFontFamily`, and `String? iconFontPackage`.
2.  **Infrastructure Layer:** 
    -   Updated `HomeModuleModel` to support these new fields and handle them in `fromJson` and `toJson`.
    -   Updated `HomeRepositoryImpl` to provide these attributes for default system modules.
3.  **Presentation Layer:** Updated `ModuleCards` to instantiate the `IconData` object at the point of use in the widget tree.
4.  **Testing:** Updated existing tests for the home feature to match the new constructor signatures and added a specific test for `HomeModuleModel` serialization.
5.  **Cleanup:** Ensured `pubspec.lock` files were restored to their original state and removed temporary diagnostic files.

Fixes #938

---
*PR created automatically by Jules for task [5173881170221357420](https://jules.google.com/task/5173881170221357420) started by @iberi22*