### PR TITLE
Increase test coverage for reports, health_data_import, home, and about

### DIFF
--- a/test/features/about/domain/entities/blog_post_extra_test.dart
+++ b/test/features/about/domain/entities/blog_post_extra_test.dart
@@ -1,0 +1,40 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/about/domain/entities/about_info.dart';
+
+void main() {
+  group('BlogPost Extra Tests', () {
+    test('supports value equality', () {
+      const post1 = BlogPost(
+        title: 'A',
+        content: 'B',
+        date: 'C',
+        category: 'D',
+      );
+      const post2 = BlogPost(
+        title: 'A',
+        content: 'B',
+        date: 'C',
+        category: 'D',
+      );
+
+      expect(post1, equals(post2));
+    });
+
+    test('different values are not equal', () {
+      const post1 = BlogPost(
+        title: 'A',
+        content: 'B',
+        date: 'C',
+        category: 'D',
+      );
+      const post2 = BlogPost(
+        title: 'Diff',
+        content: 'B',
+        date: 'C',
+        category: 'D',
+      );
+
+      expect(post1, isNot(equals(post2)));
+    });
+  });
+}

--- a/test/features/about/presentation/pages/about_page_test.dart
+++ b/test/features/about/presentation/pages/about_page_test.dart
@@ -76,4 +76,32 @@ void main() {
     addTearDown(tester.view.resetPhysicalSize);
     addTearDown(tester.view.resetDevicePixelRatio);
   });
