### PR TITLE
Add True E2E tests for About feature

### DIFF
--- a/integration_test/about_e2e_test.dart
+++ b/integration_test/about_e2e_test.dart
@@ -1,45 +1,39 @@
+import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
+import 'package:orionhealth_health/core/di/injection.dart' as di;
 import 'package:orionhealth_health/features/about/presentation/pages/about_page.dart';
-import 'package:orionhealth_health/features/about/application/about_cubit.dart';
 import 'package:orionhealth_health/features/about/domain/entities/about_info.dart';
+import 'package:orionhealth_health/features/about/domain/repositories/i_about_repository.dart';
 import 'utils/video_recorder.dart';
 
-class MockAboutCubit extends Mock implements AboutCubit {}
+class MockAboutRepository extends Mock implements IAboutRepository {}
 
 void main() {
   IntegrationTestWidgetsFlutterBinding.ensureInitialized();
 
-  late MockAboutCubit mockCubit;
+  late MockAboutRepository mockRepository;
 
-  setUp(() async {
-    mockCubit = MockAboutCubit();
-    await GetIt.I.reset();
-    GetIt.I.registerFactory<AboutCubit>(() => mockCubit);
-
-    when(() => mockCubit.loadAboutInfo()).thenAnswer((_) async {});
-    when(() => mockCubit.close()).thenAnswer((_) async {});
+  setUpAll(() async {
+    await di.configureDependencies();
   });
 
-  tearDown(() async {
-    await GetIt.I.reset();
+  setUp(() {
+    mockRepository = MockAboutRepository();
+    di.getIt.allowReassignment = true;
+    di.getIt.registerSingleton<IAboutRepository>(mockRepository);
   });
 
-  group('About Flow - E2E Tests', () {
-    testWidgets('E2E: About Page Loading State', (WidgetTester tester) async {
-      when(() => mockCubit.state).thenReturn(const AboutLoading());
-      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+  tearDown(() {
+    di.getIt.unregister<IAboutRepository>();
+  });
 
-      await tester.pumpWidget(const MaterialApp(home: AboutPage()));
-      await VideoRecorder.recordStep(tester, 'about', '01_loading');
+  group('About Flow - True E2E Tests', () {
+    testWidgets('E2E: About Page Loading and Loaded State', (WidgetTester tester) async {
+      final completer = Completer<AboutInfo>();
 
-      expect(find.byType(CircularProgressIndicator), findsOneWidget);
-    });
-
-    testWidgets('E2E: About Page Loaded State', (WidgetTester tester) async {
       const aboutInfo = AboutInfo(
         missionStatement: 'Nuestra misión es empoderar a los pacientes a través de la tecnología.',
         values: ['Privacidad Primero', 'Seguridad'],
@@ -54,11 +48,18 @@ void main() {
         ],
       );
 
-      when(() => mockCubit.state).thenReturn(const AboutLoaded(aboutInfo));
-      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockRepository.getAboutInfo()).thenAnswer((_) => completer.future);
 
       await tester.pumpWidget(const MaterialApp(home: AboutPage()));
+
+      // Verify loading state
+      expect(find.byType(CircularProgressIndicator), findsOneWidget);
+      await VideoRecorder.recordStep(tester, 'about', '01_loading');
+
+      // Complete the future to move to loaded state
+      completer.complete(aboutInfo);
       await tester.pumpAndSettle();
+
       await VideoRecorder.recordStep(tester, 'about', '02_loaded');
 
       expect(find.text('Sobre OrionHealth'), findsOneWidget);
@@ -69,14 +70,13 @@ void main() {
 
     testWidgets('E2E: About Page Error State', (WidgetTester tester) async {
       const errorMessage = 'No se pudo cargar la información';
-      when(() => mockCubit.state).thenReturn(const AboutError(errorMessage));
-      when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+      when(() => mockRepository.getAboutInfo()).thenThrow(Exception(errorMessage));
 
       await tester.pumpWidget(const MaterialApp(home: AboutPage()));
       await tester.pumpAndSettle();
       await VideoRecorder.recordStep(tester, 'about', '03_error');
 
-      expect(find.text('Error: $errorMessage'), findsOneWidget);
+      expect(find.textContaining(errorMessage), findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
The 'about' feature lacked proper E2E tests. This change introduces `integration_test/about_e2e_test.dart` which implements the project's 'True E2E' pattern by using the real `AboutCubit` while mocking the `IAboutRepository`. The tests cover the transition from loading to loaded states using a `Completer` and verify error handling. Visual states are captured using `VideoRecorder.recordStep`.

Fixes #1251

---
*PR created automatically by Jules for task [15816323934093462551](https://jules.google.com/task/15816323934093462551) started by @iberi22*