### PR TITLE
[fix] about: add usecases to domain layer

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -15,7 +15,7 @@ import 'package:flutter_appauth/flutter_appauth.dart' as _i34;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i36;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:google_generative_ai/google_generative_ai.dart' as _i38;
-import 'package:health_wallet/health_wallet.dart' as _i30;
+import 'package:health_wallet/health_wallet.dart' as _i29;
 import 'package:http/http.dart' as _i21;
 import 'package:injectable/injectable.dart' as _i2;
 import 'package:isar/isar.dart' as _i54;
@@ -24,28 +24,30 @@ import 'package:just_audio/just_audio.dart' as _i9;
 import 'package:medical_standards/medical_standards.dart' as _i62;
 import 'package:shared_preferences/shared_preferences.dart' as _i45;
 
-import '../../features/about/application/about_cubit.dart' as _i122;
+import '../../features/about/application/about_cubit.dart' as _i196;
 import '../../features/about/data/datasources/about_local_datasource.dart'
     as _i4;
 import '../../features/about/data/datasources/about_remote_datasource.dart'
-    as _i123;
+    as _i122;
 import '../../features/about/domain/repositories/i_about_repository.dart'
     as _i47;
+import '../../features/about/domain/usecases/check_updates.dart' as _i134;
+import '../../features/about/domain/usecases/get_app_info.dart' as _i151;
 import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
     as _i48;
-import '../../features/allergies/application/allergies_cubit.dart' as _i195;
-import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i196;
+import '../../features/allergies/application/allergies_cubit.dart' as _i197;
+import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i198;
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i124;
+    as _i123;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i5;
 import '../../features/allergies/infrastructure/repositories/isar_allergy_repository.dart'
-    as _i125;
+    as _i124;
 import '../../features/appointments/application/appointments_cubit.dart'
-    as _i128;
+    as _i127;
 import '../../features/appointments/application/bloc/appointment_bloc.dart'
-    as _i197;
+    as _i199;
 import '../../features/appointments/domain/repositories/appointment_repository.dart'
-    as _i126;
+    as _i125;
 import '../../features/appointments/domain/services/appointment_service.dart'
     as _i6;
 import '../../features/appointments/domain/usecases/delete_appointment_usecase.dart'
@@ -53,34 +55,34 @@ import '../../features/appointments/domain/usecases/delete_appointment_usecase.d
 import '../../features/appointments/domain/usecases/get_all_appointments_usecase.dart'
     as _i150;
 import '../../features/appointments/domain/usecases/save_appointment_usecase.dart'
-    as _i184;
+    as _i185;
 import '../../features/appointments/infrastructure/repositories/isar_appointment_repository.dart'
-    as _i127;
-import '../../features/auth/application/auth_cubit.dart' as _i198;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i199;
-import '../../features/auth/domain/auth_service.dart' as _i131;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i129;
+    as _i126;
+import '../../features/auth/application/auth_cubit.dart' as _i200;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i201;
+import '../../features/auth/domain/auth_service.dart' as _i130;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i128;
 import '../../features/auth/infrastructure/repositories/auth_repository_impl.dart'
-    as _i130;
+    as _i129;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i11;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i29;
+    as _i30;
 import '../../features/calendar_import/application/calendar_import_cubit.dart'
-    as _i202;
+    as _i204;
 import '../../features/calendar_import/domain/repositories/calendar_repository.dart'
     as _i18;
 import '../../features/calendar_import/domain/services/calendar_parser_service.dart'
     as _i16;
 import '../../features/calendar_import/domain/usecases/import_calendar_usecase.dart'
-    as _i169;
+    as _i170;
 import '../../features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart'
     as _i14;
 import '../../features/calendar_import/infrastructure/repositories/calendar_repository_impl.dart'
     as _i19;
 import '../../features/calendar_import/infrastructure/services/calendar_parser_service_impl.dart'
     as _i17;
-import '../../features/dashboard/application/dashboard_cubit.dart' as _i203;
+import '../../features/dashboard/application/dashboard_cubit.dart' as _i205;
 import '../../features/dashboard/data/datasources/dashboard_local_datasource.dart'
     as _i137;
 import '../../features/dashboard/data/datasources/dashboard_remote_datasource.dart'
@@ -90,17 +92,17 @@ import '../../features/dashboard/data/repositories/dashboard_repository_impl.dar
 import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
     as _i138;
 import '../../features/dashboard/domain/usecases/get_dashboard_stats_usecase.dart'
-    as _i153;
+    as _i154;
 import '../../features/dashboard/domain/usecases/get_recent_activity_usecase.dart'
-    as _i155;
+    as _i156;
 import '../../features/doctor_verification/application/badge_cubit.dart'
-    as _i201;
+    as _i203;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
     as _i146;
 import '../../features/doctor_verification/application/second_opinion_cubit.dart'
-    as _i185;
+    as _i186;
 import '../../features/doctor_verification/application/vouch_cubit.dart'
-    as _i194;
+    as _i195;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
     as _i144;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
@@ -110,7 +112,7 @@ import '../../features/doctor_verification/domain/repositories/second_opinion_re
 import '../../features/doctor_verification/domain/repositories/vouch_repository.dart'
     as _i119;
 import '../../features/doctor_verification/domain/services/badge_calculator.dart'
-    as _i200;
+    as _i202;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
     as _i56;
 import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
@@ -133,9 +135,9 @@ import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
 import '../../features/email-citas/infrastructure/repositories/email_repository_impl.dart'
     as _i27;
 import '../../features/eps_connection/application/bloc/eps_connection_bloc.dart'
-    as _i205;
+    as _i207;
 import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
-    as _i206;
+    as _i208;
 import '../../features/eps_connection/data/datasources/oauth_local_datasource.dart'
     as _i85;
 import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
@@ -145,19 +147,19 @@ import '../../features/eps_connection/domain/usecases/connect_provider_usecase.d
 import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
     as _i141;
 import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
-    as _i152;
+    as _i153;
 import '../../features/eps_connection/infrastructure/oauth_repository.dart'
     as _i87;
 import '../../features/health_data_import/application/bloc/health_import_bloc.dart'
-    as _i163;
-import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i164;
+import '../../features/health_data_import/application/health_import_cubit.dart'
+    as _i165;
 import '../../features/health_data_import/data/datasources/health_data_file_datasource.dart'
-    as _i160;
+    as _i161;
 import '../../features/health_data_import/data/datasources/health_data_sensor_datasource.dart'
     as _i40;
 import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i161;
+    as _i162;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i39;
 import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
@@ -165,42 +167,42 @@ import '../../features/health_data_import/domain/usecases/health_import_usecases
 import '../../features/health_data_import/infrastructure/data_source.dart'
     as _i98;
 import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i162;
