### PR TITLE
Add E2E tests for medical_research feature

### DIFF
--- a/integration_test/medical_research_e2e_test.dart
+++ b/integration_test/medical_research_e2e_test.dart
@@ -1,53 +1,46 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
-import 'package:orionhealth_health/core/di/injection.dart';
+import 'package:orionhealth_health/core/di/injection.dart' as di;
 import 'package:orionhealth_health/features/medical_research/presentation/pages/medical_research_page.dart';
-import 'package:orionhealth_health/features/medical_research/application/medical_research_cubit.dart';
+import 'package:orionhealth_health/features/medical_research/domain/entities/medical_research_result.dart';
+import 'package:orionhealth_health/features/medical_research/domain/entities/research_query.dart';
 import 'package:orionhealth_health/features/medical_research/domain/models/research_result.dart';
+import 'package:orionhealth_health/features/medical_research/domain/repositories/medical_research_repository.dart';
+import 'package:orionhealth_health/features/medical_research/domain/services/medical_standards_service.dart';
 import 'package:medical_standards/medical_standards.dart';
 import 'package:mocktail/mocktail.dart';
 import 'utils/video_recorder.dart';
 
-class MockMedicalResearchCubit extends Mock implements MedicalResearchCubit {}
+class MockMedicalResearchRepository extends Mock implements MedicalResearchRepository {}
+class MockMedicalStandardsService extends Mock implements MedicalStandardsService {}
+
+class FakeResearchQuery extends Fake implements ResearchQuery {}
+class FakeMedicalResearchResult extends Fake implements MedicalResearchResult {}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  late MockMedicalResearchCubit mockCubit;
-  late StreamController<MedicalResearchState> stateController;
+  late MockMedicalResearchRepository mockRepository;
+  late MockMedicalStandardsService mockStandardsService;
 
