### PR TITLE
Add golden tests for voice_chat feature

### DIFF
--- a/test/features/voice_chat/presentation/golden/chat_page_golden_test.dart
+++ b/test/features/voice_chat/presentation/golden/chat_page_golden_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/voice_chat/presentation/pages/chat_page.dart';
+import 'package:orionhealth_health/features/voice_chat/application/voice_chat_cubit.dart';
+import 'package:orionhealth_health/features/voice_chat/application/voice_chat_state.dart';
+import 'package:orionhealth_health/core/services/aicore_service.dart';
+import '../../../../core/golden_test_utils.dart';
+
+class MockVoiceChatCubit extends Mock implements VoiceChatCubit {}
+class MockAIService extends Mock implements AIService {}
+
+void main() {
+  late MockVoiceChatCubit mockCubit;
+  late MockAIService mockAIService;
+
+  setUpAll(() {
+    registerFallbackValue(const VoiceChatState());
+  });
+
+  setUp(() async {
+    mockCubit = MockVoiceChatCubit();
+    mockAIService = MockAIService();
+    final getIt = GetIt.I;
+    if (getIt.isRegistered<VoiceChatCubit>()) {
+      await getIt.unregister<VoiceChatCubit>();
+    }
+    if (getIt.isRegistered<AIService>()) {
+      await getIt.unregister<AIService>();
+    }
+    getIt.registerSingleton<VoiceChatCubit>(mockCubit);
+    getIt.registerSingleton<AIService>(mockAIService);
+
+    when(() => mockCubit.state).thenReturn(const VoiceChatState());
+    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockCubit.init()).thenAnswer((_) async {});
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+    when(() => mockAIService.currentState).thenReturn(AIServiceState.ready);
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  group('ChatPage Golden Tests', () {
+    testWidgets('ChatPage - Default State', (tester) async {
+      setupGoldenTest(tester);
+      await tester.pumpWidget(wrapWithMaterial(const ChatPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(ChatPage),
+        matchesGoldenFile("../../../../../golden/reference/voice_chat_page_alt.png"),
+      );
+      resetGoldenTest(tester);
+    });
+  });
+}

--- a/test/features/voice_chat/presentation/golden/privacy_policy_page_golden_test.dart
+++ b/test/features/voice_chat/presentation/golden/privacy_policy_page_golden_test.dart
@@ -1,0 +1,58 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/voice_chat/presentation/pages/privacy_policy_page.dart';
+import 'package:orionhealth_health/features/voice_chat/application/voice_chat_cubit.dart';
+import 'package:orionhealth_health/features/voice_chat/application/voice_chat_state.dart';
+import 'package:orionhealth_health/core/services/aicore_service.dart';
+import '../../../../core/golden_test_utils.dart';
+
+class MockVoiceChatCubit extends Mock implements VoiceChatCubit {}
+class MockAIService extends Mock implements AIService {}
+
+void main() {
+  late MockVoiceChatCubit mockCubit;
+  late MockAIService mockAIService;
+
+  setUpAll(() {
+    registerFallbackValue(const VoiceChatState());
+  });
+
+  setUp(() async {
+    mockCubit = MockVoiceChatCubit();
+    mockAIService = MockAIService();
+    final getIt = GetIt.I;
+    if (getIt.isRegistered<VoiceChatCubit>()) {
+      await getIt.unregister<VoiceChatCubit>();
+    }
+    if (getIt.isRegistered<AIService>()) {
+      await getIt.unregister<AIService>();
+    }
+    getIt.registerSingleton<VoiceChatCubit>(mockCubit);
+    getIt.registerSingleton<AIService>(mockAIService);
+
+    when(() => mockCubit.state).thenReturn(const VoiceChatState());
+    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockCubit.init()).thenAnswer((_) async {});
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+    when(() => mockAIService.currentState).thenReturn(AIServiceState.ready);
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  group('PrivacyPolicyPage Golden Tests', () {
+    testWidgets('PrivacyPolicyPage - Default State', (tester) async {
+      setupGoldenTest(tester);
+      await tester.pumpWidget(wrapWithMaterial(const PrivacyPolicyPage()));
+      await tester.pumpAndSettle();
+
+      await expectLater(
+        find.byType(PrivacyPolicyPage),
+        matchesGoldenFile("../../../../../golden/reference/voice_chat_privacy_policy.png"),
+      );
+      resetGoldenTest(tester);
+    });
+  });
+}

--- a/test/features/voice_chat/presentation/golden/voice_chat_page_golden_test.dart
+++ b/test/features/voice_chat/presentation/golden/voice_chat_page_golden_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/features/voice_chat/presentation/pages/voice_chat_page.dart';
+import 'package:orionhealth_health/features/voice_chat/application/voice_chat_cubit.dart';
+import 'package:orionhealth_health/features/voice_chat/application/voice_chat_state.dart';
+import 'package:orionhealth_health/core/services/aicore_service.dart';
+import '../../../../core/golden_test_utils.dart';
+
+class MockVoiceChatCubit extends Mock implements VoiceChatCubit {}
+class MockAIService extends Mock implements AIService {}
+
+void main() {
+  late MockVoiceChatCubit mockCubit;
+  late MockAIService mockAIService;
+
+  setUpAll(() {
+    registerFallbackValue(const VoiceChatState());
+  });
+
+  setUp(() async {
+    mockCubit = MockVoiceChatCubit();
+    mockAIService = MockAIService();
+    final getIt = GetIt.I;
+    if (getIt.isRegistered<VoiceChatCubit>()) {
+      await getIt.unregister<VoiceChatCubit>();
+    }
+    if (getIt.isRegistered<AIService>()) {
+      await getIt.unregister<AIService>();
+    }
+    getIt.registerSingleton<VoiceChatCubit>(mockCubit);
+    getIt.registerSingleton<AIService>(mockAIService);
+
+    when(() => mockCubit.state).thenReturn(const VoiceChatState());
+    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockCubit.init()).thenAnswer((_) async {});
+    when(() => mockCubit.close()).thenAnswer((_) async {});
+    when(() => mockAIService.currentState).thenReturn(AIServiceState.ready);
+  });
+
+  tearDown(() async {
+    await GetIt.I.reset();
+  });
+
+  group('VoiceChatPage Golden Tests', () {
+    testWidgets('VoiceChatPage - Recording State', (tester) async {
+      setupGoldenTest(tester);
+      // Even larger size to avoid overflow in ConnectionStatusIndicator
+      tester.view.physicalSize = const Size(600, 1000);
+
+      when(() => mockCubit.state).thenReturn(const VoiceChatState(
+        status: VoiceChatStatus.recording,
+        statusMessage: 'Escuchando...',
+      ));
+
+      await tester.pumpWidget(wrapWithMaterial(const VoiceChatPage()));
+      await tester.pump(const Duration(milliseconds: 500));
+
+      await expectLater(
+        find.byType(VoiceChatPage),
+        matchesGoldenFile("../../../../../golden/reference/voice_chat_page.png"),
+      );
+      resetGoldenTest(tester);
+    });
+  });
+}

--- a/test/features/voice_chat/presentation/golden/voice_chat_widgets_golden_test.dart
+++ b/test/features/voice_chat/presentation/golden/voice_chat_widgets_golden_test.dart
@@ -1,19 +1,15 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';
-import 'package:orionhealth_health/features/voice_chat/presentation/pages/chat_page.dart';
-import 'package:orionhealth_health/features/voice_chat/presentation/pages/privacy_policy_page.dart';
-import 'package:orionhealth_health/features/voice_chat/presentation/pages/voice_chat_page.dart';
 import 'package:orionhealth_health/features/voice_chat/presentation/widgets/message_bubble.dart';
 import 'package:orionhealth_health/features/voice_chat/presentation/widgets/voice_input_button.dart';
 import 'package:orionhealth_health/features/voice_chat/application/voice_chat_cubit.dart';
 import 'package:orionhealth_health/features/voice_chat/application/voice_chat_state.dart';
 import 'package:orionhealth_health/core/services/aicore_service.dart';
 import 'package:orionhealth_health/features/voice_chat/domain/entities/voice_chat_message.dart';
-import '../../../core/golden_test_utils.dart';
+import '../../../../core/golden_test_utils.dart';
 
 class MockVoiceChatCubit extends Mock implements VoiceChatCubit {}
 class MockAIService extends Mock implements AIService {}
@@ -50,51 +46,7 @@ void main() {
     await GetIt.I.reset();
   });
 
-  group('Voice Chat Golden Tests', () {
-    testWidgets('ChatPage', (tester) async {
-      setupGoldenTest(tester);
-      await tester.pumpWidget(wrapWithMaterial(const ChatPage()));
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(ChatPage),
-        matchesGoldenFile("../../../../golden/reference/voice_chat_page_alt.png"),
-      );
-      resetGoldenTest(tester);
-    });
-
-    testWidgets('PrivacyPolicyPage', (tester) async {
-      setupGoldenTest(tester);
-      await tester.pumpWidget(wrapWithMaterial(const PrivacyPolicyPage()));
-      await tester.pumpAndSettle();
-
-      await expectLater(
-        find.byType(PrivacyPolicyPage),
-        matchesGoldenFile("../../../../golden/reference/voice_chat_privacy_policy.png"),
-      );
-      resetGoldenTest(tester);
-    });
-
-    testWidgets('VoiceChatPage', (tester) async {
-      setupGoldenTest(tester);
-      // Even larger size to avoid overflow in ConnectionStatusIndicator
-      tester.view.physicalSize = const Size(600, 1000);
-
-      when(() => mockCubit.state).thenReturn(const VoiceChatState(
-        status: VoiceChatStatus.recording,
-        statusMessage: 'Escuchando...',
-      ));
-
-      await tester.pumpWidget(wrapWithMaterial(const VoiceChatPage()));
-      await tester.pump(const Duration(milliseconds: 500));
-
-      await expectLater(
-        find.byType(VoiceChatPage),
-        matchesGoldenFile("../../../../golden/reference/voice_chat_page.png"),
-      );
-      resetGoldenTest(tester);
-    });
-
+  group('Voice Chat Widgets Golden Tests', () {
     testWidgets('MessageBubble - User', (tester) async {
       setupGoldenTest(tester);
       final message = VoiceChatMessage(
@@ -109,7 +61,7 @@ void main() {
 
       await expectLater(
         find.byType(MessageBubble),
-        matchesGoldenFile("../../../../golden/reference/voice_message_bubble_user.png"),
+        matchesGoldenFile("../../../../../golden/reference/voice_message_bubble_user.png"),
       );
       resetGoldenTest(tester);
     });
@@ -128,7 +80,7 @@ void main() {
 
       await expectLater(
         find.byType(MessageBubble),
-        matchesGoldenFile("../../../../golden/reference/voice_message_bubble_ai.png"),
+        matchesGoldenFile("../../../../../golden/reference/voice_message_bubble_ai.png"),
       );
       resetGoldenTest(tester);
     });
@@ -149,7 +101,7 @@ void main() {
 
       await expectLater(
         find.byType(VoiceInputButton),
-        matchesGoldenFile("../../../../golden/reference/voice_chat_input_button.png"),
+        matchesGoldenFile("../../../../../golden/reference/voice_chat_input_button.png"),
       );
       resetGoldenTest(tester);
     });


### PR DESCRIPTION
I have added comprehensive golden tests for the `voice_chat` feature. These tests are organized into specific files within a new `test/features/voice_chat/presentation/golden/` directory, mirroring the structure of other features in the project.

Key changes:
- Created `voice_chat_page_golden_test.dart` for the main voice chat page.
- Created `chat_page_golden_test.dart` for the alternate chat view.
- Created `privacy_policy_page_golden_test.dart` for the voice chat privacy policy.
- Created `voice_chat_widgets_golden_test.dart` for reusable components like `MessageBubble` and `VoiceInputButton`.
- Updated all references to use the correct relative paths to the central `golden/reference/` directory.
- Removed the old `voice_chat_golden_test.dart` to maintain a clean and modular test suite.

All new tests have been verified and pass successfully.

Fixes #1075

---
*PR created automatically by Jules for task [12231932466573731050](https://jules.google.com/task/12231932466573731050) started by @iberi22*