### PR TITLE
Add E2E tests for email-citas feature

### DIFF
--- a/integration_test/email_citas_e2e_test.dart
+++ b/integration_test/email_citas_e2e_test.dart
@@ -5,33 +5,61 @@ import 'package:integration_test/integration_test.dart';
 import 'package:orionhealth_health/core/di/injection.dart';
 import 'package:orionhealth_health/features/email-citas/presentation/email_connect_page.dart';
 import 'package:orionhealth_health/features/email-citas/application/email_citas_cubit.dart';
-import 'package:orionhealth_health/features/email-citas/application/email_citas_state.dart';
+import 'package:orionhealth_health/features/email-citas/domain/repositories/email_repository.dart';
+import 'package:orionhealth_health/features/appointments/domain/repositories/appointment_repository.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:flutter/services.dart';
 import 'utils/video_recorder.dart';
 
-class MockEmailCitasCubit extends Mock implements EmailCitasCubit {}
+class MockEmailRepository extends Mock implements EmailRepository {}
+class MockAppointmentRepository extends Mock implements AppointmentRepository {}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  late MockEmailCitasCubit mockCubit;
+  late MockEmailRepository mockEmailRepository;
+  late MockAppointmentRepository mockAppointmentRepository;
+  late EmailCitasCubit cubit;
 