-  setUp(() {
-    mockCubit = MockMedicalResearchCubit();
-    stateController = StreamController<MedicalResearchState>.broadcast();
-
-    // Register the mock in GetIt
-    if (getIt.isRegistered<MedicalResearchCubit>()) {
-      getIt.unregister<MedicalResearchCubit>();
-    }
-    getIt.registerSingleton<MedicalResearchCubit>(mockCubit);
-
-    when(() => mockCubit.stream).thenAnswer((_) => stateController.stream);
-    when(() => mockCubit.close()).thenAnswer((_) async {});
+  setUpAll(() async {
+    await di.configureDependencies();
+    registerFallbackValue(FakeResearchQuery());
+    registerFallbackValue(FakeMedicalResearchResult());
   });
 
-  tearDown(() {
-    stateController.close();
-    getIt.unregister<MedicalResearchCubit>();
+  setUp(() {
+    mockRepository = MockMedicalResearchRepository();
+    mockStandardsService = MockMedicalStandardsService();
+
+    di.getIt.allowReassignment = true;
+    di.getIt.registerSingleton<MedicalResearchRepository>(mockRepository);
+    di.getIt.registerSingleton<MedicalStandardsService>(mockStandardsService);
   });
 
   group('Medical Research Flow - E2E Tests', () {
     testWidgets('E2E: Search Research Evidence', (WidgetTester tester) async {
-      const initialState = MedicalResearchState(status: MedicalResearchStatus.idle);
-      when(() => mockCubit.state).thenReturn(initialState);
-
-      await tester.pumpWidget(const MaterialApp(home: MedicalResearchPage()));
-      await tester.pumpAndSettle();
-      await VideoRecorder.recordStep(tester, 'research', '01_initial_evidence');
-
-      expect(find.text('BUSCAR EN BASES DE DATOS MÉDICAS'), findsOneWidget);
-
       final results = [
         const ResearchResult(
           title: 'Diabetes Study 2025',
@@ -58,42 +51,35 @@ void main() {
         ),
       ];
 
-      when(() => mockCubit.performResearch(any())).thenAnswer((_) async {
-        final loadingState = initialState.copyWith(
-          status: MedicalResearchStatus.loading,
-          loadingMessage: 'Buscando evidencia médica...',
-        );
-        when(() => mockCubit.state).thenReturn(loadingState);
-        stateController.add(loadingState);
+      when(() => mockRepository.search(any())).thenAnswer((_) async => results);
+      when(() => mockRepository.saveToHistory(any())).thenAnswer((_) async {});
+      when(() => mockRepository.getHistory()).thenAnswer((_) async => []);
 
-        // Simulate delay
-        await Future.delayed(const Duration(milliseconds: 100));
+      await tester.pumpWidget(const MaterialApp(home: MedicalResearchPage()));
+      await tester.pumpAndSettle();
+      await VideoRecorder.recordStep(tester, 'medical_research', '01_initial_evidence');
 
-        final successState = initialState.copyWith(
-          status: MedicalResearchStatus.success,
-          results: results,
-        );
-        when(() => mockCubit.state).thenReturn(successState);
-        stateController.add(successState);
-      });
+      expect(find.text('BUSCAR EN BASES DE DATOS MÉDICAS'), findsOneWidget);
 
       await tester.enterText(find.byType(TextField).first, 'Diabetes AI');
       await tester.tap(find.byIcon(Icons.send));
       await tester.pump(); // Start loading
 
+      // Verify loading state
       expect(find.byType(CircularProgressIndicator), findsOneWidget);
+
       await tester.pumpAndSettle();
 
       expect(find.text('Diabetes Study 2025'), findsOneWidget);
       expect(find.text('PUBMED'), findsOneWidget);
       expect(find.text('95% conf.'), findsOneWidget);
 
-      await VideoRecorder.recordStep(tester, 'research', '02_research_results');
+      await VideoRecorder.recordStep(tester, 'medical_research', '02_research_results');
     });
 
     testWidgets('E2E: Drug Interactions Check', (WidgetTester tester) async {
-      const initialState = MedicalResearchState(status: MedicalResearchStatus.idle);
-      when(() => mockCubit.state).thenReturn(initialState);
+      when(() => mockStandardsService.checkDrugInteractions(any()))
+          .thenAnswer((_) async => ['Aspirin and Warfarin may increase bleeding risk.']);
 
       await tester.pumpWidget(const MaterialApp(home: MedicalResearchPage()));
       await tester.pumpAndSettle();
@@ -101,29 +87,9 @@ void main() {
       // Navigate to Interactions tab
       await tester.tap(find.text('INTERACCIONES'));
       await tester.pumpAndSettle();
-      await VideoRecorder.recordStep(tester, 'research', '03_interactions_tab');
+      await VideoRecorder.recordStep(tester, 'medical_research', '03_interactions_tab');
 
       expect(find.text('VERIFICADOR DE INTERACCIONES'), findsOneWidget);
-
-      final interactions = ['Aspirin and Warfarin may increase bleeding risk.'];
-
-      when(() => mockCubit.checkInteractions(any())).thenAnswer((_) async {
-        final loadingState = initialState.copyWith(
-          status: MedicalResearchStatus.loading,
-          loadingMessage: 'Verificando interacciones...',
-        );
-        when(() => mockCubit.state).thenReturn(loadingState);
-        stateController.add(loadingState);
-
-        await Future.delayed(const Duration(milliseconds: 100));
-
-        final successState = initialState.copyWith(
-          status: MedicalResearchStatus.success,
-          interactions: interactions,
-        );
-        when(() => mockCubit.state).thenReturn(successState);
-        stateController.add(successState);
-      });
 
       // Enter first drug
       await tester.enterText(find.byType(TextField), 'Aspirin');
@@ -136,23 +102,10 @@ void main() {
       await tester.pumpAndSettle();
 
       expect(find.text('Aspirin and Warfarin may increase bleeding risk.'), findsOneWidget);
-      await VideoRecorder.recordStep(tester, 'research', '04_interactions_found');
+      await VideoRecorder.recordStep(tester, 'medical_research', '04_interactions_found');
     });
 
     testWidgets('E2E: ICD-10 Lookup', (WidgetTester tester) async {
-      const initialState = MedicalResearchState(status: MedicalResearchStatus.idle);
-      when(() => mockCubit.state).thenReturn(initialState);
-
-      await tester.pumpWidget(const MaterialApp(home: MedicalResearchPage()));
-      await tester.pumpAndSettle();
-
-      // Navigate to ICD-10 tab
-      await tester.tap(find.text('ICD-10'));
-      await tester.pumpAndSettle();
-      await VideoRecorder.recordStep(tester, 'research', '05_icd10_tab');
-
-      expect(find.text('BÚSQUEDA DE CÓDIGOS ICD-10'), findsOneWidget);
-
       final icdCode = Icd10Code(
         code: 'E11.9',
         displayName: 'Type 2 diabetes mellitus without complications',
@@ -160,23 +113,17 @@ void main() {
         synonyms: ['NIDDM', 'Type 2 diabetes'],
       );
 
-      when(() => mockCubit.lookupIcd10(any())).thenAnswer((_) async {
-        final loadingState = initialState.copyWith(
-          status: MedicalResearchStatus.loading,
-          loadingMessage: 'Buscando código ICD-10...',
-        );
-        when(() => mockCubit.state).thenReturn(loadingState);
-        stateController.add(loadingState);
+      when(() => mockStandardsService.lookupIcd10(any())).thenAnswer((_) async => icdCode);
 
-        await Future.delayed(const Duration(milliseconds: 100));
+      await tester.pumpWidget(const MaterialApp(home: MedicalResearchPage()));
+      await tester.pumpAndSettle();
 
-        final successState = initialState.copyWith(
-          status: MedicalResearchStatus.success,
-          icd10Result: icdCode,
-        );
-        when(() => mockCubit.state).thenReturn(successState);
-        stateController.add(successState);
-      });
+      // Navigate to ICD-10 tab
+      await tester.tap(find.text('ICD-10'));
+      await tester.pumpAndSettle();
+      await VideoRecorder.recordStep(tester, 'medical_research', '05_icd10_tab');
+
+      expect(find.text('BÚSQUEDA DE CÓDIGOS ICD-10'), findsOneWidget);
 
       await tester.enterText(find.byType(TextField), 'Diabetes');
       await tester.tap(find.byIcon(Icons.search));
@@ -186,7 +133,22 @@ void main() {
       expect(find.text('Type 2 diabetes mellitus without complications'), findsOneWidget);
       expect(find.textContaining('NIDDM, Type 2 diabetes'), findsOneWidget);
 
-      await VideoRecorder.recordStep(tester, 'research', '06_icd10_result');
+      await VideoRecorder.recordStep(tester, 'medical_research', '06_icd10_result');
+    });
+
+    testWidgets('E2E: Search Research Error', (WidgetTester tester) async {
+      when(() => mockRepository.search(any())).thenThrow(Exception('API Error'));
+      when(() => mockRepository.getHistory()).thenAnswer((_) async => []);
+
+      await tester.pumpWidget(const MaterialApp(home: MedicalResearchPage()));
+      await tester.pumpAndSettle();
+
+      await tester.enterText(find.byType(TextField).first, 'test error');
+      await tester.tap(find.byIcon(Icons.send));
+      await tester.pumpAndSettle();
+
+      expect(find.textContaining('Error en la investigación: Exception: API Error'), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'medical_research', '07_search_error');
     });
   });
 }


### PR DESCRIPTION
I have added a comprehensive E2E test suite for the `medical_research` feature. Following the project's standard pattern, these tests utilize the real `MedicalResearchCubit` while mocking the underlying `MedicalResearchRepository` and `MedicalStandardsService` via `GetIt` overrides.

Key flows covered:
1. **Search Evidence**: Verifies input field, loading indicator, and results display from PubMed.
2. **Drug Interactions**: Verifies tab switching, multi-drug entry, and interaction alert display.
3. **ICD-10 Lookup**: Verifies diagnosis search and code detail card display.
4. **Error Handling**: Verifies UI response when the repository throws an exception.

The tests include `VideoRecorder.recordStep` calls for each major state transition to support visual regression testing and documentation. All relevant unit tests passed after these additions.

Fixes #1252

---
*PR created automatically by Jules for task [11234273351861849989](https://jules.google.com/task/11234273351861849989) started by @iberi22*