### PR TITLE
feat: improve test coverage for appointments data layer and usecases

### DIFF
--- a/lib/features/appointments/data/repositories/appointment_repository_impl.dart
+++ b/lib/features/appointments/data/repositories/appointment_repository_impl.dart
@@ -11,7 +11,7 @@ class AppointmentRepositoryImpl implements AppointmentRepository {
   AppointmentRepositoryImpl(this._localDataSource);
 
   @override
-  Future<List<Appointment>> getAppointments() {
+  Future<List<Appointment>> getAllAppointments() {
     return _localDataSource.getAppointments();
   }
 

--- a/test/features/appointments/data/datasources/appointment_local_datasource_test.dart
+++ b/test/features/appointments/data/datasources/appointment_local_datasource_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:isar/isar.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/appointments/data/datasources/appointment_local_datasource.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+
+class MockIsar extends Mock implements Isar {
+  @override
+  Future<T> writeTxn<T>(Future<T> Function() callback, {bool silent = false}) {
+    return callback();
+  }
+}
+
+abstract class IsarCollectionAppointment extends IsarCollection<Appointment> {}
+class MockIsarCollection extends Mock implements IsarCollectionAppointment {}
+
+class FakeAppointment extends Fake implements Appointment {}
+
+void main() {
+  late MockIsar mockIsar;
+  late MockIsarCollection mockCollection;
+  late AppointmentLocalDataSource dataSource;
+
+  setUpAll(() {
+    registerFallbackValue(FakeAppointment());
+  });
+
+  setUp(() {
+    mockIsar = MockIsar();
+    mockCollection = MockIsarCollection();
+    dataSource = AppointmentLocalDataSource(mockIsar);
+
+    when(() => mockIsar.appointments).thenReturn(mockCollection);
+  });
+
+  group('AppointmentLocalDataSource', () {
+    final tAppointment = Appointment(
+      id: 1,
+      doctorName: 'Dr. Smith',
+      specialty: 'Cardiology',
+      dateTime: DateTime(2023, 10, 10),
+      status: AppointmentStatus.upcoming,
+    );
+
+    test('saveAppointment should put appointment in Isar', () async {
+      when(() => mockCollection.put(any())).thenAnswer((_) async => 1);
+
+      await dataSource.saveAppointment(tAppointment);
+
+      verify(() => mockCollection.put(tAppointment)).called(1);
+    });
+
+    test('deleteAppointment should delete appointment from Isar', () async {
+      const tId = 1;
+      when(() => mockCollection.delete(any())).thenAnswer((_) async => true);
+
+      await dataSource.deleteAppointment(tId);
+
+      verify(() => mockCollection.delete(tId)).called(1);
+    });
+
+    test('getAppointmentById should return appointment from Isar', () async {
+      const tId = 1;
+      when(() => mockCollection.get(any())).thenAnswer((_) async => tAppointment);
+
+      final result = await dataSource.getAppointmentById(tId);
+
+      expect(result, tAppointment);
+      verify(() => mockCollection.get(tId)).called(1);
+    });
+  });
+}

--- a/test/features/appointments/data/models/appointment_dto_test.dart
+++ b/test/features/appointments/data/models/appointment_dto_test.dart
@@ -1,0 +1,89 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/appointments/data/models/appointment_dto.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+
+void main() {
+  final tDateTime = DateTime(2023, 10, 10, 10, 0);
+  final tAppointment = Appointment(
+    id: 1,
+    doctorName: 'Dr. Smith',
+    specialty: 'Cardiology',
+    dateTime: tDateTime,
+    durationInMinutes: 45,
+    notes: 'Checkup',
+    status: AppointmentStatus.upcoming,
+  );
+
+  final tDto = AppointmentDto(
+    id: 1,
+    doctorName: 'Dr. Smith',
+    specialty: 'Cardiology',
+    dateTime: tDateTime,
+    durationInMinutes: 45,
+    notes: 'Checkup',
+    status: 'upcoming',
+  );
+
+  final tJson = {
+    'id': 1,
+    'doctorName': 'Dr. Smith',
+    'specialty': 'Cardiology',
+    'dateTime': tDateTime.toIso8601String(),
+    'durationInMinutes': 45,
+    'recurrenceRule': null,
+    'notes': 'Checkup',
+    'source': null,
+    'status': 'upcoming',
+  };
+
+  group('AppointmentDto', () {
+    test('fromEntity should return a valid DTO', () {
+      final result = AppointmentDto.fromEntity(tAppointment);
+      expect(result.id, tDto.id);
+      expect(result.doctorName, tDto.doctorName);
+      expect(result.specialty, tDto.specialty);
+      expect(result.dateTime, tDto.dateTime);
+      expect(result.durationInMinutes, tDto.durationInMinutes);
+      expect(result.notes, tDto.notes);
+      expect(result.status, tDto.status);
+    });
+
+    test('toEntity should return a valid entity', () {
+      final result = tDto.toEntity();
+      expect(result.id, tAppointment.id);
+      expect(result.doctorName, tAppointment.doctorName);
+      expect(result.specialty, tAppointment.specialty);
+      expect(result.dateTime, tAppointment.dateTime);
+      expect(result.durationInMinutes, tAppointment.durationInMinutes);
+      expect(result.notes, tAppointment.notes);
+      expect(result.status, tAppointment.status);
+    });
+
+    test('fromJson should return a valid DTO', () {
+      final result = AppointmentDto.fromJson(tJson);
+      expect(result.id, tDto.id);
+      expect(result.doctorName, tDto.doctorName);
+      expect(result.specialty, tDto.specialty);
+      expect(result.dateTime, tDto.dateTime);
+      expect(result.durationInMinutes, tDto.durationInMinutes);
+      expect(result.notes, tDto.notes);
+      expect(result.status, tDto.status);
+    });
+
+    test('toJson should return a JSON map containing proper data', () {
+      final result = tDto.toJson();
+      expect(result, tJson);
+    });
+
+    test('toEntity should use default status if status is invalid', () {
+      final dto = AppointmentDto(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardiology',
+        dateTime: tDateTime,
+        status: 'invalid_status',
+      );
+      final result = dto.toEntity();
+      expect(result.status, AppointmentStatus.upcoming);
+    });
+  });
+}

--- a/test/features/appointments/data/repositories/appointment_repository_impl_test.dart
+++ b/test/features/appointments/data/repositories/appointment_repository_impl_test.dart
@@ -1,0 +1,59 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/appointments/data/datasources/appointment_local_datasource.dart';
+import 'package:orionhealth_health/features/appointments/data/repositories/appointment_repository_impl.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+
+class MockAppointmentLocalDataSource extends Mock implements AppointmentLocalDataSource {}
+
+class FakeAppointment extends Fake implements Appointment {}
+
+void main() {
+  late MockAppointmentLocalDataSource mockDataSource;
+  late AppointmentRepositoryImpl repository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeAppointment());
+  });
+
+  setUp(() {
+    mockDataSource = MockAppointmentLocalDataSource();
+    repository = AppointmentRepositoryImpl(mockDataSource);
+  });
+
+  group('AppointmentRepositoryImpl', () {
+    final tAppointment = Appointment(
+      id: 1,
+      doctorName: 'Dr. Smith',
+      specialty: 'Cardiology',
+      dateTime: DateTime(2023, 10, 10),
+      status: AppointmentStatus.upcoming,
+    );
+
+    test('getAllAppointments should call getAppointments on data source', () async {
+      when(() => mockDataSource.getAppointments()).thenAnswer((_) async => [tAppointment]);
+
+      final result = await repository.getAllAppointments();
+
+      expect(result, [tAppointment]);
+      verify(() => mockDataSource.getAppointments()).called(1);
+    });
+
+    test('saveAppointment should call saveAppointment on data source', () async {
+      when(() => mockDataSource.saveAppointment(any())).thenAnswer((_) async => {});
+
+      await repository.saveAppointment(tAppointment);
+
+      verify(() => mockDataSource.saveAppointment(tAppointment)).called(1);
+    });
+
+    test('deleteAppointment should call deleteAppointment on data source', () async {
+      const tId = 1;
+      when(() => mockDataSource.deleteAppointment(any())).thenAnswer((_) async => {});
+
+      await repository.deleteAppointment(tId);
+
+      verify(() => mockDataSource.deleteAppointment(tId)).called(1);
+    });
+  });
+}

