### PR TITLE
Add E2E tests for user_profile navigation

### DIFF
--- a/integration_test/user_profile_e2e_test.dart
+++ b/integration_test/user_profile_e2e_test.dart
@@ -69,5 +69,95 @@ void main() {
       final savedProfile = await repo.getUserProfile();
       expect(savedProfile?.allowCloudApi, isFalse);
     });
+
+    testWidgets('E2E: Navigate to Medications from Profile', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: const UserProfilePage(),
+          theme: ThemeData.dark(),
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('es'),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Find "Medicamentos" section/tile
+      final medicationsTile = find.text('Medicamentos');
+      expect(medicationsTile, findsOneWidget);
+
+      await tester.tap(medicationsTile);
+      await tester.pumpAndSettle();
+      await VideoRecorder.recordStep(tester, 'user_profile', '04_medications_page');
+
+      // Verify we are on MedicationsPage (Checking AppBar title)
+      expect(find.descendant(of: find.byType(AppBar), matching: find.text('Medicamentos')), findsOneWidget);
+    });
+
+    testWidgets('E2E: Navigate to Allergies from Profile', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: const UserProfilePage(),
+          theme: ThemeData.dark(),
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('es'),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Find "Alergias" section/tile
+      final allergiesTile = find.text('Alergias');
+      expect(allergiesTile, findsOneWidget);
+
+      await tester.tap(allergiesTile);
+      await tester.pumpAndSettle();
+      await VideoRecorder.recordStep(tester, 'user_profile', '05_allergies_page');
+
+      // Verify we are on AllergiesPage
+      expect(find.descendant(of: find.byType(AppBar), matching: find.text('Alergias')), findsOneWidget);
+    });
+
+    testWidgets('E2E: Navigate to Appointments from Profile', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: const UserProfilePage(),
+          theme: ThemeData.dark(),
+          localizationsDelegates: const [
+            AppLocalizations.delegate,
+            GlobalMaterialLocalizations.delegate,
+            GlobalWidgetsLocalizations.delegate,
+            GlobalCupertinoLocalizations.delegate,
+          ],
+          supportedLocales: AppLocalizations.supportedLocales,
+          locale: const Locale('es'),
+        ),
+      );
+
+      await tester.pumpAndSettle();
+
+      // Find "Citas" section/tile
+      final appointmentsTile = find.text('Citas');
+      expect(appointmentsTile, findsOneWidget);
+
+      await tester.tap(appointmentsTile);
+      await tester.pumpAndSettle();
+      await VideoRecorder.recordStep(tester, 'user_profile', '06_appointments_page');
+
+      // Verify we are on AppointmentsPage
+      expect(find.descendant(of: find.byType(AppBar), matching: find.text('Citas')), findsOneWidget);
+    });
   });
 }


### PR DESCRIPTION
Added E2E tests for the `user_profile` feature to verify navigation to sub-pages. The existing `user_profile_e2e_test.dart` was enhanced with tests for Medications, Allergies, and Appointments navigation, following the established E2E pattern in the project.

Fixes #1223

---
*PR created automatically by Jules for task [4976336306886788689](https://jules.google.com/task/4976336306886788689) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded end-to-end coverage for the User Profile flow.
  * Added checks for Spanish-language navigation to the Medicamentos, Alergias, and Citas screens.
  * Improved confidence that profile section taps open the correct destination pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->