+    as _i163;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i208;
+    as _i210;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i165;
-import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
     as _i166;
+import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+    as _i167;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i32;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
     as _i49;
 import '../../features/health_record/infrastructure/services/ocr_service.dart'
     as _i88;
-import '../../features/health_sharing/application/sharing_cubit.dart' as _i215;
+import '../../features/health_sharing/application/sharing_cubit.dart' as _i217;
 import '../../features/health_sharing/data/datasources/health_sharing_local_datasource.dart'
     as _i41;
 import '../../features/health_sharing/data/datasources/health_sharing_remote_datasource.dart'
     as _i42;
 import '../../features/health_sharing/domain/usecases/cancel_sharing_usecase.dart'
-    as _i133;
-import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
-    as _i188;
-import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
-    as _i189;
-import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
     as _i132;
+import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
+    as _i189;
+import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
+    as _i190;
+import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
+    as _i131;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i12;
 import '../../features/health_sharing/infrastructure/nfc_handler.dart' as _i80;
 import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
     as _i82;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
     as _i121;
-import '../../features/home/application/home_cubit.dart' as _i209;
-import '../../features/home/domain/repositories/home_repository.dart' as _i167;
+import '../../features/home/application/home_cubit.dart' as _i211;
+import '../../features/home/domain/repositories/home_repository.dart' as _i168;
 import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
-    as _i207;
+    as _i209;
 import '../../features/home/infrastructure/datasources/health_summary_datasource.dart'
     as _i43;
 import '../../features/home/infrastructure/datasources/home_local_datasource.dart'
@@ -208,11 +210,11 @@ import '../../features/home/infrastructure/datasources/home_local_datasource.dar
 import '../../features/home/infrastructure/datasources/home_remote_datasource.dart'
     as _i46;
 import '../../features/home/infrastructure/repositories/home_repository_impl.dart'
-    as _i168;
+    as _i169;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i187;
+    as _i188;
 import '../../features/local_agent/data/datasources/chat_message_local_datasource.dart'
-    as _i134;
+    as _i133;
 import '../../features/local_agent/data/datasources/local_model_local_datasource.dart'
     as _i61;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
@@ -225,36 +227,36 @@ import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i35;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i170;
+    as _i171;
 import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i37;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i171;
+    as _i172;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
     as _i59;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i174;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i173;
+    as _i175;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i174;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
-    as _i210;
+    as _i212;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i64;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i65;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i64;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
     as _i113;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i172;
+    as _i173;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i60;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i211;
+    as _i213;
 import '../../features/local_agent/infrastructure/services/model_download_service.dart'
     as _i79;
 import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i181;
+    as _i182;
 import '../../features/medical_research/application/medical_research_cubit.dart'
-    as _i212;
+    as _i214;
 import '../../features/medical_research/domain/services/medical_scraper_service.dart'
     as _i66;
 import '../../features/medical_research/domain/services/medical_standards_service.dart'
@@ -264,7 +266,7 @@ import '../../features/medical_research/domain/services/medical_web_search_servi
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i13;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i176;
+    as _i177;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i67;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
@@ -272,21 +274,21 @@ import '../../features/medical_research/infrastructure/medical_standards_service
 import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
     as _i71;
 import '../../features/medications/application/bloc/medication_bloc.dart'
-    as _i177;
+    as _i178;
 import '../../features/medications/application/medications_cubit.dart' as _i74;
 import '../../features/medications/domain/repositories/medication_repository.dart'
     as _i72;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
     as _i73;
-import '../../features/meditation/application/meditation_cubit.dart' as _i178;
+import '../../features/meditation/application/meditation_cubit.dart' as _i179;
 import '../../features/meditation/domain/repositories/meditation_repository.dart'
     as _i76;
 import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
     as _i135;
 import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
-    as _i154;
+    as _i155;
 import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
-    as _i156;
+    as _i157;
 import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
     as _i92;
 import '../../features/meditation/domain/usecases/start_session_usecase.dart'
@@ -296,39 +298,39 @@ import '../../features/meditation/infrastructure/datasources/meditation_local_da
 import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
     as _i77;
 import '../../features/network/governance/domain/repositories/governance_repository.dart'
-    as _i158;
-import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
-    as _i157;
-import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
     as _i159;
+import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
+    as _i158;
+import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
+    as _i160;
 import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
     as _i51;
 import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
     as _i50;
 import '../../features/network/incentives/infrastructure/repositories/incentive_repository_impl.dart'
     as _i52;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i213;
-import '../../features/onboarding/application/sync_cubit.dart' as _i190;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i215;
+import '../../features/onboarding/application/sync_cubit.dart' as _i191;
 import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i179;
-import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
     as _i180;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i214;
+import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
+    as _i181;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i216;
 import '../../features/reports/domain/repositories/report_repository.dart'
     as _i93;
 import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i182;
+    as _i183;
 import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i94;
 import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i183;
+    as _i184;
 import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i78;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i175;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i176;
 import '../../features/settings/domain/repositories/settings_repository.dart'
     as _i100;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i24;
+    as _i23;
 import '../../features/settings/infrastructure/datasources/settings_local_datasource.dart'
     as _i99;
 import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
@@ -341,7 +343,7 @@ import '../../features/sync/domain/services/node_discovery_service.dart'
     as _i83;
 import '../../features/sync/domain/services/sync_service.dart' as _i106;
 import '../../features/sync/domain/usecases/distributed_cache_usecase.dart'
-    as _i204;
+    as _i206;
 import '../../features/sync/infrastructure/datasources/filecoin_datasource.dart'
     as _i33;
 import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
@@ -355,7 +357,7 @@ import '../../features/sync/infrastructure/services/node_discovery_service.dart'
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
     as _i107;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i191;
+    as _i192;
 import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
     as _i108;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
@@ -364,19 +366,19 @@ import '../../features/user_profile/domain/services/user_profile_service.dart'
     as _i111;
 import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
     as _i110;
-import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i192;
+import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i193;
 import '../../features/vitals/application/vitals_cubit.dart' as _i116;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
     as _i114;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
     as _i115;
-import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i193;
+import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i194;
 import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
     as _i117;
 import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
-    as _i151;
+    as _i152;
 import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
-    as _i186;
+    as _i187;
 import '../../features/voice_chat/infrastructure/datasources/chat_ai_datasource.dart'
     as _i20;
 import '../../features/voice_chat/infrastructure/repositories/voice_chat_repository_impl.dart'
@@ -385,13 +387,13 @@ import '../services/aicore_service.dart' as _i3;
 import '../services/asr/asr_service.dart' as _i7;
 import '../services/audio/audio_player_service.dart' as _i8;
 import '../services/audio/audio_recorder_service.dart' as _i10;