--- a/test/features/appointments/domain/usecases/delete_appointment_usecase_test.dart
+++ b/test/features/appointments/domain/usecases/delete_appointment_usecase_test.dart
@@ -26,4 +26,15 @@ void main() {
     verify(() => mockRepository.deleteAppointment(tId));
     verifyNoMoreInteractions(mockRepository);
   });
+
+  test('should throw exception when repository fails to delete', () async {
+    // arrange
+    when(() => mockRepository.deleteAppointment(any()))
+        .thenThrow(Exception('Delete failed'));
+    // act
+    final call = useCase(tId);
+    // assert
+    expect(() => call, throwsException);
+    verify(() => mockRepository.deleteAppointment(tId));
+  });
 }

--- a/test/features/appointments/domain/usecases/get_all_appointments_usecase_test.dart
+++ b/test/features/appointments/domain/usecases/get_all_appointments_usecase_test.dart
@@ -35,4 +35,26 @@ void main() {
     verify(() => mockRepository.getAllAppointments());
     verifyNoMoreInteractions(mockRepository);
   });
+
+  test('should return empty list when repository returns empty', () async {
+    // arrange
+    when(() => mockRepository.getAllAppointments())
+        .thenAnswer((_) async => []);
+    // act
+    final result = await useCase();
+    // assert
+    expect(result, []);
+    verify(() => mockRepository.getAllAppointments());
+  });
+
+  test('should throw exception when repository fails', () async {
+    // arrange
+    when(() => mockRepository.getAllAppointments())
+        .thenThrow(Exception('DB Error'));
+    // act
+    final call = useCase();
+    // assert
+    expect(() => call, throwsException);
+    verify(() => mockRepository.getAllAppointments());
+  });
 }

--- a/test/features/appointments/domain/usecases/save_appointment_usecase_test.dart
+++ b/test/features/appointments/domain/usecases/save_appointment_usecase_test.dart
@@ -40,4 +40,15 @@ void main() {
     verify(() => mockRepository.saveAppointment(tAppointment));
     verifyNoMoreInteractions(mockRepository);
   });
+
+  test('should throw exception when repository fails to save', () async {
+    // arrange
+    when(() => mockRepository.saveAppointment(any()))
+        .thenThrow(Exception('Save failed'));
+    // act
+    final call = useCase(tAppointment);
+    // assert
+    expect(() => call, throwsException);
+    verify(() => mockRepository.saveAppointment(tAppointment));
+  });
 }


### PR DESCRIPTION
This PR improves the test coverage for the appointments feature, focusing on the data layer and use cases as part of the stabilization plan.

Changes:
- Corrected a method naming mismatch in `AppointmentRepositoryImpl`.
- Added new test files for `AppointmentDto`, `AppointmentLocalDataSource`, and `AppointmentRepositoryImpl`.
- Enhanced existing use case tests to cover edge cases and repository failures.
- Ensured all tests pass and verified that no regressions were introduced in the appointments feature.

Fixes #985

---
*PR created automatically by Jules for task [16025902168892466311](https://jules.google.com/task/16025902168892466311) started by @iberi22*