-  setUp(() {
-    mockCubit = MockEmailCitasCubit();
-    getIt.allowReassignment = true;
-    getIt.registerSingleton<EmailCitasCubit>(mockCubit);
+  const MethodChannel messagesChannel = MethodChannel('com.llfbandit.app_links/messages');
+  const MethodChannel eventsChannel = MethodChannel('com.llfbandit.app_links/events');
 
-    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+  setUpAll(() {
+    registerFallbackValue(Appointment(
+      doctorName: '',
+      specialty: '',
+      dateTime: DateTime.now(),
+      status: AppointmentStatus.upcoming,
+    ));
   });
 
-  tearDown(() {
-    getIt.unregister<EmailCitasCubit>();
+  setUp(() async {
+    await getIt.reset();
+
+    // Mock AppLinks channels to avoid platform-related failures
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      messagesChannel,
+      (MethodCall methodCall) async => null,
+    );
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler(
+      eventsChannel,
+      (MethodCall methodCall) async => null,
+    );
+
+    mockEmailRepository = MockEmailRepository();
+    mockAppointmentRepository = MockAppointmentRepository();
+
+    getIt.registerSingleton<EmailRepository>(mockEmailRepository);
+    getIt.registerSingleton<AppointmentRepository>(mockAppointmentRepository);
+
+    cubit = EmailCitasCubit(mockEmailRepository, mockAppointmentRepository);
+    getIt.registerSingleton<EmailCitasCubit>(cubit);
   });
 
   group('Email Citas Flow - E2E Tests', () {
-    testWidgets('E2E: Connect Email', (WidgetTester tester) async {
-      when(() => mockCubit.state).thenReturn(const EmailCitasInitial());
-
+    testWidgets('E2E: Connect and Sync Gmail', (WidgetTester tester) async {
+      // 1. Initial State
       await tester.pumpWidget(const MaterialApp(home: EmailConnectPage()));
       await tester.pumpAndSettle();
       await VideoRecorder.recordStep(tester, 'email_citas', '01_initial');
@@ -39,86 +67,104 @@ void main() {
       expect(find.text('Gmail'), findsOneWidget);
       expect(find.text('No conectado').first, findsOneWidget);
 
-      await tester.tap(find.text('CONECTAR').first);
-      verify(() => mockCubit.connectGmail()).called(1);
-    });
-
-    testWidgets('E2E: Connection Timeout', (WidgetTester tester) async {
-      final stateController = StreamController<EmailCitasState>.broadcast();
-      when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
-      when(() => mockCubit.state).thenReturn(const EmailCitasInitial());
-
-      await tester.pumpWidget(const MaterialApp(home: EmailConnectPage()));
-      await tester.pumpAndSettle();
-
-      when(() => mockCubit.connectGmail()).thenAnswer((_) async {
-        stateController.add(const EmailCitasError('Timeout'));
-      });
+      // 2. Connect Gmail (triggers OAuth flow)
+      when(() => mockEmailRepository.connectGmail()).thenAnswer((_) async => true);
 
       await tester.tap(find.text('CONECTAR').first);
       await tester.pumpAndSettle();
-      await VideoRecorder.recordStep(tester, 'email_citas', '02_timeout');
 
-      expect(find.text('Error: Timeout'), findsOneWidget);
-    });
+      verify(() => mockEmailRepository.connectGmail()).called(1);
+      await VideoRecorder.recordStep(tester, 'email_citas', '02_connecting');
 
-    testWidgets('E2E: Invalid Email Credentials', (WidgetTester tester) async {
-      final stateController = StreamController<EmailCitasState>.broadcast();
-      when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
-      when(() => mockCubit.state).thenReturn(const EmailCitasInitial());
+      // 3. Simulate OAuth redirect success
+      final uri = Uri.parse('orionhealth://oauth2redirect?code=test_code');
 
-      await tester.pumpWidget(const MaterialApp(home: EmailConnectPage()));
+      // Mock repository methods for sync
+      when(() => mockEmailRepository.fetchParsedAppointments(any(), any()))
+          .thenAnswer((_) async => [
+            Appointment(
+              doctorName: 'Dr. Test',
+              specialty: 'E2E Testing',
+              dateTime: DateTime.now(),
+              status: AppointmentStatus.upcoming,
+            )
+          ]);
+      when(() => mockAppointmentRepository.saveAppointment(any())).thenAnswer((_) async => 1);
+      when(() => mockEmailRepository.syncToNativeCalendar(any())).thenAnswer((_) async => {});
+
+      await cubit.handleOAuthRedirect(uri);
       await tester.pumpAndSettle();
 
-      when(() => mockCubit.connectGmail()).thenAnswer((_) async {
-        stateController.add(const EmailCitasError('Invalid credentials'));
-      });
-
-      await tester.tap(find.text('CONECTAR').first);
-      await tester.pumpAndSettle();
-      await VideoRecorder.recordStep(tester, 'email_citas', '03_invalid_creds');
-
-      expect(find.text('Error: Invalid credentials'), findsOneWidget);
-    });
-
-    testWidgets('E2E: Network Drop During Sync', (WidgetTester tester) async {
-      final stateController = StreamController<EmailCitasState>.broadcast();
-      when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
-      when(() => mockCubit.state).thenReturn(const EmailCitasConnected(isGmailConnected: true));
-
-      await tester.pumpWidget(const MaterialApp(home: EmailConnectPage()));
-      await tester.pumpAndSettle();
-
-      when(() => mockCubit.manualSync()).thenAnswer((_) async {
-        stateController.add(const EmailCitasLoading());
-        stateController.add(const EmailCitasError('Network connection lost'));
-      });
-
-      await tester.tap(find.text('SINCRONIZAR AHORA'));
-      await tester.pumpAndSettle();
-      await VideoRecorder.recordStep(tester, 'email_citas', '04_network_drop');
-
-      expect(find.text('Error: Network connection lost'), findsOneWidget);
-    });
-
-    testWidgets('E2E: Empty Inbox Sync', (WidgetTester tester) async {
-      final stateController = StreamController<EmailCitasState>.broadcast();
-      when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
-      when(() => mockCubit.state).thenReturn(const EmailCitasConnected(isGmailConnected: true));
-
-      await tester.pumpWidget(const MaterialApp(home: EmailConnectPage()));
-      await tester.pumpAndSettle();
-
-      when(() => mockCubit.manualSync()).thenAnswer((_) async {
-        stateController.add(const EmailCitasLoading());
-        stateController.add(const EmailCitasSyncSuccess());
-      });
-
-      await tester.tap(find.text('SINCRONIZAR AHORA'));
-      await tester.pumpAndSettle();
-      await VideoRecorder.recordStep(tester, 'email_citas', '05_empty_inbox');
-
+      // Check if snackbar appeared and UI updated to Connected
       expect(find.text('Sincronización completada'), findsOneWidget);
+      expect(find.text('Conectado').first, findsOneWidget);
+      expect(find.text('SINCRONIZAR AHORA'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'email_citas', '03_connected_and_synced');
+    });
+
+    testWidgets('E2E: Manual Sync Flow', (WidgetTester tester) async {
+      // Setup: Start as connected
+      final uri = Uri.parse('orionhealth://oauth2redirect?code=test_code');
+      when(() => mockEmailRepository.connectGmail()).thenAnswer((_) async => true);
+      when(() => mockEmailRepository.fetchParsedAppointments(any(), any())).thenAnswer((_) async => []);
+
+      await cubit.connectGmail();
+      await cubit.handleOAuthRedirect(uri);
+
+      await tester.pumpWidget(const MaterialApp(home: EmailConnectPage()));
+      await tester.pumpAndSettle();
+
+      expect(find.text('SINCRONIZAR AHORA'), findsOneWidget);
+
+      // Trigger manual sync
+      when(() => mockEmailRepository.fetchParsedAppointments(any(), any()))
+          .thenAnswer((_) async => []);
+
+      await tester.tap(find.text('SINCRONIZAR AHORA'));
+      await tester.pump(); // Start loading
+
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'email_citas', '04_manual_sync_loading');
+
+      await tester.pumpAndSettle();
+      expect(find.text('Sincronización completada'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'email_citas', '05_manual_sync_success');
+    });
+
+    testWidgets('E2E: Error Handling - Connection Failed', (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(home: EmailConnectPage()));
+      await tester.pumpAndSettle();
+
+      when(() => mockEmailRepository.connectGmail()).thenAnswer((_) async => false);
+
+      await tester.tap(find.text('CONECTAR').first);
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('No se pudo abrir la página de conexión'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'email_citas', '06_connection_error');
+    });
+
+    testWidgets('E2E: Error Handling - Sync Failed', (WidgetTester tester) async {
+      // Setup: Start as connected
+      final uri = Uri.parse('orionhealth://oauth2redirect?code=test_code');
+      when(() => mockEmailRepository.connectGmail()).thenAnswer((_) async => true);
+      when(() => mockEmailRepository.fetchParsedAppointments(any(), any())).thenAnswer((_) async => []);
+
+      await cubit.connectGmail();
+      await cubit.handleOAuthRedirect(uri);
+
+      await tester.pumpWidget(const MaterialApp(home: EmailConnectPage()));
+      await tester.pumpAndSettle();
+
+      // Mock sync failure
+      when(() => mockEmailRepository.fetchParsedAppointments(any(), any()))
+          .thenThrow(Exception('Network Error'));
+
+      await tester.tap(find.text('SINCRONIZAR AHORA'));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Error: Exception: Network Error'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'email_citas', '07_sync_error');
     });
   });
 }

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -15,7 +15,7 @@ import 'package:flutter_appauth/flutter_appauth.dart' as _i38;
 import 'package:flutter_secure_storage/flutter_secure_storage.dart' as _i40;
 import 'package:get_it/get_it.dart' as _i1;
 import 'package:google_generative_ai/google_generative_ai.dart' as _i42;
-import 'package:health_wallet/health_wallet.dart' as _i34;
+import 'package:health_wallet/health_wallet.dart' as _i33;
 import 'package:http/http.dart' as _i24;
 import 'package:injectable/injectable.dart' as _i2;
 import 'package:isar/isar.dart' as _i58;
@@ -66,7 +66,7 @@ import '../../features/auth/domain/repositories/auth_repository.dart' as _i136;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i14;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i33;
+    as _i34;
 import '../../features/calendar_import/application/calendar_import_cubit.dart'
     as _i209;
 import '../../features/calendar_import/domain/repositories/calendar_import_repository.dart'
@@ -222,7 +222,7 @@ import '../../features/local_agent/domain/services/llm_adapter.dart' as _i61;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
     as _i120;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i63;
+    as _i62;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i39;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
@@ -232,7 +232,7 @@ import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
     as _i177;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i62;
+    as _i63;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
     as _i180;
 import '../../features/local_agent/infrastructure/llm_service.dart' as _i179;
@@ -351,7 +351,7 @@ import '../../features/settings/application/llm_settings_cubit.dart' as _i181;
 import '../../features/settings/domain/repositories/settings_repository.dart'
     as _i108;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i27;
+    as _i28;
 import '../../features/settings/infrastructure/datasources/settings_local_datasource.dart'
     as _i107;
 import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
@@ -408,7 +408,7 @@ import '../services/aicore_service.dart' as _i3;
 import '../services/asr/asr_service.dart' as _i10;
 import '../services/audio/audio_player_service.dart' as _i11;
 import '../services/audio/audio_recorder_service.dart' as _i13;
-import '../services/device_capability_service.dart' as _i28;
+import '../services/device_capability_service.dart' as _i27;
 import '../services/privacy_anonymizer.dart' as _i96;
 import 'database_module.dart' as _i231;
 import 'fhir_module.dart' as _i232;
@@ -416,9 +416,9 @@ import 'memory_module.dart' as _i230;
 import 'network_module.dart' as _i229;
 import 'service_module.dart' as _i228;
 
-const String _mobile = 'mobile';
 const String _desktop = 'desktop';
 const String _test = 'test';
+const String _mobile = 'mobile';
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -481,9 +481,9 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.lazySingleton<_i32.EmbeddingsAdapter>(
         () => memoryModule.embeddingsAdapter);
-    gh.lazySingleton<_i33.EncryptionService>(() => _i33.EncryptionService());
-    gh.lazySingleton<_i34.EncryptionService>(
+    gh.lazySingleton<_i33.EncryptionService>(
         () => databaseModule.walletEncryptionService);
+    gh.lazySingleton<_i34.EncryptionService>(() => _i34.EncryptionService());
     gh.lazySingleton<_i35.FhirClient>(() => fhirModule.fhirClient);
     gh.lazySingleton<_i36.FilePickerService>(
         () => _i36.FilePickerServiceImpl());
@@ -529,12 +529,12 @@ extension GetItInjectableX on _i1.GetIt {
         _i60.LicenseVerifier(
             await getAsync<_i59.LicenseRegistryLocalDataSource>()));
     gh.lazySingleton<_i61.LlmAdapter>(
-      () => _i62.OpenaiCompatibleAdapter(),
-      instanceName: 'openai',
+      () => _i62.FlutterGemmaAdapter(wrapper: gh<_i39.FlutterGemmaWrapper>()),
+      instanceName: 'gemma',
     );
     gh.lazySingleton<_i61.LlmAdapter>(
-      () => _i63.FlutterGemmaAdapter(wrapper: gh<_i39.FlutterGemmaWrapper>()),
-      instanceName: 'gemma',
+      () => _i63.OpenaiCompatibleAdapter(),
+      instanceName: 'openai',
     );
     gh.lazySingleton<_i64.LocalLlmService>(() => _i64.LocalLlmService());
     gh.lazySingleton<_i65.LocalModelLocalDataSource>(
@@ -653,9 +653,9 @@ extension GetItInjectableX on _i1.GetIt {
         () => _i126.VoiceChatRepositoryImpl(gh<_i23.ChatAiDatasource>()));
     gh.lazySingleton<_i127.VouchRepository>(
         () => _i128.IsarVouchRepository(gh<_i58.Isar>()));
-    gh.lazySingleton<_i34.WalletService>(() => databaseModule.walletService(
+    gh.lazySingleton<_i33.WalletService>(() => databaseModule.walletService(
           gh<_i58.Isar>(),
-          gh<_i34.EncryptionService>(),
+          gh<_i33.EncryptionService>(),
         ));
     gh.lazySingleton<_i129.WifiDirectService>(() => _i129.WifiDirectService());
     gh.factory<_i130.AboutCubit>(
@@ -671,7 +671,7 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i136.AuthRepository>(
         () => _i137.AuthRepositoryImpl(gh<_i135.AuthLocalDataSource>()));
     gh.lazySingleton<_i138.AuthService>(
-        () => _i138.AuthServiceImpl(gh<_i33.EncryptionService>()));
+        () => _i138.AuthServiceImpl(gh<_i34.EncryptionService>()));
     gh.lazySingleton<_i139.BleSharingService>(
         () => _i139.BleSharingService(gh<_i15.BleWrapper>()));
     gh.lazySingleton<_i140.CancelSharingUseCase>(
@@ -805,7 +805,7 @@ extension GetItInjectableX on _i1.GetIt {
         ));
     gh.factory<_i181.LlmSettingsCubit>(() => _i181.LlmSettingsCubit(
           gh<_i108.SettingsRepository>(),
-          gh<_i27.DeviceCapabilityService>(),
+          gh<_i28.DeviceCapabilityService>(),
           gh<_i61.LlmAdapter>(instanceName: 'gemma'),
         ));
     gh.lazySingleton<_i182.MedicalResearchService>(
@@ -892,7 +892,7 @@ extension GetItInjectableX on _i1.GetIt {
     gh.factory<_i205.AuthCubit>(() => _i205.AuthCubit(gh<_i138.AuthService>()));
     gh.factory<_i206.AuthCubit>(() => _i206.AuthCubit(
           gh<_i136.AuthRepository>(),
-          gh<_i33.EncryptionService>(),
+          gh<_i34.EncryptionService>(),
           gh<_i14.BiometricService>(),
         ));
     gh.lazySingleton<_i207.BadgeCalculator>(() => _i207.BadgeCalculator(
@@ -974,8 +974,8 @@ extension GetItInjectableX on _i1.GetIt {
           startSharingUseCase: gh<_i195.StartSharingUseCase>(),
           startListeningUseCase: gh<_i194.StartListeningUseCase>(),
           cancelSharingUseCase: gh<_i140.CancelSharingUseCase>(),
-          walletService: gh<_i34.WalletService>(),
-          walletEncryption: gh<_i34.EncryptionService>(),
+          walletService: gh<_i33.WalletService>(),
+          walletEncryption: gh<_i33.EncryptionService>(),
         ));
     gh.factory<_i226.GetResearchHistory>(
         () => _i226.GetResearchHistory(gh<_i220.MedicalResearchRepository>()));


### PR DESCRIPTION
This PR adds a robust E2E (integration) test suite for the `email-citas` feature. Unlike the previous version that mocked the Cubit, this new test uses the real application logic (`EmailCitasCubit`) while mocking the underlying repositories. This ensures that the UI-to-Logic integration is correctly tested.

Key changes:
- New comprehensive test file: `integration_test/email_citas_e2e_test.dart`
- Tests for Gmail connection success, manual sync, and various error scenarios.
- Use of `VideoRecorder` for step-by-step screenshots.
- Mocking of `app_links` platform channels to ensure tests run in various environments.
- Updated `injection.config.dart` following a `build_runner` execution to ensure all dependencies are correctly wired.

Fixes #1199

---
*PR created automatically by Jules for task [9176767362099601180](https://jules.google.com/task/9176767362099601180) started by @iberi22*