### PR TITLE
Add golden tests for voice_chat feature

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -222,26 +222,26 @@ import '../../features/local_agent/domain/services/llm_adapter.dart' as _i65;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
     as _i121;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i67;
+    as _i66;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i41;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i174;
+    as _i175;
 import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i43;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i175;
+    as _i174;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i66;
+    as _i67;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
     as _i178;
 import '../../features/local_agent/infrastructure/llm_service.dart' as _i177;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
     as _i215;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i73;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i72;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i73;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
     as _i122;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
@@ -529,12 +529,12 @@ extension GetItInjectableX on _i1.GetIt {
         _i64.LicenseVerifier(
             await getAsync<_i63.LicenseRegistryLocalDataSource>()));
     gh.lazySingleton<_i65.LlmAdapter>(
-      () => _i66.OpenaiCompatibleAdapter(),
-      instanceName: 'openai',
+      () => _i66.FlutterGemmaAdapter(wrapper: gh<_i41.FlutterGemmaWrapper>()),
+      instanceName: 'gemma',
     );
     gh.lazySingleton<_i65.LlmAdapter>(
-      () => _i67.FlutterGemmaAdapter(wrapper: gh<_i41.FlutterGemmaWrapper>()),
-      instanceName: 'gemma',
+      () => _i67.OpenaiCompatibleAdapter(),
+      instanceName: 'openai',
     );
     gh.lazySingleton<_i68.LocalLlmService>(() => _i68.LocalLlmService());
     gh.lazySingleton<_i69.LocalModelLocalDataSource>(
@@ -542,15 +542,15 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i70.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
     gh.factory<_i71.MedicalKnowledgeRepository>(
-      () => _i72.JsonMedicalKnowledgeRepository(),
+      () => _i72.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
+    );
+    gh.factory<_i71.MedicalKnowledgeRepository>(
+      () => _i73.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
-    );
-    gh.factory<_i71.MedicalKnowledgeRepository>(
-      () => _i73.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
     );
     gh.lazySingleton<_i74.MedicalScraperService>(
         () => _i75.MedicalScraperServiceImpl(
@@ -774,17 +774,17 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i7.AppointmentRepository>(),
           gh<_i118.UserProfileRepository>(),
         ));
+    gh.factory<_i65.LlmAdapter>(
+      () => _i174.MockLlmAdapter(gh<_i97.PromptScrubber>()),
+      instanceName: 'mock',
+    );
     gh.lazySingleton<_i65.LlmAdapter>(
-      () => _i174.GeminiLlmAdapter(
+      () => _i175.GeminiLlmAdapter(
         scrubber: gh<_i97.PromptScrubber>(),
         userProfileRepository: gh<_i118.UserProfileRepository>(),
         modelWrapper: gh<_i43.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
-    );
-    gh.factory<_i65.LlmAdapter>(
-      () => _i175.MockLlmAdapter(gh<_i97.PromptScrubber>()),
-      instanceName: 'mock',
     );
     gh.lazySingleton<_i176.LlmAdapterFactory>(
         () => _i176.LlmAdapterFactory(gh<_i109.SettingsRepository>()));

--- a/test/features/voice_chat/presentation/golden/voice_chat_pages_golden_test.dart
+++ b/test/features/voice_chat/presentation/golden/voice_chat_pages_golden_test.dart
@@ -1,0 +1,97 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-FileCopyrightText: 2025 SouthWest AI Labs
+
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/voice_chat/presentation/pages/chat_page.dart';
+import 'package:orionhealth_health/features/voice_chat/presentation/pages/privacy_policy_page.dart';
+import 'package:orionhealth_health/features/voice_chat/presentation/pages/voice_chat_page.dart';
+import 'package:orionhealth_health/features/voice_chat/application/voice_chat_cubit.dart';
+import 'package:orionhealth_health/features/voice_chat/application/voice_chat_state.dart';
+import 'package:orionhealth_health/core/services/aicore_service.dart';
+import '../../../../core/golden_test_utils.dart';
+
+class MockVoiceChatCubit extends Mock implements VoiceChatCubit {}
+class MockAIService extends Mock implements AIService {}
+
+void main() {
+  late MockVoiceChatCubit mockCubit;
+  late MockAIService mockAIService;
+
+  setUpAll(() {
+    registerFallbackValue(const VoiceChatState());
+  });
+
+  setUp(() async {
+    mockCubit = MockVoiceChatCubit();
+    mockAIService = MockAIService();
+    final getIt = GetIt.I;
+    if (getIt.isRegistered<VoiceChatCubit>()) {
+      await getIt.unregister<VoiceChatCubit>();
+    }
+    if (getIt.isRegistered<AIService>()) {
+      await getIt.unregister<AIService>();
+    }
+    getIt.registerSingleton<VoiceChatCubit>(mockCubit);
+    getIt.registerSingleton<AIService>(mockAIService);
+
+    when(() => mockCubit.state).thenReturn(const VoiceChatState());
+    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockCubit.init()).thenAnswer((_) async {});
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+    when(() => mockAIService.currentState).thenReturn(AIServiceState.ready);
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  group('Voice Chat Pages Golden Tests', () {
+    testWidgets('ChatPage', (tester) async {
+      setupGoldenTest(tester);
+      await tester.pumpWidget(wrapWithMaterial(const ChatPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(ChatPage),
+        matchesGoldenFile("../../../../../golden/reference/voice_chat_page_alt.png"),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('PrivacyPolicyPage', (tester) async {
+      setupGoldenTest(tester);
+      await tester.pumpWidget(wrapWithMaterial(const PrivacyPolicyPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(PrivacyPolicyPage),
+        matchesGoldenFile("../../../../../golden/reference/voice_chat_privacy_policy.png"),
+      );
+      resetGoldenTest(tester);
+    });
+
+    testWidgets('VoiceChatPage', (tester) async {
+      setupGoldenTest(tester);
+      // Large size to avoid overflow in ConnectionStatusIndicator
+      tester.view.physicalSize = const Size(600, 1000);
+
+      when(() => mockCubit.state).thenReturn(const VoiceChatState(
+        status: VoiceChatStatus.recording,
+        statusMessage: 'Escuchando...',
+      ));
+
+      await tester.pumpWidget(wrapWithMaterial(const VoiceChatPage()));
+      await tester.pump(const Duration(milliseconds: 500));
+
+      await expectLater(
+        find.byType(VoiceChatPage),
+        matchesGoldenFile("../../../../../golden/reference/voice_chat_page.png"),
+      );
+      resetGoldenTest(tester);
+    });
+  });
+}

--- a/test/features/voice_chat/presentation/golden/voice_chat_widgets_golden_test.dart
+++ b/test/features/voice_chat/presentation/golden/voice_chat_widgets_golden_test.dart
@@ -1,26 +1,23 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-FileCopyrightText: 2025 SouthWest AI Labs
+
 import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';
-import 'package:orionhealth_health/features/voice_chat/presentation/pages/chat_page.dart';
-import 'package:orionhealth_health/features/voice_chat/presentation/pages/privacy_policy_page.dart';
-import 'package:orionhealth_health/features/voice_chat/presentation/pages/voice_chat_page.dart';
 import 'package:orionhealth_health/features/voice_chat/presentation/widgets/message_bubble.dart';
 import 'package:orionhealth_health/features/voice_chat/presentation/widgets/voice_input_button.dart';
 import 'package:orionhealth_health/features/voice_chat/application/voice_chat_cubit.dart';
 import 'package:orionhealth_health/features/voice_chat/application/voice_chat_state.dart';
-import 'package:orionhealth_health/core/services/aicore_service.dart';
 import 'package:orionhealth_health/features/voice_chat/domain/entities/voice_chat_message.dart';
-import '../../../core/golden_test_utils.dart';
+import '../../../../core/golden_test_utils.dart';
 
 class MockVoiceChatCubit extends Mock implements VoiceChatCubit {}
-class MockAIService extends Mock implements AIService {}
 
 void main() {
   late MockVoiceChatCubit mockCubit;
-  late MockAIService mockAIService;
 
   setUpAll(() {
     registerFallbackValue(const VoiceChatState());
@@ -28,73 +25,21 @@ void main() {
 
   setUp(() async {
     mockCubit = MockVoiceChatCubit();
-    mockAIService = MockAIService();
     final getIt = GetIt.I;
     if (getIt.isRegistered<VoiceChatCubit>()) {
       await getIt.unregister<VoiceChatCubit>();
     }
-    if (getIt.isRegistered<AIService>()) {
-      await getIt.unregister<AIService>();
-    }
     getIt.registerSingleton<VoiceChatCubit>(mockCubit);
-    getIt.registerSingleton<AIService>(mockAIService);
 
     when(() => mockCubit.state).thenReturn(const VoiceChatState());
     when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
-    when(() => mockCubit.init()).thenAnswer((_) async {});
-    when(() => mockCubit.close()).thenAnswer((_) async {});
-    when(() => mockAIService.currentState).thenReturn(AIServiceState.ready);
   });
 
   tearDown(() async {
     await GetIt.I.reset();
   });
 
-  group('Voice Chat Golden Tests', () {
-    testWidgets('ChatPage', (tester) async {
-      setupGoldenTest(tester);
-      await tester.pumpWidget(wrapWithMaterial(const ChatPage()));
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(ChatPage),
-        matchesGoldenFile("../../../../golden/reference/voice_chat_page_alt.png"),
-      );
-      resetGoldenTest(tester);
-    });
-
-    testWidgets('PrivacyPolicyPage', (tester) async {
-      setupGoldenTest(tester);
-      await tester.pumpWidget(wrapWithMaterial(const PrivacyPolicyPage()));
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(PrivacyPolicyPage),
-        matchesGoldenFile("../../../../golden/reference/voice_chat_privacy_policy.png"),
-      );
-      resetGoldenTest(tester);
-    });
-
-    testWidgets('VoiceChatPage', (tester) async {
-      setupGoldenTest(tester);
-      // Even larger size to avoid overflow in ConnectionStatusIndicator
-      tester.view.physicalSize = const Size(600, 1000);
-
-      when(() => mockCubit.state).thenReturn(const VoiceChatState(
-        status: VoiceChatStatus.recording,
-        statusMessage: 'Escuchando...',
-      ));
-
-      await tester.pumpWidget(wrapWithMaterial(const VoiceChatPage()));
-      await tester.pump(const Duration(milliseconds: 500));
-
-      await expectLater(
-        find.byType(VoiceChatPage),
-        matchesGoldenFile("../../../../golden/reference/voice_chat_page.png"),
-      );
-      resetGoldenTest(tester);
-    });
-
+  group('Voice Chat Widgets Golden Tests', () {
     testWidgets('MessageBubble - User', (tester) async {
       setupGoldenTest(tester);
       final message = VoiceChatMessage(
@@ -109,7 +54,7 @@ void main() {
 
       await expectLater(
         find.byType(MessageBubble),
-        matchesGoldenFile("../../../../golden/reference/voice_message_bubble_user.png"),
+        matchesGoldenFile("../../../../../golden/reference/voice_message_bubble_user.png"),
       );
       resetGoldenTest(tester);
     });
@@ -128,7 +73,7 @@ void main() {
 
       await expectLater(
         find.byType(MessageBubble),
-        matchesGoldenFile("../../../../golden/reference/voice_message_bubble_ai.png"),
+        matchesGoldenFile("../../../../../golden/reference/voice_message_bubble_ai.png"),
       );
       resetGoldenTest(tester);
     });
@@ -149,7 +94,7 @@ void main() {
 
       await expectLater(
         find.byType(VoiceInputButton),
-        matchesGoldenFile("../../../../golden/reference/voice_chat_input_button.png"),
+        matchesGoldenFile("../../../../../golden/reference/voice_chat_input_button.png"),
       );
       resetGoldenTest(tester);
     });


### PR DESCRIPTION
I have added golden tests for the `voice_chat` feature as requested. 

The tests are organized into two files in `test/features/voice_chat/presentation/golden/`:
1. `voice_chat_pages_golden_test.dart`: Tests for `VoiceChatPage`, `ChatPage`, and `PrivacyPolicyPage`.
2. `voice_chat_widgets_golden_test.dart`: Tests for `MessageBubble` (User/AI) and `VoiceInputButton`.

I utilized the existing golden reference images and confirmed that all tests pass. I also refactored the existing redundant test file into this new structure. Additionally, I ran `build_runner` to ensure the dependency injection configuration is up to date.

Fixes #1027

---
*PR created automatically by Jules for task [8673820699351236630](https://jules.google.com/task/8673820699351236630) started by @iberi22*