### PR TITLE
Sprint 2/8: Unit Tests Domain (Batch 2)

### DIFF
--- a/test/features/about/domain/usecases/get_about_info_usecase_test.dart
+++ b/test/features/about/domain/usecases/get_about_info_usecase_test.dart
@@ -1,0 +1,51 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/about/domain/entities/about_info.dart';
+import 'package:orionhealth_health/features/about/domain/repositories/i_about_repository.dart';
+import 'package:orionhealth_health/features/about/domain/usecases/get_about_info_usecase.dart';
+
+class MockIAboutRepository extends Mock implements IAboutRepository {}
+
+void main() {
+  late MockIAboutRepository mockRepository;
+  late GetAboutInfoUseCase useCase;
+
+  setUp(() {
+    mockRepository = MockIAboutRepository();
+    useCase = GetAboutInfoUseCase(mockRepository);
+  });
+
+  const tAboutInfo = AboutInfo(
+    blogPosts: [],
+    missionStatement: 'Test Mission',
+    values: ['Test Value'],
+    activities: ['Test Activity'],
+  );
+
+  test('should get about info from the repository', () async {
+    // arrange
+    when(() => mockRepository.getAboutInfo())
+        .thenAnswer((_) async => tAboutInfo);
+
+    // act
+    final result = await useCase();
+
+    // assert
+    expect(result, tAboutInfo);
+    verify(() => mockRepository.getAboutInfo()).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+
+  test('should throw an exception when repository fails', () async {
+    // arrange
+    when(() => mockRepository.getAboutInfo())
+        .thenThrow(Exception('Repository Error'));
+
+    // act
+    final call = useCase();
+
+    // assert
+    expect(() => call, throwsA(isA<Exception>()));
+    verify(() => mockRepository.getAboutInfo()).called(1);
+  });
+}

--- a/test/features/allergies/domain/usecases/get_allergies_usecase_test.dart
+++ b/test/features/allergies/domain/usecases/get_allergies_usecase_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
+import 'package:orionhealth_health/features/allergies/domain/repositories/allergy_repository.dart';
+import 'package:orionhealth_health/features/allergies/domain/usecases/get_allergies_usecase.dart';
+
+class MockAllergyRepository extends Mock implements AllergyRepository {}
+
+void main() {
+  late MockAllergyRepository mockRepository;
+  late GetAllergiesUseCase useCase;
+
+  setUp(() {
+    mockRepository = MockAllergyRepository();
+    useCase = GetAllergiesUseCase(mockRepository);
+  });
+
+  final tAllergies = [
+    Allergy(id: 1, allergen: 'Peanuts', severity: AllergySeverity.severe),
+    Allergy(id: 2, allergen: 'Dust', severity: AllergySeverity.mild),
+  ];
+
+  test('should get allergies from the repository', () async {
+    // arrange
+    when(() => mockRepository.getAllergies())
+        .thenAnswer((_) async => tAllergies);
+
+    // act
+    final result = await useCase();
+
+    // assert
+    expect(result, tAllergies);
+    verify(() => mockRepository.getAllergies()).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/allergies/domain/usecases/save_allergy_usecase_test.dart
+++ b/test/features/allergies/domain/usecases/save_allergy_usecase_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
+import 'package:orionhealth_health/features/allergies/domain/repositories/allergy_repository.dart';
+import 'package:orionhealth_health/features/allergies/domain/usecases/save_allergy_usecase.dart';
+
+class MockAllergyRepository extends Mock implements AllergyRepository {}
+
+class FakeAllergy extends Fake implements Allergy {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeAllergy());
+  });
+
+  late MockAllergyRepository mockRepository;
+  late SaveAllergyUseCase useCase;
+
+  setUp(() {
+    mockRepository = MockAllergyRepository();
+    useCase = SaveAllergyUseCase(mockRepository);
+  });
+
+  final tAllergy = Allergy(
+    id: 1,
+    allergen: 'Peanuts',
+    severity: AllergySeverity.severe,
+  );
+
+  test('should save allergy in the repository', () async {
+    // arrange
+    when(() => mockRepository.saveAllergy(any()))
+        .thenAnswer((_) async => {});
+
+    // act
+    await useCase(tAllergy);
+
+    // assert
+    verify(() => mockRepository.saveAllergy(tAllergy)).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/calendar_import/domain/entities/calendar_appointment_test.dart
+++ b/test/features/calendar_import/domain/entities/calendar_appointment_test.dart
@@ -1,0 +1,54 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/calendar_import/domain/entities/calendar_appointment.dart';
+import 'package:orionhealth_health/features/calendar_import/domain/entities/calendar_event.dart';
+
+void main() {
+  group('CalendarAppointment', () {
+    final tDateTime = DateTime(2025, 1, 1, 10, 0);
+
+    test('should support value equality', () {
+      final a1 = CalendarAppointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardiology',
+        dateTime: tDateTime,
+        notes: 'Checkup',
+        source: CalendarEventSource.deviceCalendar,
+      );
+      final a2 = CalendarAppointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardiology',
+        dateTime: tDateTime,
+        notes: 'Checkup',
+        source: CalendarEventSource.deviceCalendar,
+      );
+
+      expect(a1, equals(a2));
+    });
+
+    test('should have different hashCodes for different values', () {
+      final a1 = CalendarAppointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardiology',
+        dateTime: tDateTime,
+      );
+      final a2 = CalendarAppointment(
+        doctorName: 'Dr. Jones',
+        specialty: 'Cardiology',
+        dateTime: tDateTime,
+      );
+
+      expect(a1.hashCode, isNot(equals(a2.hashCode)));
+    });
+
+    test('toString should return correct string representation', () {
+      final a1 = CalendarAppointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardiology',
+        dateTime: tDateTime,
+      );
+
+      expect(a1.toString(), contains('Dr. Smith'));
+      expect(a1.toString(), contains('Cardiology'));
+    });
+  });
+}

--- a/test/features/calendar_import/domain/entities/calendar_import_state_test.dart
+++ b/test/features/calendar_import/domain/entities/calendar_import_state_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/calendar_import/domain/entities/calendar_import_state.dart';
+import 'package:orionhealth_health/features/calendar_import/domain/entities/calendar_appointment.dart';
+
+void main() {
+  group('CalendarImportState', () {
+    test('CalendarImportLoaded should hold found appointments', () {
+      final appointments = [
+        CalendarAppointment(
+          doctorName: 'Dr. Smith',
+          specialty: 'Cardiology',
+          dateTime: DateTime.now(),
+        ),
+      ];
+      final state = CalendarImportLoaded(appointments);
+      expect(state.foundAppointments, appointments);
+    });
+
+    test('CalendarImportSuccess should hold imported count', () {
+      const state = CalendarImportSuccess(5);
+      expect(state.importedCount, 5);
+    });
+
+    test('CalendarImportError should hold error message', () {
+      const state = CalendarImportError('Error message');
+      expect(state.message, 'Error message');
+    });
+  });
+}

--- a/test/features/doctor_verification/domain/usecases/get_all_doctors_usecase_test.dart
+++ b/test/features/doctor_verification/domain/usecases/get_all_doctors_usecase_test.dart
@@ -1,0 +1,45 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/doctor_profile.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/repositories/doctor_profile_repository.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/usecases/get_all_doctors_usecase.dart';
+
+class MockDoctorProfileRepository extends Mock
+    implements DoctorProfileRepository {}
+
+void main() {
+  late MockDoctorProfileRepository mockRepository;
+  late GetAllDoctorsUseCase useCase;
+
+  setUp(() {
+    mockRepository = MockDoctorProfileRepository();
+    useCase = GetAllDoctorsUseCase(mockRepository);
+  });
+
+  final tDoctorProfiles = [
+    DoctorProfile(
+      id: '1',
+      fullName: 'Dr. Smith',
+      specialty: 'Cardiology',
+      licenseNumber: '12345',
+      verified: true,
+      countryCode: 'CO',
+      createdAt: DateTime(2025, 1, 1),
+      updatedAt: DateTime(2025, 1, 1),
+    ),
+  ];
+
+  test('should get all doctor profiles from the repository', () async {
+    // arrange
+    when(() => mockRepository.getAllDoctorProfiles())
+        .thenAnswer((_) async => tDoctorProfiles);
+
+    // act
+    final result = await useCase();
+
+    // assert
+    expect(result, tDoctorProfiles);
+    verify(() => mockRepository.getAllDoctorProfiles()).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/doctor_verification/domain/usecases/get_doctor_profile_usecase_test.dart
+++ b/test/features/doctor_verification/domain/usecases/get_doctor_profile_usecase_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/entities/doctor_profile.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/repositories/doctor_profile_repository.dart';
+import 'package:orionhealth_health/features/doctor_verification/domain/usecases/get_doctor_profile_usecase.dart';
+
+class MockDoctorProfileRepository extends Mock
+    implements DoctorProfileRepository {}
+
+void main() {
+  late MockDoctorProfileRepository mockRepository;
+  late GetDoctorProfileUseCase useCase;
+
+  setUp(() {
+    mockRepository = MockDoctorProfileRepository();
+    useCase = GetDoctorProfileUseCase(mockRepository);
+  });
+
+  const tId = '1';
+  final tDoctorProfile = DoctorProfile(
+    id: tId,
+    fullName: 'Dr. Smith',
+    specialty: 'Cardiology',
+    licenseNumber: '12345',
+    verified: true,
+    countryCode: 'CO',
+    createdAt: DateTime(2025, 1, 1),
+    updatedAt: DateTime(2025, 1, 1),
+  );
+
+  test('should get doctor profile by id from the repository', () async {
+    // arrange
+    when(() => mockRepository.getDoctorProfile(any()))
+        .thenAnswer((_) async => tDoctorProfile);
+
+    // act
+    final result = await useCase(tId);
+
+    // assert
+    expect(result, tDoctorProfile);
+    verify(() => mockRepository.getDoctorProfile(tId)).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/email-citas/domain/usecases/email_citas_usecases_test.dart
+++ b/test/features/email-citas/domain/usecases/email_citas_usecases_test.dart
@@ -1,0 +1,66 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+import 'package:orionhealth_health/features/email-citas/domain/repositories/email_repository.dart';
+import 'package:orionhealth_health/features/email-citas/domain/usecases/email_citas_usecases.dart';
+
+class MockEmailRepository extends Mock implements EmailRepository {}
+
+void main() {
+  late MockEmailRepository mockRepository;
+  late ConnectEmailProviderUseCase connectUseCase;
+  late SyncEmailAppointmentsUseCase syncUseCase;
+
+  setUp(() {
+    mockRepository = MockEmailRepository();
+    connectUseCase = ConnectEmailProviderUseCase(mockRepository);
+    syncUseCase = SyncEmailAppointmentsUseCase(mockRepository);
+  });
+
+  group('ConnectEmailProviderUseCase', () {
+    test('should connect Gmail when provider is Gmail', () async {
+      when(() => mockRepository.connectGmail()).thenAnswer((_) async => true);
+
+      final result = await connectUseCase('Gmail');
+
+      expect(result, true);
+      verify(() => mockRepository.connectGmail()).called(1);
+    });
+
+    test('should connect Outlook when provider is Outlook', () async {
+      when(() => mockRepository.connectOutlook()).thenAnswer((_) async => true);
+
+      final result = await connectUseCase('Outlook');
+
+      expect(result, true);
+      verify(() => mockRepository.connectOutlook()).called(1);
+    });
+
+    test('should return false for unknown provider', () async {
+      final result = await connectUseCase('Yahoo');
+
+      expect(result, false);
+    });
+  });
+
+  group('SyncEmailAppointmentsUseCase', () {
+    test('should fetch parsed appointments from repository', () async {
+      final tAppointments = [
+        Appointment(
+          doctorName: 'Dr. House',
+          specialty: 'Diagnostic',
+          dateTime: DateTime.now(),
+          status: AppointmentStatus.upcoming,
+        ),
+      ];
+      when(() => mockRepository.fetchParsedAppointments(any(), any()))
+          .thenAnswer((_) async => tAppointments);
+
+      final result = await syncUseCase('Gmail', 'auth_code');
+
+      expect(result, tAppointments);
+      verify(() => mockRepository.fetchParsedAppointments('Gmail', 'auth_code'))
+          .called(1);
+    });
+  });
+}

--- a/test/features/health_record/domain/usecases/get_all_records_usecase_test.dart
+++ b/test/features/health_record/domain/usecases/get_all_records_usecase_test.dart
@@ -1,0 +1,39 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+import 'package:orionhealth_health/features/health_record/domain/repositories/health_record_repository.dart';
+import 'package:orionhealth_health/features/health_record/domain/usecases/get_all_records_usecase.dart';
+
+class MockHealthRecordRepository extends Mock implements HealthRecordRepository {}
+
+void main() {
+  late MockHealthRecordRepository mockRepository;
+  late GetAllRecordsUseCase useCase;
+
+  setUp(() {
+    mockRepository = MockHealthRecordRepository();
+    useCase = GetAllRecordsUseCase(mockRepository);
+  });
+
+  final tRecords = [
+    MedicalRecord(
+      date: DateTime(2025, 1, 1),
+      type: RecordType.labResult,
+      summary: 'Normal',
+    )..id = 1,
+  ];
+
+  test('should get all records from the repository', () async {
+    // arrange
+    when(() => mockRepository.getAllRecords())
+        .thenAnswer((_) async => tRecords);
+
+    // act
+    final result = await useCase();
+
+    // assert
+    expect(result, tRecords);
+    verify(() => mockRepository.getAllRecords()).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}

--- a/test/features/health_record/domain/usecases/save_record_usecase_test.dart
+++ b/test/features/health_record/domain/usecases/save_record_usecase_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
+import 'package:orionhealth_health/features/health_record/domain/repositories/health_record_repository.dart';
+import 'package:orionhealth_health/features/health_record/domain/usecases/save_record_usecase.dart';
+
+class MockHealthRecordRepository extends Mock implements HealthRecordRepository {}
+
+class FakeMedicalRecord extends Fake implements MedicalRecord {}
+
+void main() {
+  setUpAll(() {
+    registerFallbackValue(FakeMedicalRecord());
+  });
+
+  late MockHealthRecordRepository mockRepository;
+  late SaveRecordUseCase useCase;
+
+  setUp(() {
+    mockRepository = MockHealthRecordRepository();
+    useCase = SaveRecordUseCase(mockRepository);
+  });
+
+  final tRecord = MedicalRecord(
+    date: DateTime(2025, 1, 1),
+    type: RecordType.labResult,
+    summary: 'Normal',
+  )..id = 1;
+
+  test('should save record in the repository', () async {
+    // arrange
+    when(() => mockRepository.saveRecord(any()))
+        .thenAnswer((_) async => {});
+
+    // act
+    await useCase(tRecord);
+
+    // assert
+    verify(() => mockRepository.saveRecord(tRecord)).called(1);
+    verifyNoMoreInteractions(mockRepository);
+  });
+}


### PR DESCRIPTION
Implemented domain unit tests for the following features:
- about: GetAboutInfoUseCase
- allergies: GetAllergiesUseCase, SaveAllergyUseCase
- calendar_import: CalendarAppointment, CalendarImportState entities
- doctor_verification: GetAllDoctorsUseCase, GetDoctorProfileUseCase
- email-citas: ConnectEmailProviderUseCase, SyncEmailAppointmentsUseCase
- health_record: GetAllRecordsUseCase, SaveRecordUseCase

All tests verify logic and interactions with repositories using mocks. Out-of-scope changes to DI and lockfiles were reverted following code review.

Fixes #1346

---
*PR created automatically by Jules for task [12996427669418039873](https://jules.google.com/task/12996427669418039873) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added coverage for multiple app flows, including about info, allergies, doctors, email sync, health records, and calendar import.
  * Expanded validation for key use cases to confirm expected results, error handling, and repository interactions.
  * Added entity/state checks to improve confidence in data handling and output formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->