+
+  testWidgets('AboutPage displays loading indicator', (WidgetTester tester) async {
+    when(() => mockAboutCubit.state).thenReturn(AboutLoading());
+    when(() => mockAboutCubit.loadAboutInfo()).thenAnswer((_) async {});
+    when(() => mockAboutCubit.stream).thenAnswer((_) => const Stream.empty());
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AboutPage(),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('AboutPage displays error message', (WidgetTester tester) async {
+    when(() => mockAboutCubit.state).thenReturn(const AboutError('Error loading info'));
+    when(() => mockAboutCubit.loadAboutInfo()).thenAnswer((_) async {});
+    when(() => mockAboutCubit.stream).thenAnswer((_) => const Stream.empty());
+
+    await tester.pumpWidget(
+      const MaterialApp(
+        home: AboutPage(),
+      ),
+    );
+
+    expect(find.text('Error: Error loading info'), findsOneWidget);
+  });
 }

--- a/test/features/health_data_import/domain/entities/health_data_source_test.dart
+++ b/test/features/health_data_import/domain/entities/health_data_source_test.dart
@@ -1,0 +1,18 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_data_source.dart';
+
+void main() {
+  group('HealthDataSource', () {
+    test('displayName returns correct names', () {
+      expect(HealthDataSource.googleFit.displayName, 'Google Fit / Health Connect');
+      expect(HealthDataSource.appleHealth.displayName, 'Apple Health');
+      expect(HealthDataSource.samsungHealth.displayName, 'Samsung Health');
+    });
+
+    test('sourceKey returns correct keys', () {
+      expect(HealthDataSource.googleFit.sourceKey, 'google_fit');
+      expect(HealthDataSource.appleHealth.sourceKey, 'apple_health');
+      expect(HealthDataSource.samsungHealth.sourceKey, 'samsung_health');
+    });
+  });
+}

--- a/test/features/health_data_import/domain/entities/health_import_config_test.dart
+++ b/test/features/health_data_import/domain/entities/health_import_config_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health/health.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_data_source.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_import_config.dart';
+
+void main() {
+  group('HealthImportConfig', () {
+    test('constructor correctly assigns values', () {
+      final startTime = DateTime(2024, 1, 1);
+      final endTime = DateTime(2024, 1, 31);
+      final types = [HealthDataType.STEPS, HealthDataType.HEART_RATE];
+
+      final config = HealthImportConfig(
+        source: HealthDataSource.googleFit,
+        types: types,
+        startTime: startTime,
+        endTime: endTime,
+      );
+
+      expect(config.source, HealthDataSource.googleFit);
+      expect(config.types, types);
+      expect(config.startTime, startTime);
+      expect(config.endTime, endTime);
+    });
+  });
+}

--- a/test/features/health_data_import/domain/entities/health_import_result_test.dart
+++ b/test/features/health_data_import/domain/entities/health_import_result_test.dart
@@ -1,0 +1,19 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_data_source.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_import_result.dart';
+
+void main() {
+  group('HealthImportResult', () {
+    test('supports value equality', () {
+      expect(
+        const HealthImportResult(source: HealthDataSource.googleFit, importedCount: 10),
+        const HealthImportResult(source: HealthDataSource.googleFit, importedCount: 10),
+      );
+    });
+
+    test('props are correct', () {
+      const result = HealthImportResult(source: HealthDataSource.appleHealth, importedCount: 5);
+      expect(result.props, [HealthDataSource.appleHealth, 5]);
+    });
+  });
+}

--- a/test/features/health_data_import/domain/usecases/health_import_usecases_test.dart
+++ b/test/features/health_data_import/domain/usecases/health_import_usecases_test.dart
@@ -1,0 +1,43 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/services/health_data_import_service.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/usecases/health_import_usecases.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_data_source.dart';
+
+class MockHealthDataImportService extends Mock implements HealthDataImportService {}
+
+void main() {
+  late GetAvailableSourcesUseCase getSourcesUseCase;
+  late RequestHealthAuthUseCase requestAuthUseCase;
+  late MockHealthDataImportService mockService;
+
+  setUp(() {
+    mockService = MockHealthDataImportService();
+    getSourcesUseCase = GetAvailableSourcesUseCase(mockService);
+    requestAuthUseCase = RequestHealthAuthUseCase(mockService);
+  });
+
+  group('GetAvailableSourcesUseCase', () {
+    test('should return list of available sources from service', () async {
+      final tSources = [HealthDataSource.googleFit];
+      when(() => mockService.getAvailableSources()).thenAnswer((_) async => tSources);
+
+      final result = await getSourcesUseCase();
+
+      expect(result, tSources);
+      verify(() => mockService.getAvailableSources()).called(1);
+    });
+  });
+
+  group('RequestHealthAuthUseCase', () {
+    test('should return auth result from service', () async {
+      const tSource = HealthDataSource.appleHealth;
+      when(() => mockService.requestAuthorization(tSource)).thenAnswer((_) async => true);
+
+      final result = await requestAuthUseCase(tSource);
+
+      expect(result, true);
+      verify(() => mockService.requestAuthorization(tSource)).called(1);
+    });
+  });
+}

--- a/test/features/health_data_import/presentation/pages/health_import_page_test.dart
+++ b/test/features/health_data_import/presentation/pages/health_import_page_test.dart
@@ -1,0 +1,100 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/health_data_import/application/health_import_cubit.dart';
+import 'package:orionhealth_health/features/health_data_import/application/health_import_state.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_data_source.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_import_result.dart';
+import 'package:orionhealth_health/features/health_data_import/presentation/pages/health_import_page.dart';
+import 'package:orionhealth_health/features/health_data_import/presentation/widgets/data_source_card.dart';
+import 'package:orionhealth_health/features/health_data_import/presentation/widgets/import_progress_dialog.dart';
+
+class MockHealthImportCubit extends Mock implements HealthImportCubit {}
+
+void main() {
+  late MockHealthImportCubit mockCubit;
+  late StreamController<HealthImportState> stateController;
+
+  setUpAll(() {
+    mockCubit = MockHealthImportCubit();
+    GetIt.instance.registerSingleton<HealthImportCubit>(mockCubit);
+  });
+
+  setUp(() {
+    reset(mockCubit);
+    stateController = StreamController<HealthImportState>.broadcast();
+    when(() => mockCubit.checkAvailableSources()).thenAnswer((_) async {});
+    when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+  });
+
+  tearDown(() {
+    stateController.close();
+  });
+
+  tearDownAll(() async {
+    await GetIt.instance.reset();
+  });
+
+  Widget createWidgetUnderTest() {
+    return MaterialApp(
+      home: BlocProvider<HealthImportCubit>.value(
+        value: mockCubit,
+        child: const HealthImportPage(),
+      ),
+    );
+  }
+
+  testWidgets('displays loading indicator when state is HealthImportLoading', (tester) async {
+    when(() => mockCubit.state).thenReturn(HealthImportLoading());
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+
+  testWidgets('displays ready view with data sources when state is HealthImportReady', (tester) async {
+    when(() => mockCubit.state).thenReturn(const HealthImportReady(
+      availableSources: [HealthDataSource.googleFit],
+      availability: {
+        HealthDataSource.googleFit: true,
+        HealthDataSource.appleHealth: false,
+        HealthDataSource.samsungHealth: false,
+      },
+    ));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+    await tester.pump();
+
+    expect(find.text('Import Health Data'), findsAtLeastNWidgets(1));
+    expect(find.text('Data Sources'), findsOneWidget);
+    expect(find.byType(DataSourceCard), findsNWidgets(HealthDataSource.values.length));
+  });
+
+  testWidgets('displays progress dialog when state is HealthImportImporting', (tester) async {
+    when(() => mockCubit.state).thenReturn(const HealthImportImporting(
+      source: HealthDataSource.googleFit,
+      currentStep: 'Importing steps...',
+      totalSteps: 8,
+      currentStepNum: 1,
+      importedCount: 0,
+    ));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.byType(ImportProgressDialog), findsOneWidget);
+    expect(find.text('Importing steps...'), findsOneWidget);
+  });
+
+  testWidgets('displays authenticating view when state is HealthImportAuthenticating', (tester) async {
+    when(() => mockCubit.state).thenReturn(const HealthImportAuthenticating(HealthDataSource.appleHealth));
+
+    await tester.pumpWidget(createWidgetUnderTest());
+
+    expect(find.text('Authenticating with Apple Health...'), findsOneWidget);
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}

--- a/test/features/home/domain/entities/home_health_summary_extra_test.dart
+++ b/test/features/home/domain/entities/home_health_summary_extra_test.dart
@@ -1,0 +1,31 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/home/domain/entities/home_health_summary.dart';
+
+void main() {
+  group('HomeHealthSummary', () {
+    test('supports value equality', () {
+      final summary1 = HomeHealthSummary(
+        latestVitals: [],
+        upcomingAppointments: [],
+        medicationCount: 5,
+      );
+      final summary2 = HomeHealthSummary(
+        latestVitals: [],
+        upcomingAppointments: [],
+        medicationCount: 5,
+      );
+
+      expect(summary1, equals(summary2));
+    });
+
+    test('props are correct', () {
+      final summary = HomeHealthSummary(
+        latestVitals: [],
+        upcomingAppointments: [],
+        medicationCount: 10,
+      );
+
+      expect(summary.props, [[], [], 10]);
+    });
+  });
+}

--- a/test/features/home/presentation/pages/home_page_extra_test.dart
+++ b/test/features/home/presentation/pages/home_page_extra_test.dart
@@ -1,0 +1,35 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:orionhealth_health/features/home/application/home_cubit.dart';
+import 'package:orionhealth_health/features/home/application/home_state.dart';
+import 'package:orionhealth_health/features/home/presentation/pages/home_page.dart';
+
+class MockHomeCubit extends Mock implements HomeCubit {}
+
+void main() {
+  late MockHomeCubit mockHomeCubit;
+
+  setUp(() {
+    mockHomeCubit = MockHomeCubit();
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(status: HomeStatus.loaded));
+    when(() => mockHomeCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockHomeCubit.close()).thenAnswer((_) async {});
+  });
+
+  testWidgets('HomePageView shows progress indicator when loading', (tester) async {
+    when(() => mockHomeCubit.state).thenReturn(const HomeState(status: HomeStatus.loading, modules: []));
+
+    await tester.pumpWidget(
+      MaterialApp(
+        home: BlocProvider<HomeCubit>.value(
+          value: mockHomeCubit,
+          child: const Scaffold(body: HomePageView()),
+        ),
+      ),
+    );
+
+    expect(find.byType(CircularProgressIndicator), findsOneWidget);
+  });
+}

--- a/test/features/reports/domain/entities/report_status_test.dart
+++ b/test/features/reports/domain/entities/report_status_test.dart
@@ -1,0 +1,21 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/reports/domain/entities/report.dart';
+
+void main() {
+  group('ReportStatus Extension', () {
+    test('pending should have correct label', () {
+      final report = Report(status: ReportStatus.pending);
+      expect(report.statusLabel, 'Pendiente');
+    });
+
+    test('finalized should have correct label', () {
+      final report = Report(status: ReportStatus.finalized);
+      expect(report.statusLabel, 'Finalizado');
+    });
+
+    test('urgent should have correct label', () {
+      final report = Report(status: ReportStatus.urgent);
+      expect(report.statusLabel, 'Urgente');
+    });
+  });
+}

--- a/test/features/reports/presentation/pages/report_detail_page_extra_test.dart
+++ b/test/features/reports/presentation/pages/report_detail_page_extra_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/reports/domain/entities/report.dart';
+import 'package:orionhealth_health/features/reports/presentation/pages/report_detail_page.dart';
+
+void main() {
+  group('ReportDetailPage Extra Tests', () {
+    testWidgets('displays title and handles long content', (tester) async {
+      final report = Report(
+        title: 'Long Report',
+        content: 'Line 1\n' * 100,
+        status: ReportStatus.finalized,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: ReportDetailPage(report: report),
+        ),
+      );
+
+      expect(find.text('Long Report'), findsOneWidget);
+      // Should be scrollable
+      expect(find.byType(SingleChildScrollView), findsNothing); // It uses CustomScrollView
+      expect(find.byType(CustomScrollView), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
This PR increases the test coverage for four key features: reports, health_data_import, home, and about. 

Key changes:
1.  **Reports**: Added `report_status_test.dart` and `report_detail_page_extra_test.dart`.
2.  **Health Data Import**: Added domain entity tests (`health_data_source_test.dart`, `health_import_config_test.dart`, `health_import_result_test.dart`), use case tests (`health_import_usecases_test.dart`), and a main page test (`health_import_page_test.dart`).
3.  **Home**: Added `home_health_summary_extra_test.dart` and `home_page_extra_test.dart`.
4.  **About**: Added `blog_post_extra_test.dart` and expanded `about_page_test.dart` to cover loading and error states.

I encountered significant challenges with the project's dependency injection generation (`build_runner`). The generated `injection.config.dart` consistently had compilation errors due to what appeared to be conflicting or missing registrations in the existing codebase. I worked around this by restoring the original state where possible, but some tests may require a clean build environment to run successfully.

Fixes #922

---
*PR created automatically by Jules for task [9765049289582300211](https://jules.google.com/task/9765049289582300211) started by @iberi22*