-import '../services/device_capability_service.dart' as _i23;
+import '../services/device_capability_service.dart' as _i24;
 import '../services/privacy_anonymizer.dart' as _i89;
-import 'database_module.dart' as _i219;
-import 'fhir_module.dart' as _i220;
-import 'memory_module.dart' as _i218;
-import 'network_module.dart' as _i217;
-import 'service_module.dart' as _i216;
+import 'database_module.dart' as _i221;
+import 'fhir_module.dart' as _i222;
+import 'memory_module.dart' as _i220;
+import 'network_module.dart' as _i219;
+import 'service_module.dart' as _i218;
 
 const String _desktop = 'desktop';
 const String _test = 'test';
@@ -452,9 +454,9 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.lazySingleton<_i28.EmbeddingsAdapter>(
         () => memoryModule.embeddingsAdapter);
-    gh.lazySingleton<_i29.EncryptionService>(() => _i29.EncryptionService());
-    gh.lazySingleton<_i30.EncryptionService>(
+    gh.lazySingleton<_i29.EncryptionService>(
         () => databaseModule.walletEncryptionService);
+    gh.lazySingleton<_i30.EncryptionService>(() => _i30.EncryptionService());
     gh.lazySingleton<_i31.FhirClient>(() => fhirModule.fhirClient);
     gh.lazySingleton<_i32.FilePickerService>(
         () => _i32.FilePickerServiceImpl());
@@ -512,15 +514,15 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i62.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
     gh.factory<_i63.MedicalKnowledgeRepository>(
-      () => _i64.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
-    );
-    gh.factory<_i63.MedicalKnowledgeRepository>(
-      () => _i65.JsonMedicalKnowledgeRepository(),
+      () => _i64.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
+    );
+    gh.factory<_i63.MedicalKnowledgeRepository>(
+      () => _i65.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
     );
     gh.lazySingleton<_i66.MedicalScraperService>(
         () => _i67.MedicalScraperServiceImpl(
@@ -618,35 +620,35 @@ extension GetItInjectableX on _i1.GetIt {
         () => _i118.VoiceChatRepositoryImpl(gh<_i20.ChatAiDatasource>()));
     gh.lazySingleton<_i119.VouchRepository>(
         () => _i120.IsarVouchRepository(gh<_i54.Isar>()));
-    gh.lazySingleton<_i30.WalletService>(() => databaseModule.walletService(
+    gh.lazySingleton<_i29.WalletService>(() => databaseModule.walletService(
           gh<_i54.Isar>(),
-          gh<_i30.EncryptionService>(),
+          gh<_i29.EncryptionService>(),
         ));
     gh.lazySingleton<_i121.WifiDirectService>(() => _i121.WifiDirectService());
-    gh.factory<_i122.AboutCubit>(
-        () => _i122.AboutCubit(gh<_i47.IAboutRepository>()));
-    gh.lazySingleton<_i123.AboutRemoteDataSource>(
-        () => _i123.AboutRemoteDataSource(gh<_i25.Dio>()));
-    gh.lazySingleton<_i124.AllergyRepository>(
-        () => _i125.IsarAllergyRepository(gh<_i54.Isar>()));
-    gh.lazySingleton<_i126.AppointmentRepository>(
-        () => _i127.IsarAppointmentRepository(gh<_i54.Isar>()));
-    gh.factory<_i128.AppointmentsCubit>(
-        () => _i128.AppointmentsCubit(gh<_i126.AppointmentRepository>()));
-    gh.lazySingleton<_i129.AuthRepository>(
-        () => _i130.AuthRepositoryImpl(gh<_i54.Isar>()));
-    gh.lazySingleton<_i131.AuthService>(
-        () => _i131.AuthServiceImpl(gh<_i29.EncryptionService>()));
-    gh.lazySingleton<_i132.BleSharingService>(
-        () => _i132.BleSharingService(gh<_i12.BleWrapper>()));
-    gh.lazySingleton<_i133.CancelSharingUseCase>(
-        () => _i133.CancelSharingUseCase(
-              gh<_i132.BleSharingService>(),
+    gh.lazySingleton<_i122.AboutRemoteDataSource>(
+        () => _i122.AboutRemoteDataSource(gh<_i25.Dio>()));
+    gh.lazySingleton<_i123.AllergyRepository>(
+        () => _i124.IsarAllergyRepository(gh<_i54.Isar>()));
+    gh.lazySingleton<_i125.AppointmentRepository>(
+        () => _i126.IsarAppointmentRepository(gh<_i54.Isar>()));
+    gh.factory<_i127.AppointmentsCubit>(
+        () => _i127.AppointmentsCubit(gh<_i125.AppointmentRepository>()));
+    gh.lazySingleton<_i128.AuthRepository>(
+        () => _i129.AuthRepositoryImpl(gh<_i54.Isar>()));
+    gh.lazySingleton<_i130.AuthService>(
+        () => _i130.AuthServiceImpl(gh<_i30.EncryptionService>()));
+    gh.lazySingleton<_i131.BleSharingService>(
+        () => _i131.BleSharingService(gh<_i12.BleWrapper>()));
+    gh.lazySingleton<_i132.CancelSharingUseCase>(
+        () => _i132.CancelSharingUseCase(
+              gh<_i131.BleSharingService>(),
               gh<_i82.NfcSharingService>(),
               gh<_i121.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i134.ChatMessageLocalDataSource>(
-        () => _i134.ChatMessageLocalDataSource(gh<_i54.Isar>()));
+    gh.lazySingleton<_i133.ChatMessageLocalDataSource>(
+        () => _i133.ChatMessageLocalDataSource(gh<_i54.Isar>()));
+    gh.factory<_i134.CheckUpdates>(
+        () => _i134.CheckUpdates(gh<_i47.IAboutRepository>()));
     gh.lazySingleton<_i135.CompleteSessionUseCase>(
         () => _i135.CompleteSessionUseCase(gh<_i76.MeditationRepository>()));
     gh.factory<_i103.ConnectEmailProviderUseCase>(
@@ -665,7 +667,7 @@ extension GetItInjectableX on _i1.GetIt {
               gh<_i93.ReportRepository>(),
             ));
     gh.factory<_i140.DeleteAppointmentUseCase>(() =>
-        _i140.DeleteAppointmentUseCase(gh<_i126.AppointmentRepository>()));
+        _i140.DeleteAppointmentUseCase(gh<_i125.AppointmentRepository>()));
     gh.factory<_i141.DisconnectProviderUseCase>(
         () => _i141.DisconnectProviderUseCase(
               gh<_i86.OAuthRepository>(),
@@ -687,11 +689,11 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i103.ConnectEmailProviderUseCase>(),
           gh<_i103.SyncEmailAppointmentsUseCase>(),
           gh<_i26.EmailRepository>(),
-          gh<_i126.AppointmentRepository>(),
+          gh<_i125.AppointmentRepository>(),
         ));
     gh.factory<_i148.EmailCitasCubit>(() => _i148.EmailCitasCubit(
           gh<_i26.EmailRepository>(),
-          gh<_i126.AppointmentRepository>(),
+          gh<_i125.AppointmentRepository>(),
         ));
     gh.factory<_i149.FhirSyncCubit>(() => _i149.FhirSyncCubit(
           gh<_i106.SyncService>(),
@@ -703,61 +705,63 @@ extension GetItInjectableX on _i1.GetIt {
               gh<_i88.OcrService>(),
             ));
     gh.factory<_i150.GetAllAppointmentsUseCase>(() =>
-        _i150.GetAllAppointmentsUseCase(gh<_i126.AppointmentRepository>()));
+        _i150.GetAllAppointmentsUseCase(gh<_i125.AppointmentRepository>()));
+    gh.factory<_i151.GetAppInfo>(
+        () => _i151.GetAppInfo(gh<_i47.IAboutRepository>()));
     gh.factory<_i95.GetAvailableSourcesUseCase>(() =>
         _i95.GetAvailableSourcesUseCase(gh<_i39.HealthDataImportService>()));
-    gh.factory<_i151.GetChatHistoryUseCase>(
-        () => _i151.GetChatHistoryUseCase(gh<_i117.VoiceChatRepository>()));
-    gh.factory<_i152.GetConnectionsUseCase>(
-        () => _i152.GetConnectionsUseCase(gh<_i86.OAuthRepository>()));
-    gh.factory<_i153.GetDashboardStatsUseCase>(
-        () => _i153.GetDashboardStatsUseCase(gh<_i138.DashboardRepository>()));
-    gh.lazySingleton<_i154.GetProgressUseCase>(
-        () => _i154.GetProgressUseCase(gh<_i76.MeditationRepository>()));
-    gh.factory<_i155.GetRecentActivityUseCase>(
-        () => _i155.GetRecentActivityUseCase(gh<_i138.DashboardRepository>()));
-    gh.lazySingleton<_i156.GetScriptsUseCase>(
-        () => _i156.GetScriptsUseCase(gh<_i76.MeditationRepository>()));
-    gh.lazySingleton<_i157.GovernanceIpfsDatasource>(
-        () => _i157.GovernanceIpfsDatasource(gh<_i53.IpfsDatasource>()));
-    gh.lazySingleton<_i158.GovernanceRepository>(() =>
-        _i159.GovernanceRepositoryImpl(gh<_i157.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i160.HealthDataFileDataSource>(
-        () => _i160.HealthDataFileDataSource(
+    gh.factory<_i152.GetChatHistoryUseCase>(
+        () => _i152.GetChatHistoryUseCase(gh<_i117.VoiceChatRepository>()));
+    gh.factory<_i153.GetConnectionsUseCase>(
+        () => _i153.GetConnectionsUseCase(gh<_i86.OAuthRepository>()));
+    gh.factory<_i154.GetDashboardStatsUseCase>(
+        () => _i154.GetDashboardStatsUseCase(gh<_i138.DashboardRepository>()));
+    gh.lazySingleton<_i155.GetProgressUseCase>(
+        () => _i155.GetProgressUseCase(gh<_i76.MeditationRepository>()));
+    gh.factory<_i156.GetRecentActivityUseCase>(
+        () => _i156.GetRecentActivityUseCase(gh<_i138.DashboardRepository>()));
+    gh.lazySingleton<_i157.GetScriptsUseCase>(
+        () => _i157.GetScriptsUseCase(gh<_i76.MeditationRepository>()));
+    gh.lazySingleton<_i158.GovernanceIpfsDatasource>(
+        () => _i158.GovernanceIpfsDatasource(gh<_i53.IpfsDatasource>()));
+    gh.lazySingleton<_i159.GovernanceRepository>(() =>
+        _i160.GovernanceRepositoryImpl(gh<_i158.GovernanceIpfsDatasource>()));
+    gh.lazySingleton<_i161.HealthDataFileDataSource>(
+        () => _i161.HealthDataFileDataSource(
               gh<_i32.FilePickerService>(),
               gh<_i88.OcrService>(),
             ));
-    gh.lazySingleton<_i161.HealthDataImportRepository>(
-        () => _i162.HealthDataImportRepositoryImpl(
+    gh.lazySingleton<_i162.HealthDataImportRepository>(
+        () => _i163.HealthDataImportRepositoryImpl(
               gh<_i98.SensorHealthDataSource>(),
               gh<_i98.FileHealthDataSource>(),
             ));
-    gh.factory<_i163.HealthImportBloc>(() => _i163.HealthImportBloc(
+    gh.factory<_i164.HealthImportBloc>(() => _i164.HealthImportBloc(
           gh<_i95.GetAvailableSourcesUseCase>(),
           gh<_i95.RequestHealthAuthUseCase>(),
           gh<_i39.HealthDataImportService>(),
           gh<_i114.VitalSignRepository>(),
         ));
-    gh.factory<_i164.HealthImportCubit>(() => _i164.HealthImportCubit(
+    gh.factory<_i165.HealthImportCubit>(() => _i165.HealthImportCubit(
           gh<_i39.HealthDataImportService>(),
           gh<_i114.VitalSignRepository>(),
         ));
-    gh.lazySingleton<_i165.HealthRecordRepository>(
-        () => _i166.HealthRecordRepositoryImpl(gh<_i54.Isar>()));
-    gh.lazySingleton<_i167.HomeRepository>(() => _i168.HomeRepositoryImpl(
+    gh.lazySingleton<_i166.HealthRecordRepository>(
+        () => _i167.HealthRecordRepositoryImpl(gh<_i54.Isar>()));
+    gh.lazySingleton<_i168.HomeRepository>(() => _i169.HomeRepositoryImpl(
           gh<_i114.VitalSignRepository>(),
-          gh<_i126.AppointmentRepository>(),
+          gh<_i125.AppointmentRepository>(),
           gh<_i72.MedicationRepository>(),
           gh<_i44.HomeLocalDataSource>(),
           gh<_i46.HomeRemoteDataSource>(),
         ));
-    gh.factory<_i169.ImportCalendarUseCase>(() => _i169.ImportCalendarUseCase(
+    gh.factory<_i170.ImportCalendarUseCase>(() => _i170.ImportCalendarUseCase(
           gh<_i18.CalendarRepository>(),
-          gh<_i126.AppointmentRepository>(),
+          gh<_i125.AppointmentRepository>(),
           gh<_i109.UserProfileRepository>(),
         ));
     gh.lazySingleton<_i57.LlmAdapter>(
-      () => _i170.GeminiLlmAdapter(
+      () => _i171.GeminiLlmAdapter(
         scrubber: gh<_i89.PromptScrubber>(),
         userProfileRepository: gh<_i109.UserProfileRepository>(),
         modelWrapper: gh<_i37.GeminiModelWrapper>(),
@@ -765,188 +769,192 @@ extension GetItInjectableX on _i1.GetIt {
       instanceName: 'gemini',
     );
     gh.factory<_i57.LlmAdapter>(
-      () => _i171.MockLlmAdapter(gh<_i89.PromptScrubber>()),
+      () => _i172.MockLlmAdapter(gh<_i89.PromptScrubber>()),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i172.LlmAdapterFactory>(
-        () => _i172.LlmAdapterFactory(gh<_i100.SettingsRepository>()));
-    gh.lazySingleton<_i173.LlmService>(() => _i174.GemmaLlmService(
+    gh.lazySingleton<_i173.LlmAdapterFactory>(
+        () => _i173.LlmAdapterFactory(gh<_i100.SettingsRepository>()));
+    gh.lazySingleton<_i174.LlmService>(() => _i175.GemmaLlmService(
           gh<_i112.VectorStoreService>(),
           gh<_i109.UserProfileRepository>(),
           gh<_i57.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i175.LlmSettingsCubit>(() => _i175.LlmSettingsCubit(
+    gh.factory<_i176.LlmSettingsCubit>(() => _i176.LlmSettingsCubit(
           gh<_i100.SettingsRepository>(),
-          gh<_i24.DeviceCapabilityService>(),
+          gh<_i23.DeviceCapabilityService>(),
           gh<_i57.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.lazySingleton<_i176.MedicalResearchService>(
-        () => _i176.MedicalResearchService(
+    gh.lazySingleton<_i177.MedicalResearchService>(
+        () => _i177.MedicalResearchService(
               gh<_i70.MedicalWebSearchService>(),
               gh<_i66.MedicalScraperService>(),
             ));
-    gh.factory<_i177.MedicationBloc>(
-        () => _i177.MedicationBloc(gh<_i72.MedicationRepository>()));
-    gh.factory<_i178.MeditationCubit>(() => _i178.MeditationCubit(
+    gh.factory<_i178.MedicationBloc>(
+        () => _i178.MedicationBloc(gh<_i72.MedicationRepository>()));
+    gh.factory<_i179.MeditationCubit>(() => _i179.MeditationCubit(
           gh<_i92.RecommendScriptUseCase>(),
           gh<_i102.StartSessionUseCase>(),
           gh<_i135.CompleteSessionUseCase>(),
-          gh<_i154.GetProgressUseCase>(),
+          gh<_i155.GetProgressUseCase>(),
           gh<_i8.AudioService>(),
         ));
-    gh.lazySingleton<_i179.OnboardingRepository>(() =>
-        _i180.OnboardingRepositoryImpl(gh<_i109.UserProfileRepository>()));
-    gh.lazySingleton<_i181.PatientContextIndexer>(
-      () => _i181.PatientContextIndexer(
+    gh.lazySingleton<_i180.OnboardingRepository>(() =>
+        _i181.OnboardingRepositoryImpl(gh<_i109.UserProfileRepository>()));
+    gh.lazySingleton<_i182.PatientContextIndexer>(
+      () => _i182.PatientContextIndexer(
         gh<_i54.Isar>(),
         gh<_i112.VectorStoreService>(),
-        gh<_i165.HealthRecordRepository>(),
+        gh<_i166.HealthRecordRepository>(),
         gh<_i72.MedicationRepository>(),
-        gh<_i124.AllergyRepository>(),
+        gh<_i123.AllergyRepository>(),
         gh<_i114.VitalSignRepository>(),
-        gh<_i126.AppointmentRepository>(),
+        gh<_i125.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i182.ReportGenerationService>(
-        () => _i183.GemmaReportGenerationService(
+    gh.lazySingleton<_i183.ReportGenerationService>(
+        () => _i184.GemmaReportGenerationService(
               gh<_i57.LlmAdapter>(instanceName: 'gemma'),
               gh<_i112.VectorStoreService>(),
               gh<_i109.UserProfileRepository>(),
               gh<_i89.PromptScrubber>(),
             ));
-    gh.factory<_i184.SaveAppointmentUseCase>(
-        () => _i184.SaveAppointmentUseCase(gh<_i126.AppointmentRepository>()));
-    gh.factory<_i185.SecondOpinionCubit>(
-        () => _i185.SecondOpinionCubit(gh<_i96.SecondOpinionRepository>()));
-    gh.factory<_i186.SendMessageUseCase>(
-        () => _i186.SendMessageUseCase(gh<_i117.VoiceChatRepository>()));
-    gh.lazySingleton<_i187.SmartSearchUseCase>(
-        () => _i187.SmartSearchUseCase(gh<_i112.VectorStoreService>()));
-    gh.lazySingleton<_i188.StartListeningUseCase>(
-        () => _i188.StartListeningUseCase(
-              gh<_i132.BleSharingService>(),
+    gh.factory<_i185.SaveAppointmentUseCase>(
+        () => _i185.SaveAppointmentUseCase(gh<_i125.AppointmentRepository>()));
+    gh.factory<_i186.SecondOpinionCubit>(
+        () => _i186.SecondOpinionCubit(gh<_i96.SecondOpinionRepository>()));
+    gh.factory<_i187.SendMessageUseCase>(
+        () => _i187.SendMessageUseCase(gh<_i117.VoiceChatRepository>()));
+    gh.lazySingleton<_i188.SmartSearchUseCase>(
+        () => _i188.SmartSearchUseCase(gh<_i112.VectorStoreService>()));
+    gh.lazySingleton<_i189.StartListeningUseCase>(
+        () => _i189.StartListeningUseCase(
+              gh<_i131.BleSharingService>(),
               gh<_i82.NfcSharingService>(),
               gh<_i121.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i189.StartSharingUseCase>(() => _i189.StartSharingUseCase(
-          gh<_i132.BleSharingService>(),
+    gh.lazySingleton<_i190.StartSharingUseCase>(() => _i190.StartSharingUseCase(
+          gh<_i131.BleSharingService>(),
           gh<_i82.NfcSharingService>(),
           gh<_i121.WifiDirectService>(),
         ));
-    gh.factory<_i190.SyncCubit>(() => _i190.SyncCubit(
+    gh.factory<_i191.SyncCubit>(() => _i191.SyncCubit(
           gh<_i62.SyncService>(),
           gh<_i112.VectorStoreService>(),
         ));
-    gh.factory<_i191.UserProfileCubit>(
-        () => _i191.UserProfileCubit(gh<_i109.UserProfileRepository>()));
-    gh.factory<_i192.VitalSignBloc>(
-        () => _i192.VitalSignBloc(gh<_i114.VitalSignRepository>()));
-    gh.factory<_i193.VoiceChatCubit>(() => _i193.VoiceChatCubit(
-          gh<_i186.SendMessageUseCase>(),
-          gh<_i151.GetChatHistoryUseCase>(),
+    gh.factory<_i192.UserProfileCubit>(
+        () => _i192.UserProfileCubit(gh<_i109.UserProfileRepository>()));
+    gh.factory<_i193.VitalSignBloc>(
+        () => _i193.VitalSignBloc(gh<_i114.VitalSignRepository>()));
+    gh.factory<_i194.VoiceChatCubit>(() => _i194.VoiceChatCubit(
+          gh<_i187.SendMessageUseCase>(),
+          gh<_i152.GetChatHistoryUseCase>(),
           gh<_i117.VoiceChatRepository>(),
           gh<_i8.AudioService>(),
         ));
-    gh.factory<_i194.VouchCubit>(
-        () => _i194.VouchCubit(gh<_i119.VouchRepository>()));
-    gh.factory<_i195.AllergiesCubit>(
-        () => _i195.AllergiesCubit(gh<_i124.AllergyRepository>()));
-    gh.factory<_i196.AllergyBloc>(
-        () => _i196.AllergyBloc(gh<_i124.AllergyRepository>()));
-    gh.factory<_i197.AppointmentBloc>(
-        () => _i197.AppointmentBloc(gh<_i126.AppointmentRepository>()));
-    gh.factory<_i198.AuthCubit>(() => _i198.AuthCubit(gh<_i131.AuthService>()));
-    gh.factory<_i199.AuthCubit>(() => _i199.AuthCubit(
-          gh<_i129.AuthRepository>(),
-          gh<_i29.EncryptionService>(),
+    gh.factory<_i195.VouchCubit>(
+        () => _i195.VouchCubit(gh<_i119.VouchRepository>()));
+    gh.factory<_i196.AboutCubit>(() => _i196.AboutCubit(
+          gh<_i151.GetAppInfo>(),
+          gh<_i134.CheckUpdates>(),
+        ));
+    gh.factory<_i197.AllergiesCubit>(
+        () => _i197.AllergiesCubit(gh<_i123.AllergyRepository>()));
+    gh.factory<_i198.AllergyBloc>(
+        () => _i198.AllergyBloc(gh<_i123.AllergyRepository>()));
+    gh.factory<_i199.AppointmentBloc>(
+        () => _i199.AppointmentBloc(gh<_i125.AppointmentRepository>()));
+    gh.factory<_i200.AuthCubit>(() => _i200.AuthCubit(gh<_i130.AuthService>()));
+    gh.factory<_i201.AuthCubit>(() => _i201.AuthCubit(
+          gh<_i128.AuthRepository>(),
+          gh<_i30.EncryptionService>(),
           gh<_i11.BiometricService>(),
         ));
-    gh.lazySingleton<_i200.BadgeCalculator>(() => _i200.BadgeCalculator(
+    gh.lazySingleton<_i202.BadgeCalculator>(() => _i202.BadgeCalculator(
           gh<_i144.DoctorProfileRepository>(),
           gh<_i90.RatingRepository>(),
           gh<_i119.VouchRepository>(),
         ));
-    gh.factory<_i201.BadgeCubit>(
-        () => _i201.BadgeCubit(gh<_i200.BadgeCalculator>()));
-    gh.factory<_i202.CalendarImportCubit>(() => _i202.CalendarImportCubit(
+    gh.factory<_i203.BadgeCubit>(
+        () => _i203.BadgeCubit(gh<_i202.BadgeCalculator>()));
+    gh.factory<_i204.CalendarImportCubit>(() => _i204.CalendarImportCubit(
           gh<_i18.CalendarRepository>(),
-          gh<_i169.ImportCalendarUseCase>(),
+          gh<_i170.ImportCalendarUseCase>(),
         ));
-    gh.factory<_i203.DashboardCubit>(() => _i203.DashboardCubit(
-          gh<_i153.GetDashboardStatsUseCase>(),
-          gh<_i155.GetRecentActivityUseCase>(),
+    gh.factory<_i205.DashboardCubit>(() => _i205.DashboardCubit(
+          gh<_i154.GetDashboardStatsUseCase>(),
+          gh<_i156.GetRecentActivityUseCase>(),
         ));
-    gh.lazySingleton<_i204.DistributedCacheUsecase>(() =>
-        _i204.DistributedCacheUsecase(gh<_i142.DistributedStorageService>()));
-    gh.factory<_i205.EpsConnectionBloc>(() => _i205.EpsConnectionBloc(
-          gh<_i152.GetConnectionsUseCase>(),
+    gh.lazySingleton<_i206.DistributedCacheUsecase>(() =>
+        _i206.DistributedCacheUsecase(gh<_i142.DistributedStorageService>()));
+    gh.factory<_i207.EpsConnectionBloc>(() => _i207.EpsConnectionBloc(
+          gh<_i153.GetConnectionsUseCase>(),
           gh<_i136.ConnectProviderUseCase>(),
           gh<_i141.DisconnectProviderUseCase>(),
         ));
-    gh.factory<_i206.EpsConnectionCubit>(() => _i206.EpsConnectionCubit(
-          gh<_i152.GetConnectionsUseCase>(),
+    gh.factory<_i208.EpsConnectionCubit>(() => _i208.EpsConnectionCubit(
+          gh<_i153.GetConnectionsUseCase>(),
           gh<_i136.ConnectProviderUseCase>(),
           gh<_i141.DisconnectProviderUseCase>(),
         ));
-    gh.factory<_i207.GetHealthSummaryUseCase>(
-        () => _i207.GetHealthSummaryUseCase(gh<_i167.HomeRepository>()));
-    gh.factory<_i208.HealthRecordCubit>(() => _i208.HealthRecordCubit(
-          gh<_i165.HealthRecordRepository>(),
+    gh.factory<_i209.GetHealthSummaryUseCase>(
+        () => _i209.GetHealthSummaryUseCase(gh<_i168.HomeRepository>()));
+    gh.factory<_i210.HealthRecordCubit>(() => _i210.HealthRecordCubit(
+          gh<_i166.HealthRecordRepository>(),
           gh<_i32.FilePickerService>(),
           gh<_i49.ImagePickerService>(),
           gh<_i88.OcrService>(),
           gh<_i112.VectorStoreService>(),
         ));
-    gh.factory<_i209.HomeCubit>(() => _i209.HomeCubit(
-          gh<_i207.GetHealthSummaryUseCase>(),
-          gh<_i167.HomeRepository>(),
+    gh.factory<_i211.HomeCubit>(() => _i211.HomeCubit(
+          gh<_i209.GetHealthSummaryUseCase>(),
+          gh<_i168.HomeRepository>(),
         ));
-    gh.lazySingleton<_i173.LlmService>(
-      () => _i210.RagLlmService(
+    gh.lazySingleton<_i174.LlmService>(
+      () => _i212.RagLlmService(
         gh<_i112.VectorStoreService>(),
-        gh<_i176.MedicalResearchService>(),
+        gh<_i177.MedicalResearchService>(),
         gh<_i109.UserProfileRepository>(),
         gh<_i57.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
-    gh.lazySingleton<_i211.MedicalIndexingService>(
-        () => _i211.MedicalIndexingService(
+    gh.lazySingleton<_i213.MedicalIndexingService>(
+        () => _i213.MedicalIndexingService(
               gh<_i63.MedicalKnowledgeRepository>(),
               gh<_i112.VectorStoreService>(),
-              gh<_i181.PatientContextIndexer>(),
+              gh<_i182.PatientContextIndexer>(),
             ));
-    gh.factory<_i212.MedicalResearchCubit>(() => _i212.MedicalResearchCubit(
-          gh<_i176.MedicalResearchService>(),
+    gh.factory<_i214.MedicalResearchCubit>(() => _i214.MedicalResearchCubit(
+          gh<_i177.MedicalResearchService>(),
           gh<_i68.MedicalStandardsService>(),
         ));
-    gh.factory<_i213.OnboardingCubit>(
-        () => _i213.OnboardingCubit(gh<_i179.OnboardingRepository>()));
-    gh.factory<_i214.ReportBloc>(() => _i214.ReportBloc(
+    gh.factory<_i215.OnboardingCubit>(
+        () => _i215.OnboardingCubit(gh<_i180.OnboardingRepository>()));
+    gh.factory<_i216.ReportBloc>(() => _i216.ReportBloc(
           gh<_i93.ReportRepository>(),
-          gh<_i182.ReportGenerationService>(),
+          gh<_i183.ReportGenerationService>(),
         ));
-    gh.factory<_i215.SharingCubit>(() => _i215.SharingCubit(
-          bleService: gh<_i132.BleSharingService>(),
+    gh.factory<_i217.SharingCubit>(() => _i217.SharingCubit(
+          bleService: gh<_i131.BleSharingService>(),
           nfcService: gh<_i82.NfcSharingService>(),
           wifiService: gh<_i121.WifiDirectService>(),
-          startSharingUseCase: gh<_i189.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i188.StartListeningUseCase>(),
-          cancelSharingUseCase: gh<_i133.CancelSharingUseCase>(),
-          walletService: gh<_i30.WalletService>(),
-          walletEncryption: gh<_i30.EncryptionService>(),
+          startSharingUseCase: gh<_i190.StartSharingUseCase>(),
+          startListeningUseCase: gh<_i189.StartListeningUseCase>(),
+          cancelSharingUseCase: gh<_i132.CancelSharingUseCase>(),
+          walletService: gh<_i29.WalletService>(),
+          walletEncryption: gh<_i29.EncryptionService>(),
         ));
     return this;
   }
 }
 
-class _$ServiceModule extends _i216.ServiceModule {}
+class _$ServiceModule extends _i218.ServiceModule {}
 
-class _$NetworkModule extends _i217.NetworkModule {}
+class _$NetworkModule extends _i219.NetworkModule {}
 
-class _$MemoryModule extends _i218.MemoryModule {}
+class _$MemoryModule extends _i220.MemoryModule {}
 
-class _$DatabaseModule extends _i219.DatabaseModule {}
+class _$DatabaseModule extends _i221.DatabaseModule {}
 
-class _$FhirModule extends _i220.FhirModule {}
+class _$FhirModule extends _i222.FhirModule {}

--- a/lib/features/about/application/about_cubit.dart
+++ b/lib/features/about/application/about_cubit.dart
@@ -2,7 +2,8 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:equatable/equatable.dart';
 import 'package:injectable/injectable.dart';
 import '../domain/entities/about_info.dart';
-import '../domain/repositories/i_about_repository.dart';
+import '../domain/usecases/check_updates.dart';
+import '../domain/usecases/get_app_info.dart';
 
 abstract class AboutState extends Equatable {
   const AboutState();
@@ -39,17 +40,29 @@ class AboutError extends AboutState {
 
 @injectable
 class AboutCubit extends Cubit<AboutState> {
-  final IAboutRepository _repository;
+  final GetAppInfo _getAppInfo;
+  final CheckUpdates _checkUpdates;
 
-  AboutCubit(this._repository) : super(AboutInitial());
+  AboutCubit(
+    this._getAppInfo,
+    this._checkUpdates,
+  ) : super(const AboutInitial());
 
   Future<void> loadAboutInfo() async {
-    emit(AboutLoading());
+    emit(const AboutLoading());
     try {
-      final info = await _repository.getAboutInfo();
+      final info = await _getAppInfo.execute();
       emit(AboutLoaded(info));
     } catch (e) {
       emit(AboutError(e.toString()));
+    }
+  }
+
+  Future<bool> checkForUpdates() async {
+    try {
+      return await _checkUpdates.execute();
+    } catch (_) {
+      return false;
     }
   }
 }

--- a/lib/features/about/data/repositories/about_repository_impl.dart
+++ b/lib/features/about/data/repositories/about_repository_impl.dart
@@ -21,4 +21,10 @@ class AboutRepositoryImpl implements IAboutRepository {
       activities: List<String>.from(data['activities'] as List),
     );
   }
+
+  @override
+  Future<bool> checkUpdates() async {
+    // Basic implementation for the data layer repository
+    return false;
+  }
 }

--- a/lib/features/about/domain/repositories/i_about_repository.dart
+++ b/lib/features/about/domain/repositories/i_about_repository.dart
@@ -2,4 +2,5 @@ import '../entities/about_info.dart';
 
 abstract class IAboutRepository {
   Future<AboutInfo> getAboutInfo();
+  Future<bool> checkUpdates();
 }

--- a/lib/features/about/domain/usecases/check_updates.dart
+++ b/lib/features/about/domain/usecases/check_updates.dart
@@ -1,0 +1,13 @@
+import 'package:injectable/injectable.dart';
+import '../repositories/i_about_repository.dart';
+
+@injectable
+class CheckUpdates {
+  final IAboutRepository _repository;
+
+  CheckUpdates(this._repository);
+
+  Future<bool> execute() {
+    return _repository.checkUpdates();
+  }
+}

--- a/lib/features/about/domain/usecases/get_app_info.dart
+++ b/lib/features/about/domain/usecases/get_app_info.dart
@@ -1,0 +1,14 @@
+import 'package:injectable/injectable.dart';
+import '../entities/about_info.dart';
+import '../repositories/i_about_repository.dart';
+
+@injectable
+class GetAppInfo {
+  final IAboutRepository _repository;
+
+  GetAppInfo(this._repository);
+
+  Future<AboutInfo> execute() {
+    return _repository.getAboutInfo();
+  }
+}

--- a/lib/features/about/infrastructure/repositories/about_repository_impl.dart
+++ b/lib/features/about/infrastructure/repositories/about_repository_impl.dart
@@ -25,6 +25,14 @@ class AboutRepositoryImpl implements IAboutRepository {
       ],
     );
   }
+
+  @override
+  Future<bool> checkUpdates() async {
+    // Simulating an update check. In a real app, this would compare
+    // the local version with a remote version.
+    await Future.delayed(const Duration(seconds: 1));
+    return false;
+  }
 }
 
 const List<BlogPost> _staticBlogPosts = [

--- a/test/features/about/application/about_cubit_test.dart
+++ b/test/features/about/application/about_cubit_test.dart
@@ -2,13 +2,16 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/about/application/about_cubit.dart';
 import 'package:orionhealth_health/features/about/domain/entities/about_info.dart';
-import 'package:orionhealth_health/features/about/domain/repositories/i_about_repository.dart';
+import 'package:orionhealth_health/features/about/domain/usecases/check_updates.dart';
+import 'package:orionhealth_health/features/about/domain/usecases/get_app_info.dart';
 
-class MockAboutRepository extends Mock implements IAboutRepository {}
+class MockGetAppInfo extends Mock implements GetAppInfo {}
+class MockCheckUpdates extends Mock implements CheckUpdates {}
 
 void main() {
   late AboutCubit cubit;
-  late MockAboutRepository mockRepository;
+  late MockGetAppInfo mockGetAppInfo;
+  late MockCheckUpdates mockCheckUpdates;
 
   const tAboutInfo = AboutInfo(
     blogPosts: [],
@@ -18,8 +21,9 @@ void main() {
   );
 
   setUp(() {
-    mockRepository = MockAboutRepository();
-    cubit = AboutCubit(mockRepository);
+    mockGetAppInfo = MockGetAppInfo();
+    mockCheckUpdates = MockCheckUpdates();
+    cubit = AboutCubit(mockGetAppInfo, mockCheckUpdates);
   });
 
   tearDown(() {
@@ -32,10 +36,10 @@ void main() {
 
   group('loadAboutInfo', () {
     test(
-      'emits [AboutLoading, AboutLoaded] when repository returns data',
+      'emits [AboutLoading, AboutLoaded] when usecase returns data',
       () async {
         when(
-          () => mockRepository.getAboutInfo(),
+          () => mockGetAppInfo.execute(),
         ).thenAnswer((_) async => tAboutInfo);
 
         final expectedStates = [
@@ -50,11 +54,11 @@ void main() {
     );
 
     test(
-      'emits [AboutLoading, AboutError] when repository throws error',
+      'emits [AboutLoading, AboutError] when usecase throws error',
       () async {
         const errorMessage = 'Exception: Error fetching data';
         when(
-          () => mockRepository.getAboutInfo(),
+          () => mockGetAppInfo.execute(),
         ).thenThrow(Exception('Error fetching data'));
 
         final expectedStates = [
@@ -67,6 +71,23 @@ void main() {
         await cubit.loadAboutInfo();
       },
     );
+   group('checkForUpdates', () {
+    test('returns true when usecase returns true', () async {
+      when(() => mockCheckUpdates.execute()).thenAnswer((_) async => true);
+
+      final result = await cubit.checkForUpdates();
+
+      expect(result, true);
+    });
+
+    test('returns false when usecase throws', () async {
+      when(() => mockCheckUpdates.execute()).thenThrow(Exception());
+
+      final result = await cubit.checkForUpdates();
+
+      expect(result, false);
+    });
+  });
   });
 
   group('AboutState Equatable', () {

--- a/test/features/about/domain/usecases/check_updates_test.dart
+++ b/test/features/about/domain/usecases/check_updates_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/about/domain/repositories/i_about_repository.dart';
+import 'package:orionhealth_health/features/about/domain/usecases/check_updates.dart';
+
+class MockAboutRepository extends Mock implements IAboutRepository {}
+
+void main() {
+  late CheckUpdates usecase;
+  late MockAboutRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockAboutRepository();
+    usecase = CheckUpdates(mockRepository);
+  });
+
+  test(
+    'should check for updates from the repository',
+    () async {
+      // arrange
+      when(() => mockRepository.checkUpdates())
+          .thenAnswer((_) async => true);
+
+      // act
+      final result = await usecase.execute();
+
+      // assert
+      expect(result, true);
+      verify(() => mockRepository.checkUpdates());
+      verifyNoMoreInteractions(mockRepository);
+    },
+  );
+}

--- a/test/features/about/domain/usecases/get_app_info_test.dart
+++ b/test/features/about/domain/usecases/get_app_info_test.dart
@@ -1,0 +1,41 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/about/domain/entities/about_info.dart';
+import 'package:orionhealth_health/features/about/domain/repositories/i_about_repository.dart';
+import 'package:orionhealth_health/features/about/domain/usecases/get_app_info.dart';
+
+class MockAboutRepository extends Mock implements IAboutRepository {}
+
+void main() {
+  late GetAppInfo usecase;
+  late MockAboutRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockAboutRepository();
+    usecase = GetAppInfo(mockRepository);
+  });
+
+  const tAboutInfo = AboutInfo(
+    blogPosts: [],
+    missionStatement: 'Test Mission',
+    values: ['Value 1'],
+    activities: ['Activity 1'],
+  );
+
+  test(
+    'should get about info from the repository',
+    () async {
+      // arrange
+      when(() => mockRepository.getAboutInfo())
+          .thenAnswer((_) async => tAboutInfo);
+
+      // act
+      final result = await usecase.execute();
+
+      // assert
+      expect(result, tAboutInfo);
+      verify(() => mockRepository.getAboutInfo());
+      verifyNoMoreInteractions(mockRepository);
+    },
+  );
+}


### PR DESCRIPTION
Added GetAppInfo and CheckUpdates usecases to the domain layer of the about feature to follow Clean Architecture principles. Updated the repository interface and implementations, refactored AboutCubit to use the usecases, and added comprehensive unit tests.

Fixes #965

---
*PR created automatically by Jules for task [1855461005403555377](https://jules.google.com/task/1855461005403555377) started by @iberi22*