### PR TITLE
Add E2E test for health_data_import feature

### DIFF
--- a/integration_test/health_data_import_e2e_test.dart
+++ b/integration_test/health_data_import_e2e_test.dart
@@ -4,23 +4,71 @@ import 'package:integration_test/integration_test.dart';
 import 'package:orionhealth_health/core/di/injection.dart';
 import 'package:orionhealth_health/features/health_data_import/presentation/pages/health_import_page.dart';
 import 'package:orionhealth_health/features/health_data_import/application/health_import_cubit.dart';
-import 'package:orionhealth_health/features/health_data_import/application/health_import_state.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/entities/health_data_source.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/services/health_data_import_service.dart';
+import 'package:orionhealth_health/features/vitals/domain/repositories/vital_sign_repository.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:flutter/services.dart';
 import 'utils/video_recorder.dart';
 
-class MockHealthImportCubit extends Mock implements HealthImportCubit {}
+class MockHealthDataImportService extends Mock implements HealthDataImportService {}
+class MockVitalSignRepository extends Mock implements VitalSignRepository {}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  late MockHealthImportCubit mockCubit;
+  late MockHealthDataImportService mockService;
+  late MockVitalSignRepository mockVitalRepo;
+  late HealthImportCubit cubit;
+
+  setUpAll(() {
+    registerFallbackValue(HealthDataSource.googleFit);
+    registerFallbackValue([]);
+  });
 
   setUp(() {
-    mockCubit = MockHealthImportCubit();
-    getIt.registerSingleton<HealthImportCubit>(mockCubit);
+    mockService = MockHealthDataImportService();
+    mockVitalRepo = MockVitalSignRepository();
 
-    when(() => mockCubit.checkAvailableSources()).thenAnswer((_) async {});
-    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    cubit = HealthImportCubit(mockService, mockVitalRepo);
+
+    // Register in GetIt
+    getIt.allowReassignment = true;
+    getIt.registerSingleton<HealthImportCubit>(cubit);
+
+    // Mock local_auth channel
+    const MethodChannel channel = MethodChannel('plugins.flutter.io/local_auth');
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(channel, (MethodCall methodCall) async {
+      switch (methodCall.method) {
+        case 'canCheckBiometrics':
+          return true;
+        case 'isDeviceSupported':
+          return true;
+        case 'getAvailableBiometrics':
+          return <String>['fingerprint'];
+        case 'authenticate':
+          return true;
+        default:
+          return null;
+      }
+    });
+
+    // Default mocks for service
+    when(() => mockService.getAvailableSources()).thenAnswer((_) async => [HealthDataSource.googleFit]);
+    when(() => mockService.requestAuthorization(any())).thenAnswer((_) async => true);
+    when(() => mockService.fetchSteps()).thenAnswer((_) async => []);
+    when(() => mockService.fetchDistance()).thenAnswer((_) async => []);
+    when(() => mockService.fetchHeartRate()).thenAnswer((_) async => []);
+    when(() => mockService.fetchSleep()).thenAnswer((_) async => []);
+    when(() => mockService.fetchBloodGlucose()).thenAnswer((_) async => []);
+    when(() => mockService.fetchBloodPressure()).thenAnswer((_) async => []);
+    when(() => mockService.fetchHeight()).thenAnswer((_) async => []);
+    when(() => mockService.fetchWeight()).thenAnswer((_) async => []);
+    when(() => mockService.fetchOxygenSaturation()).thenAnswer((_) async => []);
+    when(() => mockService.convertToVitalSigns(any(), any())).thenAnswer((_) async => []);
+
+    when(() => mockVitalRepo.saveVitalSigns(any())).thenAnswer((_) async => {});
   });
 
   tearDown(() {
@@ -28,22 +76,64 @@ void main() {
   });
 
   group('Health Data Import Flow - E2E Tests', () {
-    testWidgets('E2E: Import from Sensor', (WidgetTester tester) async {
-      final availability = {HealthDataSource.googleFit: true, HealthDataSource.appleHealth: false};
-      when(() => mockCubit.state).thenReturn(HealthImportReady(
-        availableSources: availability.keys.toList(),
-        availability: availability,
+    testWidgets('E2E: Full Import Flow from Google Fit', (WidgetTester tester) async {
+      await tester.pumpWidget(const MaterialApp(
+        home: HealthImportPage(),
       ));
 
-      await tester.pumpWidget(const MaterialApp(home: HealthImportPage()));
+      // Wait for initial loading (checkAvailableSources)
       await tester.pumpAndSettle();
       await VideoRecorder.recordStep(tester, 'health_import', '01_ready');
 
       expect(find.text('Google Fit / Health Connect'), findsOneWidget);
+      expect(find.text('Available'), findsOneWidget);
 
-      // Trigger import (mocking biometric and cubit response)
-      // Note: Real test would need to handle biometric mock which is complex,
-      // but here we focus on the Bloc interaction.
+      // Tap Import Data
+      await tester.tap(find.text('Import Data'));
+
+      // The page will:
+      // 1. Authenticate Biometric (Mocked to return true)
+      // 2. cubit.importFromSource(googleFit)
+
+      await tester.pump(); // Start authentication
+      await tester.pump(const Duration(milliseconds: 100)); // Process auth
+
+      // Should show Requesting permission dialog (Authenticating state)
+      // Note: we use find.textContaining because it's in a dialog
+      expect(find.textContaining('Requesting permission from Google Fit'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'health_import', '02_authenticating');
+
+      await tester.pump(); // Move to Importing
+
+      // Should show ImportProgressDialog
+      expect(find.text('Importing data...'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'health_import', '03_importing');
+
+      // Finalize import
+      await tester.pumpAndSettle();
+
+      // Success SnackBar should appear
+      expect(find.textContaining('Successfully imported 0 records'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'health_import', '04_success');
+    });
+
+    testWidgets('E2E: Import Error handling', (WidgetTester tester) async {
+      when(() => mockService.requestAuthorization(any())).thenThrow(Exception('Auth Failed'));
+
+      await tester.pumpWidget(const MaterialApp(
+        home: HealthImportPage(),
+      ));
+
+      await tester.pumpAndSettle();
+
+      await tester.tap(find.text('Import Data'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pumpAndSettle();
+
+      // Error SnackBar should appear
+      expect(find.textContaining('Error: Import failed: Exception: Auth Failed'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'health_import', '05_error');
     });
   });
 }


### PR DESCRIPTION
Created `integration_test/health_data_import_e2e_test.dart` to provide E2E coverage for the health data import feature. The test simulates a full user journey from checking available sources to completing a data import, including mocking of the `local_auth` platform channel and the `HealthDataImportService`. Verified that existing unit tests pass and that the codebase is clean of unrelated changes.

Fixes #1188

---
*PR created automatically by Jules for task [11624229766596313693](https://jules.google.com/task/11624229766596313693) started by @iberi22*