### PR TITLE
Add remaining service implementation tests: local_asr_service + distributed_storage_service

### DIFF
--- a/lib/core/services/asr/sherpa_onnx_asr_service.dart
+++ b/lib/core/services/asr/sherpa_onnx_asr_service.dart
@@ -22,10 +22,18 @@ class SherpaOnnxAsrService implements LocalAsrService {
   @override
   Stream<String> get errorStream => _errorController.stream;
 
-  SherpaOnnxAsrService({AsrCallbacks? callbacks})
-      : callbacks = callbacks ?? const AsrCallbacks();
+  final OnDeviceAsrModelManager _manager;
+
+  SherpaOnnxAsrService({
+    AsrCallbacks? callbacks,
+    OnDeviceAsrModelManager? manager,
+  }) : callbacks = callbacks ?? const AsrCallbacks(),
+       _manager = manager ?? OnDeviceAsrModelManager();
 
   OfflineRecognizer? _recognizer;
+
+  @visibleForTesting
+  set recognizer(OfflineRecognizer? value) => _recognizer = value;
 
   @override
   Future<void> initialize() async {
@@ -35,11 +43,10 @@ class SherpaOnnxAsrService implements LocalAsrService {
       state = AsrState.initializing;
       _stateController.add(state);
 
-      final manager = OnDeviceAsrModelManager();
-      await manager.initialize();
+      await _manager.initialize();
 
       final modelKey = await AsrSettings.getPreferredModel();
-      final isInstalled = await manager.isInstalled(modelKey);
+      final isInstalled = await _manager.isInstalled(modelKey);
 
       if (!isInstalled) {
         state = AsrState.unavailable;
@@ -48,15 +55,15 @@ class SherpaOnnxAsrService implements LocalAsrService {
         return;
       }
 
-      final modelEntry = manager.manifest.models.firstWhere((m) => m.key == modelKey);
+      final modelEntry = _manager.manifest.models.firstWhere((m) => m.key == modelKey);
 
       // Basic SenseVoice/Paraformer configuration (adjust based on actual manifest)
       // For SenseVoiceSmall as in manifest:
       final onnxMeta = modelEntry.files.firstWhere((f) => f.url.endsWith('.onnx'));
       final tokensMeta = modelEntry.files.firstWhere((f) => f.url.endsWith('tokens.txt'));
 
-      final onnxPath = await manager.getLocalPath(modelKey, onnxMeta.url);
-      final tokensPath = await manager.getLocalPath(modelKey, tokensMeta.url);
+      final onnxPath = await _manager.getLocalPath(modelKey, onnxMeta.url);
+      final tokensPath = await _manager.getLocalPath(modelKey, tokensMeta.url);
 
       if (onnxPath == null || tokensPath == null) {
         throw Exception('Model files missing despite isInstalled returning true');

--- a/test/core/services/asr/local_asr_service_test.dart
+++ b/test/core/services/asr/local_asr_service_test.dart
@@ -1,0 +1,144 @@
+import 'dart:typed_data';
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:sherpa_onnx/sherpa_onnx.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+import 'package:orionhealth_health/core/services/asr/sherpa_onnx_asr_service.dart';
+import 'package:orionhealth_health/core/services/asr/asr_types.dart';
+import 'package:orionhealth_health/core/services/asr/asr_model_manager.dart';
+import 'package:orionhealth_health/core/services/asr/asr_model_manifest.dart';
+
+class MockOnDeviceAsrModelManager extends Mock implements OnDeviceAsrModelManager {}
+class MockOfflineRecognizer extends Mock implements OfflineRecognizer {}
+class MockOfflineStream extends Mock implements OfflineStream {}
+class MockOfflineRecognizerResult extends Mock implements OfflineRecognizerResult {}
+
+void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  late SherpaOnnxAsrService service;
+  late MockOnDeviceAsrModelManager mockManager;
+  late MockOfflineRecognizer mockRecognizer;
+
+  setUpAll(() {
+    registerFallbackValue(Uint8List(0));
+    registerFallbackValue(Float32List(0));
+  });
+
+  setUp(() {
+    mockManager = MockOnDeviceAsrModelManager();
+    mockRecognizer = MockOfflineRecognizer();
+    service = SherpaOnnxAsrService(manager: mockManager);
+
+    SharedPreferences.setMockInitialValues({});
+
+    // Default mocks for initialize
+    when(() => mockManager.initialize()).thenAnswer((_) async {});
+    when(() => mockManager.manifest).thenReturn(const AsrModelManifest(models: [
+      AsrModelEntry(
+        key: 'sense-voice-small',
+        name: 'SenseVoice',
+        language: 'es',
+        type: 'sense_voice',
+        files: [
+          AsrFileMeta(url: 'model.onnx', md5: '', sizeBytes: 100),
+          AsrFileMeta(url: 'tokens.txt', md5: '', sizeBytes: 10),
+        ],
+      )
+    ]));
+  });
+
+  group('SherpaOnnxAsrService Initialization', () {
+    test('initialize sets state to unavailable if model not installed', () async {
+      when(() => mockManager.isInstalled(any())).thenAnswer((_) async => false);
+
+      await service.initialize();
+
+      expect(service.state, AsrState.unavailable);
+    });
+
+    test('initialize transition states correctly', () async {
+      final states = <AsrState>[];
+      final subscription = service.stateStream.listen(states.add);
+
+      when(() => mockManager.isInstalled(any())).thenAnswer((_) async => false);
+
+      await service.initialize();
+
+      // Give the stream a moment to emit all events
+      await Future.delayed(Duration.zero);
+
+      expect(states, containsAllInOrder([AsrState.initializing, AsrState.unavailable]));
+      await subscription.cancel();
+    });
+  });
+
+  group('SherpaOnnxAsrService Transcription', () {
+    test('transcribe automatically initializes if not ready', () async {
+      when(() => mockManager.isInstalled(any())).thenAnswer((_) async => false);
+
+      expect(
+        () => service.transcribe(Uint8List(0)),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('ASR service not ready'))),
+      );
+
+      verify(() => mockManager.initialize()).called(1);
+    });
+
+    test('transcribe handles successful transcription', () async {
+      service.recognizer = mockRecognizer;
+
+      when(() => mockManager.isInstalled(any())).thenAnswer((_) async => true);
+      when(() => mockManager.getLocalPath(any(), 'model.onnx')).thenAnswer((_) async => 'path/to/model.onnx');
+      when(() => mockManager.getLocalPath(any(), 'tokens.txt')).thenAnswer((_) async => 'path/to/tokens.txt');
+
+      final mockStream = MockOfflineStream();
+      final mockResult = MockOfflineRecognizerResult();
+      when(() => mockResult.text).thenReturn('Hola');
+      when(() => mockRecognizer.createStream()).thenReturn(mockStream);
+      when(() => mockRecognizer.getResult(mockStream)).thenReturn(mockResult);
+      when(() => mockRecognizer.decode(mockStream)).thenReturn(null);
+      when(() => mockStream.acceptWaveform(samples: any(named: 'samples'), sampleRate: any(named: 'sampleRate'))).thenReturn(null);
+      when(() => mockStream.free()).thenReturn(null);
+
+      // We need to bypass the actual initialize() call to native OfflineRecognizer
+      // One way is to make sure service.state is already AsrState.ready
+      // Since state is private-ish (getter only in interface, but public in impl), we can't set it easily.
+      // But wait, the impl has 'AsrState state = AsrState.uninitialized;'. It's public.
+
+      service.state = AsrState.ready;
+
+      final result = await service.transcribe(Uint8List(44 + 2)); // Some dummy data with RIFF header space
+
+      expect(result, 'Hola');
+      expect(service.state, AsrState.ready);
+      verify(() => mockRecognizer.createStream()).called(1);
+    });
+
+    test('transcribe handles errors', () async {
+      service.recognizer = mockRecognizer;
+      service.state = AsrState.ready;
+
+      when(() => mockRecognizer.createStream()).thenThrow(Exception('Native error'));
+
+      expect(
+        () => service.transcribe(Uint8List(0)),
+        throwsA(isA<Exception>()),
+      );
+      expect(service.state, AsrState.error);
+    });
+  });
+
+  test('stop updates state from transcribing to ready', () async {
+    service.state = AsrState.transcribing;
+    await service.stop();
+    expect(service.state, AsrState.ready);
+  });
+
+  test('dispose closes controllers', () {
+    service.dispose();
+    expect(service.stateStream, emitsDone);
+    expect(service.errorStream, emitsDone);
+  });
+}

--- a/test/features/sync/domain/services/distributed_storage_service_test.dart
+++ b/test/features/sync/domain/services/distributed_storage_service_test.dart
@@ -1,0 +1,91 @@
+import 'dart:typed_data';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:crypto/crypto.dart';
+import 'package:orionhealth_health/features/sync/infrastructure/services/ipfs_service.dart';
+import 'package:orionhealth_health/features/sync/infrastructure/datasources/ipfs_datasource.dart';
+import 'package:orionhealth_health/features/sync/infrastructure/datasources/filecoin_datasource.dart';
+
+class MockIpfsDatasource extends Mock implements IpfsDatasource {}
+class MockFilecoinDatasource extends Mock implements FilecoinDatasource {}
+
+void main() {
+  late IpfsService ipfsService;
+  late MockIpfsDatasource mockIpfsDatasource;
+  late MockFilecoinDatasource mockFilecoinDatasource;
+
+  setUpAll(() {
+    registerFallbackValue(Uint8List(0));
+  });
+
+  setUp(() {
+    mockIpfsDatasource = MockIpfsDatasource();
+    mockFilecoinDatasource = MockFilecoinDatasource();
+    ipfsService = IpfsService(mockIpfsDatasource, mockFilecoinDatasource);
+  });
+
+  group('DistributedStorageService (IpfsService)', () {
+    test('cacheData stores data and returns CID', () async {
+      final data = Uint8List.fromList([1, 2, 3]);
+      const cid = 'QmTest';
+
+      when(() => mockIpfsDatasource.add(data)).thenAnswer((_) async => cid);
+      when(() => mockIpfsDatasource.pin(cid)).thenAnswer((_) async => {});
+
+      final result = await ipfsService.cacheData(data);
+
+      expect(result, cid);
+      verify(() => mockIpfsDatasource.add(data)).called(1);
+      verify(() => mockIpfsDatasource.pin(cid)).called(1);
+    });
+
+    test('getData retrieves data and verifies hash', () async {
+      final data = Uint8List.fromList([1, 2, 3]);
+      const cid = 'QmTest';
+      final hash = sha256.convert(data).toString();
+
+      when(() => mockIpfsDatasource.get(cid)).thenAnswer((_) async => data);
+
+      final result = await ipfsService.getData(cid, hash);
+
+      expect(result, data);
+    });
+
+    test('getData throws Exception on hash mismatch (Conflict/Integrity)', () async {
+      final data = Uint8List.fromList([1, 2, 3]);
+      const cid = 'QmTest';
+      const wrongHash = 'wronghash';
+
+      when(() => mockIpfsDatasource.get(cid)).thenAnswer((_) async => data);
+
+      expect(
+        () => ipfsService.getData(cid, wrongHash),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('integrity verification failed'))),
+      );
+    });
+
+    test('handles network/datasource errors', () async {
+      final data = Uint8List.fromList([1, 2, 3]);
+
+      when(() => mockIpfsDatasource.add(any())).thenThrow(Exception('Network unreachable'));
+
+      expect(
+        () => ipfsService.cacheData(data),
+        throwsA(isA<Exception>().having((e) => e.toString(), 'message', contains('Network unreachable'))),
+      );
+    });
+
+    test('cacheData with backupToFilecoin calls filecoin datasource', () async {
+       final data = Uint8List.fromList([1, 2, 3]);
+       const cid = 'QmTest';
+
+       when(() => mockIpfsDatasource.add(data)).thenAnswer((_) async => cid);
+       when(() => mockIpfsDatasource.pin(cid)).thenAnswer((_) async => {});
+       when(() => mockFilecoinDatasource.store(data)).thenAnswer((_) async => 'deal-id');
+
+       await ipfsService.cacheData(data, backupToFilecoin: true);
+
+       verify(() => mockFilecoinDatasource.store(data)).called(1);
+    });
+  });
+}


### PR DESCRIPTION
I have implemented the remaining service implementation tests for `local_asr_service` and `distributed_storage_service`.

1. **ASR Service Tests**: Added `test/core/services/asr/local_asr_service_test.dart`. To make `SherpaOnnxAsrService` testable, I refactored its constructor to accept an optional `OnDeviceAsrModelManager` and added a `@visibleForTesting` setter for `OfflineRecognizer`. The tests cover initialization (including failure when models are missing), state transitions, successful transcription (using mocks for native components), and error handling.

2. **Distributed Storage Service Tests**: Added `test/features/sync/domain/services/distributed_storage_service_test.dart`. These tests verify `IpfsService`'s ability to cache data (with optional Filecoin backup), retrieve data, and handle integrity failures (conflict resolution) or network errors.

3. **Environment Fixes**: I ran `flutter gen-l10n` to resolve missing localization classes that were causing compilation errors during the test run.

All new tests and relevant existing tests in the `asr` and `sync` modules have been verified to pass.

Fixes #854

---
*PR created automatically by Jules for task [16427596015793882745](https://jules.google.com/task/16427596015793882745) started by @iberi22*