### PR TITLE
Fix ink_sparkle.frag shader missing SkSL fallback — crashes tests on non-Vulkan backends

### DIFF
--- a/lib/core/theme/app_theme.dart
+++ b/lib/core/theme/app_theme.dart
@@ -13,6 +13,7 @@ class AppTheme {
 
     return base.copyWith(
       scaffoldBackgroundColor: AppColors.background,
+      splashFactory: InkRipple.splashFactory,
       colorScheme: const ColorScheme.dark(
         primary: AppColors.primary,
         secondary: AppColors.secondary,

--- a/lib/core/widgets/glassmorphic_card.dart
+++ b/lib/core/widgets/glassmorphic_card.dart
@@ -19,17 +19,20 @@ class GlassmorphicCard extends StatelessWidget {
       borderRadius: BorderRadius.circular(16),
       child: BackdropFilter(
         filter: ImageFilter.blur(sigmaX: 10, sigmaY: 10),
-        child: InkWell(
-          onTap: onTap,
-          borderRadius: BorderRadius.circular(16),
-          child: Container(
+        child: Material(
+          type: MaterialType.transparency,
+          child: InkWell(
+            onTap: onTap,
+            borderRadius: BorderRadius.circular(16),
+            child: Container(
             padding: padding ?? const EdgeInsets.all(16),
             decoration: BoxDecoration(
               color: Colors.white.withAlpha(30),
               borderRadius: BorderRadius.circular(16),
               border: Border.all(color: Colors.white.withAlpha(40)),
             ),
-            child: child,
+              child: child,
+            ),
           ),
         ),
       ),


### PR DESCRIPTION
The `ink_sparkle.frag` shader, which is the default for Material 3 splashes (`InkSparkle`), lacks a required SkSL fallback for non-Vulkan backends, causing crashes during Flutter tests.

This PR implements a robust workaround by:
1. Switching the global `splashFactory` to `InkRipple.splashFactory` in `AppTheme.darkTheme`.
2. Enhancing `GlassmorphicCard` by adding a `Material(type: MaterialType.transparency)` wrapper around its `InkWell` to support the new splash effect and prevent potential visibility issues within semi-transparent containers.

Affected tests in `appointments_page_test.dart` and `connection_status_indicator_test.dart` have been verified to pass with these changes.

Fixes #952

---
*PR created automatically by Jules for task [15175733544102755136](https://jules.google.com/task/15175733544102755136) started by @iberi22*