### PR TITLE
Sprint 1/8: Unit Tests Domain (Batch 1)

### DIFF
--- a/test/features/appointments/domain/repositories/appointment_repository_test.dart
+++ b/test/features/appointments/domain/repositories/appointment_repository_test.dart
@@ -1,0 +1,44 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+import 'package:orionhealth_health/features/appointments/domain/repositories/appointment_repository.dart';
+
+class MockAppointmentRepository extends Mock implements AppointmentRepository {}
+class FakeAppointment extends Fake implements Appointment {}
+
+void main() {
+  late MockAppointmentRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeAppointment());
+  });
+
+  setUp(() {
+    mockRepository = MockAppointmentRepository();
+  });
+
+  group('AppointmentRepository Interface', () {
+    test('can be mocked and called', () async {
+      final tAppointment = Appointment(
+        doctorName: 'Dr. Smith',
+        specialty: 'Cardiology',
+        dateTime: DateTime.now(),
+        status: AppointmentStatus.upcoming,
+      );
+
+      when(() => mockRepository.getAppointments()).thenAnswer((_) async => [tAppointment]);
+      when(() => mockRepository.saveAppointment(any())).thenAnswer((_) async {});
+      when(() => mockRepository.deleteAppointment(any())).thenAnswer((_) async {});
+
+      final appointments = await mockRepository.getAppointments();
+      await mockRepository.saveAppointment(tAppointment);
+      await mockRepository.deleteAppointment(1);
+
+      expect(appointments, [tAppointment]);
+
+      verify(() => mockRepository.getAppointments()).called(1);
+      verify(() => mockRepository.saveAppointment(tAppointment)).called(1);
+      verify(() => mockRepository.deleteAppointment(1)).called(1);
+    });
+  });
+}

--- a/test/features/auth/domain/entities/auth_session_test.dart
+++ b/test/features/auth/domain/entities/auth_session_test.dart
@@ -1,0 +1,47 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_session.dart';
+
+void main() {
+  group('AuthSession', () {
+    test('should create AuthSession with correct values', () {
+      final expiresAt = DateTime.now().add(const Duration(hours: 1));
+      final session = AuthSession(
+        token: 'token123',
+        expiresAt: expiresAt,
+      );
+
+      expect(session.token, 'token123');
+      expect(session.expiresAt, expiresAt);
+    });
+
+    test('isExpired should return true when session is expired', () {
+      final expiresAt = DateTime.now().subtract(const Duration(minutes: 1));
+      final session = AuthSession(
+        token: 'token123',
+        expiresAt: expiresAt,
+      );
+
+      expect(session.isExpired, isTrue);
+    });
+
+    test('isExpired should return false when session is not expired', () {
+      final expiresAt = DateTime.now().add(const Duration(minutes: 1));
+      final session = AuthSession(
+        token: 'token123',
+        expiresAt: expiresAt,
+      );
+
+      expect(session.isExpired, isFalse);
+    });
+
+    test('toString should return correct string representation', () {
+      final expiresAt = DateTime.now();
+      final session = AuthSession(
+        token: 'token123',
+        expiresAt: expiresAt,
+      );
+
+      expect(session.toString(), 'AuthSession(token: token123, expiresAt: $expiresAt)');
+    });
+  });
+}

--- a/test/features/auth/domain/entities/auth_user_test.dart
+++ b/test/features/auth/domain/entities/auth_user_test.dart
@@ -1,0 +1,28 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_user.dart';
+
+void main() {
+  group('AuthUser', () {
+    test('should create AuthUser with correct values', () {
+      const user = AuthUser(
+        id: '123',
+        email: 'test@example.com',
+        role: 'user',
+      );
+
+      expect(user.id, '123');
+      expect(user.email, 'test@example.com');
+      expect(user.role, 'user');
+    });
+
+    test('toString should return correct string representation', () {
+      const user = AuthUser(
+        id: '123',
+        email: 'test@example.com',
+        role: 'user',
+      );
+
+      expect(user.toString(), 'AuthUser(id: 123, email: test@example.com, role: user)');
+    });
+  });
+}

--- a/test/features/auth/domain/usecases/get_credentials_usecase_test.dart
+++ b/test/features/auth/domain/usecases/get_credentials_usecase_test.dart
@@ -1,0 +1,29 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_credentials.dart';
+import 'package:orionhealth_health/features/auth/domain/repositories/auth_repository.dart';
+import 'package:orionhealth_health/features/auth/domain/usecases/get_credentials_usecase.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late GetCredentialsUseCase useCase;
+  late MockAuthRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockAuthRepository();
+    useCase = GetCredentialsUseCase(mockRepository);
+  });
+
+  group('GetCredentialsUseCase', () {
+    test('should return credentials from repository', () async {
+      final tCredentials = AuthCredentials();
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+
+      final result = await useCase();
+
+      expect(result, tCredentials);
+      verify(() => mockRepository.getCredentials()).called(1);
+    });
+  });
+}

--- a/test/features/auth/domain/usecases/login_usecase_test.dart
+++ b/test/features/auth/domain/usecases/login_usecase_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_credential.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_credentials.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_session.dart';
+import 'package:orionhealth_health/features/auth/domain/repositories/auth_repository.dart';
+import 'package:orionhealth_health/features/auth/domain/usecases/login_usecase.dart';
+import 'package:orionhealth_health/features/auth/infrastructure/services/biometric_service.dart';
+import 'package:orionhealth_health/features/auth/infrastructure/services/encryption_service.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+class MockEncryptionService extends Mock implements EncryptionService {}
+class MockBiometricService extends Mock implements BiometricService {}
+class FakeAuthCredentials extends Fake implements AuthCredentials {}
+class FakeAuthSession extends Fake implements AuthSession {}
+
+void main() {
+  late LoginUseCase useCase;
+  late MockAuthRepository mockRepository;
+  late MockEncryptionService mockEncryptionService;
+  late MockBiometricService mockBiometricService;
+
+  setUpAll(() {
+    registerFallbackValue(FakeAuthCredentials());
+    registerFallbackValue(FakeAuthSession());
+  });
+
+  setUp(() {
+    mockRepository = MockAuthRepository();
+    mockEncryptionService = MockEncryptionService();
+    mockBiometricService = MockBiometricService();
+    useCase = LoginUseCase(
+      mockRepository,
+      mockEncryptionService,
+      mockBiometricService,
+    );
+
+    when(() => mockRepository.saveCredentials(any())).thenAnswer((_) async {});
+    when(() => mockRepository.saveSession(any())).thenAnswer((_) async {});
+  });
+
+  group('LoginUseCase', () {
+    const tPin = '1234';
+    const tSalt = 'salt';
+    const tHashedPin = 'hashedPin';
+
+    test('should return session when PIN is correct', () async {
+      final tCredentials = AuthCredentials()
+        ..hashedPin = tHashedPin
+        ..salt = tSalt
+        ..failedAttempts = 0;
+
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+      when(() => mockEncryptionService.hashPin(tPin, tSalt)).thenAnswer((_) async => tHashedPin);
+      when(() => mockRepository.saveCredentials(any())).thenAnswer((_) async {});
+      when(() => mockRepository.saveSession(any())).thenAnswer((_) async {});
+
+      final result = await useCase(const PinCredential(tPin));
+
+      expect(result, isA<AuthSession>());
+      verify(() => mockRepository.saveCredentials(any())).called(1);
+      verify(() => mockRepository.saveSession(any())).called(1);
+    });
+
+    test('should return null and increment failed attempts when PIN is incorrect', () async {
+      final tCredentials = AuthCredentials()
+        ..hashedPin = tHashedPin
+        ..salt = tSalt
+        ..failedAttempts = 0;
+
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+      when(() => mockEncryptionService.hashPin(tPin, tSalt)).thenAnswer((_) async => 'wrongHash');
+      when(() => mockRepository.saveCredentials(any())).thenAnswer((_) async {});
+
+      final result = await useCase(const PinCredential(tPin));
+
+      expect(result, isNull);
+      expect(tCredentials.failedAttempts, 1);
+      verify(() => mockRepository.saveCredentials(tCredentials)).called(1);
+    });
+
+    test('should lockout when failed attempts reach limit', () async {
+       final tCredentials = AuthCredentials()
+        ..hashedPin = tHashedPin
+        ..salt = tSalt
+        ..failedAttempts = 4;
+
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+      when(() => mockEncryptionService.hashPin(tPin, tSalt)).thenAnswer((_) async => 'wrongHash');
+      when(() => mockRepository.saveCredentials(any())).thenAnswer((_) async {});
+
+      final result = await useCase(const PinCredential(tPin));
+
+      expect(result, isNull);
+      expect(tCredentials.failedAttempts, 5);
+      expect(tCredentials.lastLockoutTime, isNotNull);
+    });
+
+    test('should return null when account is locked', () async {
+       final tCredentials = AuthCredentials()
+        ..hashedPin = tHashedPin
+        ..salt = tSalt
+        ..failedAttempts = 5
+        ..lastLockoutTime = DateTime.now();
+
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+      when(() => mockEncryptionService.hashPin(any(), any())).thenAnswer((_) async => tHashedPin);
+
+      final result = await useCase(const PinCredential(tPin));
+
+      expect(result, isNull);
+      verifyNever(() => mockEncryptionService.hashPin(any(), any()));
+    });
+
+    test('should return session when biometrics authentication is successful', () async {
+      final tCredentials = AuthCredentials()
+        ..biometricEnabled = true;
+
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+      when(() => mockBiometricService.authenticate(localizedReason: any(named: 'localizedReason')))
+          .thenAnswer((_) async => true);
+      when(() => mockRepository.saveSession(any())).thenAnswer((_) async {});
+
+      final result = await useCase(const BiometricCredential());
+
+      expect(result, isA<AuthSession>());
+      verify(() => mockRepository.saveSession(any())).called(1);
+    });
+
+    test('should return null when biometrics authentication fails', () async {
+      final tCredentials = AuthCredentials()
+        ..biometricEnabled = true;
+
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+      when(() => mockBiometricService.authenticate(localizedReason: any(named: 'localizedReason')))
+          .thenAnswer((_) async => false);
+
+      final result = await useCase(const BiometricCredential());
+
+      expect(result, isNull);
+    });
+
+    test('should return null when biometrics is not enabled', () async {
+      final tCredentials = AuthCredentials()
+        ..biometricEnabled = false;
+
+      when(() => mockRepository.getCredentials()).thenAnswer((_) async => tCredentials);
+
+      final result = await useCase(const BiometricCredential());
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/features/auth/domain/usecases/logout_usecase_test.dart
+++ b/test/features/auth/domain/usecases/logout_usecase_test.dart
@@ -1,0 +1,26 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/domain/repositories/auth_repository.dart';
+import 'package:orionhealth_health/features/auth/domain/usecases/logout_usecase.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late LogoutUseCase useCase;
+  late MockAuthRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockAuthRepository();
+    useCase = LogoutUseCase(mockRepository);
+  });
+
+  group('LogoutUseCase', () {
+    test('should call deleteSession on the repository', () async {
+      when(() => mockRepository.deleteSession()).thenAnswer((_) async {});
+
+      await useCase();
+
+      verify(() => mockRepository.deleteSession()).called(1);
+    });
+  });
+}

--- a/test/features/auth/domain/usecases/save_credentials_usecase_test.dart
+++ b/test/features/auth/domain/usecases/save_credentials_usecase_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_credentials.dart';
+import 'package:orionhealth_health/features/auth/domain/repositories/auth_repository.dart';
+import 'package:orionhealth_health/features/auth/domain/usecases/save_credentials_usecase.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+class FakeAuthCredentials extends Fake implements AuthCredentials {}
+
+void main() {
+  late SaveCredentialsUseCase useCase;
+  late MockAuthRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeAuthCredentials());
+  });
+
+  setUp(() {
+    mockRepository = MockAuthRepository();
+    useCase = SaveCredentialsUseCase(mockRepository);
+  });
+
+  group('SaveCredentialsUseCase', () {
+    test('should save credentials in repository', () async {
+      final tCredentials = AuthCredentials();
+      when(() => mockRepository.saveCredentials(any())).thenAnswer((_) async {});
+
+      await useCase(tCredentials);
+
+      verify(() => mockRepository.saveCredentials(tCredentials)).called(1);
+    });
+  });
+}

--- a/test/features/auth/domain/usecases/set_pin_usecase_test.dart
+++ b/test/features/auth/domain/usecases/set_pin_usecase_test.dart
@@ -1,0 +1,56 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_credentials.dart';
+import 'package:orionhealth_health/features/auth/domain/repositories/auth_repository.dart';
+import 'package:orionhealth_health/features/auth/domain/usecases/set_pin_usecase.dart';
+import 'package:orionhealth_health/features/auth/infrastructure/services/encryption_service.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+class MockEncryptionService extends Mock implements EncryptionService {}
+class FakeAuthCredentials extends Fake implements AuthCredentials {}
+
+void main() {
+  late SetPinUseCase useCase;
+  late MockAuthRepository mockRepository;
+  late MockEncryptionService mockEncryptionService;
+
+  setUpAll(() {
+    registerFallbackValue(FakeAuthCredentials());
+  });
+
+  setUp(() {
+    mockRepository = MockAuthRepository();
+    mockEncryptionService = MockEncryptionService();
+    useCase = SetPinUseCase(mockRepository, mockEncryptionService);
+  });
+
+  group('SetPinUseCase', () {
+    const tPin = '1234';
+    const tHashedPin = 'hashedPin';
+
+    test('should save credentials when PIN is valid', () async {
+      when(() => mockEncryptionService.hashPin(any(), any())).thenAnswer((_) async => tHashedPin);
+      when(() => mockRepository.saveCredentials(any())).thenAnswer((_) async {});
+
+      final result = await useCase(tPin);
+
+      expect(result, isTrue);
+      verify(() => mockEncryptionService.hashPin(tPin, any())).called(1);
+      verify(() => mockRepository.saveCredentials(any(that: isA<AuthCredentials>()))).called(1);
+    });
+
+    test('should return false when PIN is too short', () async {
+      final result = await useCase('123');
+
+      expect(result, isFalse);
+      verifyNever(() => mockRepository.saveCredentials(any()));
+    });
+
+    test('should return false when PIN is too long', () async {
+      final result = await useCase('1234567');
+
+      expect(result, isFalse);
+      verifyNever(() => mockRepository.saveCredentials(any()));
+    });
+  });
+}

--- a/test/features/auth/domain/usecases/validate_session_usecase_test.dart
+++ b/test/features/auth/domain/usecases/validate_session_usecase_test.dart
@@ -1,0 +1,55 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/domain/entities/auth_session.dart';
+import 'package:orionhealth_health/features/auth/domain/repositories/auth_repository.dart';
+import 'package:orionhealth_health/features/auth/domain/usecases/validate_session_usecase.dart';
+
+class MockAuthRepository extends Mock implements AuthRepository {}
+
+void main() {
+  late ValidateSessionUseCase useCase;
+  late MockAuthRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockAuthRepository();
+    useCase = ValidateSessionUseCase(mockRepository);
+  });
+
+  group('ValidateSessionUseCase', () {
+    test('should return session when it exists and is not expired', () async {
+      final tSession = AuthSession(
+        token: 'token',
+        expiresAt: DateTime.now().add(const Duration(minutes: 5)),
+      );
+
+      when(() => mockRepository.getSession()).thenAnswer((_) async => tSession);
+
+      final result = await useCase();
+
+      expect(result, tSession);
+    });
+
+    test('should return null and delete session when it is expired', () async {
+      final tSession = AuthSession(
+        token: 'token',
+        expiresAt: DateTime.now().subtract(const Duration(minutes: 5)),
+      );
+
+      when(() => mockRepository.getSession()).thenAnswer((_) async => tSession);
+      when(() => mockRepository.deleteSession()).thenAnswer((_) async {});
+
+      final result = await useCase();
+
+      expect(result, isNull);
+      verify(() => mockRepository.deleteSession()).called(1);
+    });
+
+    test('should return null when session does not exist', () async {
+      when(() => mockRepository.getSession()).thenAnswer((_) async => null);
+
+      final result = await useCase();
+
+      expect(result, isNull);
+    });
+  });
+}

--- a/test/features/health_data_import/domain/repositories/health_data_import_repository_test.dart
+++ b/test/features/health_data_import/domain/repositories/health_data_import_repository_test.dart
@@ -1,0 +1,42 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health/health.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/repositories/health_data_import_repository.dart';
+
+class MockHealthDataImportRepository extends Mock implements HealthDataImportRepository {}
+
+void main() {
+  late MockHealthDataImportRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(HealthDataType.STEPS);
+  });
+
+  setUp(() {
+    mockRepository = MockHealthDataImportRepository();
+  });
+
+  group('HealthDataImportRepository Interface', () {
+    test('can be mocked and called', () async {
+      when(() => mockRepository.hasPermissions(any())).thenAnswer((_) async => true);
+      when(() => mockRepository.requestAuthorization(any())).thenAnswer((_) async => true);
+      when(() => mockRepository.fetchHealthData(any(), any(), any())).thenAnswer((_) async => []);
+      when(() => mockRepository.pickAndExtractFromFile()).thenAnswer((_) async => 'extracted text');
+
+      final hasPerm = await mockRepository.hasPermissions([HealthDataType.STEPS]);
+      final reqAuth = await mockRepository.requestAuthorization([HealthDataType.STEPS]);
+      final data = await mockRepository.fetchHealthData(HealthDataType.STEPS, DateTime.now(), DateTime.now());
+      final text = await mockRepository.pickAndExtractFromFile();
+
+      expect(hasPerm, isTrue);
+      expect(reqAuth, isTrue);
+      expect(data, isEmpty);
+      expect(text, 'extracted text');
+
+      verify(() => mockRepository.hasPermissions(any())).called(1);
+      verify(() => mockRepository.requestAuthorization(any())).called(1);
+      verify(() => mockRepository.fetchHealthData(any(), any(), any())).called(1);
+      verify(() => mockRepository.pickAndExtractFromFile()).called(1);
+    });
+  });
+}

--- a/test/features/local_agent/domain/repositories/medical_knowledge_repository_test.dart
+++ b/test/features/local_agent/domain/repositories/medical_knowledge_repository_test.dart
@@ -101,6 +101,11 @@ class TestMedicalKnowledgeRepository implements MedicalKnowledgeRepository {
     return [];
   }
 
+  @override
+  Future<String> getRelevantContext(String query) async {
+    return 'context';
+  }
+
   void addCode(MedicalCode code) => _codes.add(code);
 
   void _ensureInitialized() {

--- a/test/features/local_agent/domain/services/llm_adapter_test.dart
+++ b/test/features/local_agent/domain/services/llm_adapter_test.dart
@@ -1,4 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/local_agent/domain/chat_message.dart';
+import 'package:orionhealth_health/features/local_agent/domain/entities/local_model_descriptor.dart';
 import 'package:orionhealth_health/features/local_agent/domain/services/llm_adapter.dart';
 
 /// Minimal concrete implementation for testing the abstract interface
@@ -38,6 +40,19 @@ class TestLlmAdapter implements LlmAdapter {
   @override
   Future<bool> isModelInstalled(String modelId) async =>
       modelId == 'test-model';
+
+  @override
+  Future<ChatMessage> generateResponse(
+    String userMessage,
+    String context,
+    LocalModelDescriptor model,
+  ) async {
+    return ChatMessage(
+      role: ChatRole.assistant,
+      content: 'Response',
+      timestamp: DateTime.now(),
+    );
+  }
 }
 
 void main() {

--- a/test/features/local_agent/domain/services/vector_store_service_test.dart
+++ b/test/features/local_agent/domain/services/vector_store_service_test.dart
@@ -1,4 +1,5 @@
 import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/local_agent/domain/chat_message.dart';
 import 'package:orionhealth_health/features/local_agent/domain/services/vector_store_service.dart';
 
 /// Minimal concrete implementation for testing the abstract interface

--- a/test/features/local_agent/domain/usecases/get_chat_history_usecase_test.dart
+++ b/test/features/local_agent/domain/usecases/get_chat_history_usecase_test.dart
@@ -1,0 +1,33 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/local_agent/domain/chat_message.dart';
+import 'package:orionhealth_health/features/local_agent/domain/services/vector_store_service.dart';
+import 'package:orionhealth_health/features/local_agent/domain/usecases/get_chat_history_usecase.dart';
+
+class MockVectorStoreService extends Mock implements VectorStoreService {}
+
+void main() {
+  late GetChatHistoryUseCase useCase;
+  late MockVectorStoreService mockStoreService;
+
+  setUp(() {
+    mockStoreService = MockVectorStoreService();
+    useCase = GetChatHistoryUseCase(mockStoreService);
+  });
+
+  group('GetChatHistoryUseCase', () {
+    test('should return history from VectorStoreService', () async {
+      final tHistory = [
+        ChatMessage(role: ChatRole.user, content: 'Hello', timestamp: DateTime.now()),
+        ChatMessage(role: ChatRole.assistant, content: 'Hi', timestamp: DateTime.now()),
+      ];
+
+      when(() => mockStoreService.getRecentMessages()).thenAnswer((_) async => tHistory);
+
+      final result = await useCase();
+
+      expect(result, tHistory);
+      verify(() => mockStoreService.getRecentMessages()).called(1);
+    });
+  });
+}

--- a/test/features/local_agent/domain/usecases/send_chat_message_usecase_test.dart
+++ b/test/features/local_agent/domain/usecases/send_chat_message_usecase_test.dart
@@ -1,0 +1,52 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/local_agent/domain/chat_message.dart';
+import 'package:orionhealth_health/features/local_agent/domain/entities/local_model_descriptor.dart';
+import 'package:orionhealth_health/features/local_agent/domain/repositories/medical_knowledge_repository.dart';
+import 'package:orionhealth_health/features/local_agent/domain/services/llm_adapter.dart';
+import 'package:orionhealth_health/features/local_agent/domain/usecases/send_chat_message_usecase.dart';
+
+class MockLlmAdapter extends Mock implements LlmAdapter {}
+class MockMedicalKnowledgeRepository extends Mock implements MedicalKnowledgeRepository {}
+class FakeLocalModelDescriptor extends Fake implements LocalModelDescriptor {}
+
+void main() {
+  late SendChatMessageUseCase useCase;
+  late MockLlmAdapter mockLlmAdapter;
+  late MockMedicalKnowledgeRepository mockKnowledgeRepository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeLocalModelDescriptor());
+  });
+
+  setUp(() {
+    mockLlmAdapter = MockLlmAdapter();
+    mockKnowledgeRepository = MockMedicalKnowledgeRepository();
+    useCase = SendChatMessageUseCase(mockLlmAdapter, mockKnowledgeRepository);
+  });
+
+  group('SendChatMessageUseCase', () {
+    const tMessage = 'What is ICD-10?';
+    const tContext = 'ICD-10 is...';
+    final tModel = LocalModelDescriptor(
+      id: 'id',
+      displayName: 'name',
+      modelType: ModelType.gemmaIt,
+      sizeLabel: '100MB',
+      minRamMb: 1024,
+      url: 'url',
+    );
+    final tResponse = ChatMessage(role: ChatRole.assistant, content: 'Response', timestamp: DateTime.now());
+
+    test('should get context and generate response', () async {
+      when(() => mockKnowledgeRepository.getRelevantContext(tMessage)).thenAnswer((_) async => tContext);
+      when(() => mockLlmAdapter.generateResponse(tMessage, tContext, any())).thenAnswer((_) async => tResponse);
+
+      final result = await useCase(tMessage, tModel);
+
+      expect(result, tResponse);
+      verify(() => mockKnowledgeRepository.getRelevantContext(tMessage)).called(1);
+      verify(() => mockLlmAdapter.generateResponse(tMessage, tContext, tModel)).called(1);
+    });
+  });
+}

--- a/test/features/network/domain/entities/network_message_test.dart
+++ b/test/features/network/domain/entities/network_message_test.dart
@@ -1,0 +1,25 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/network/domain/entities/network_message.dart';
+
+void main() {
+  group('NetworkMessage', () {
+    test('should create NetworkMessage with correct values', () {
+      final timestamp = DateTime.now();
+      final message = NetworkMessage(
+        senderId: 'sender123',
+        receiverId: 'receiver456',
+        content: 'Hello',
+        timestamp: timestamp,
+        type: MessageType.text,
+        signature: 'sig',
+      );
+
+      expect(message.senderId, 'sender123');
+      expect(message.receiverId, 'receiver456');
+      expect(message.content, 'Hello');
+      expect(message.timestamp, timestamp);
+      expect(message.type, MessageType.text);
+      expect(message.signature, 'sig');
+    });
+  });
+}

--- a/test/features/network/domain/entities/network_peer_test.dart
+++ b/test/features/network/domain/entities/network_peer_test.dart
@@ -1,0 +1,27 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/network/domain/entities/network_peer.dart';
+
+void main() {
+  group('NetworkPeer', () {
+    test('should create NetworkPeer with correct values', () {
+      final lastSeen = DateTime.now();
+      final peer = NetworkPeer(
+        peerId: 'peer123',
+        name: 'Node A',
+        address: '192.168.1.1',
+        port: 8080,
+        status: PeerStatus.online,
+        lastSeen: lastSeen,
+        publicKey: 'pubkey',
+      );
+
+      expect(peer.peerId, 'peer123');
+      expect(peer.name, 'Node A');
+      expect(peer.address, '192.168.1.1');
+      expect(peer.port, 8080);
+      expect(peer.status, PeerStatus.online);
+      expect(peer.lastSeen, lastSeen);
+      expect(peer.publicKey, 'pubkey');
+    });
+  });
+}

--- a/test/features/network/domain/repositories/network_peer_repository_test.dart
+++ b/test/features/network/domain/repositories/network_peer_repository_test.dart
@@ -1,0 +1,67 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/network/domain/entities/network_message.dart';
+import 'package:orionhealth_health/features/network/domain/entities/network_peer.dart';
+import 'package:orionhealth_health/features/network/domain/repositories/network_peer_repository.dart';
+
+class MockNetworkPeerRepository extends Mock implements NetworkPeerRepository {}
+class FakeNetworkPeer extends Fake implements NetworkPeer {}
+class FakeNetworkMessage extends Fake implements NetworkMessage {}
+
+void main() {
+  late MockNetworkPeerRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeNetworkPeer());
+    registerFallbackValue(FakeNetworkMessage());
+  });
+
+  setUp(() {
+    mockRepository = MockNetworkPeerRepository();
+  });
+
+  group('NetworkPeerRepository Interface', () {
+    test('can be mocked and called', () async {
+      final tPeer = NetworkPeer(
+        peerId: 'id',
+        name: 'name',
+        address: 'addr',
+        port: 1,
+        status: PeerStatus.online,
+        lastSeen: DateTime.now(),
+      );
+      final tMessage = NetworkMessage(
+        senderId: 's',
+        receiverId: 'r',
+        content: 'c',
+        timestamp: DateTime.now(),
+        type: MessageType.text,
+      );
+
+      when(() => mockRepository.getPeers()).thenAnswer((_) async => [tPeer]);
+      when(() => mockRepository.getPeerById(any())).thenAnswer((_) async => tPeer);
+      when(() => mockRepository.savePeer(any())).thenAnswer((_) async {});
+      when(() => mockRepository.deletePeer(any())).thenAnswer((_) async {});
+      when(() => mockRepository.getMessagesForPeer(any())).thenAnswer((_) async => [tMessage]);
+      when(() => mockRepository.saveMessage(any())).thenAnswer((_) async {});
+
+      final peers = await mockRepository.getPeers();
+      final peer = await mockRepository.getPeerById('id');
+      await mockRepository.savePeer(tPeer);
+      await mockRepository.deletePeer('id');
+      final messages = await mockRepository.getMessagesForPeer('id');
+      await mockRepository.saveMessage(tMessage);
+
+      expect(peers, [tPeer]);
+      expect(peer, tPeer);
+      expect(messages, [tMessage]);
+
+      verify(() => mockRepository.getPeers()).called(1);
+      verify(() => mockRepository.getPeerById('id')).called(1);
+      verify(() => mockRepository.savePeer(tPeer)).called(1);
+      verify(() => mockRepository.deletePeer('id')).called(1);
+      verify(() => mockRepository.getMessagesForPeer('id')).called(1);
+      verify(() => mockRepository.saveMessage(tMessage)).called(1);
+    });
+  });
+}

--- a/test/features/vitals/domain/repositories/vital_sign_repository_test.dart
+++ b/test/features/vitals/domain/repositories/vital_sign_repository_test.dart
@@ -1,0 +1,48 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+import 'package:orionhealth_health/features/vitals/domain/repositories/vital_sign_repository.dart';
+
+class MockVitalSignRepository extends Mock implements VitalSignRepository {}
+class FakeVitalSign extends Fake implements VitalSign {}
+
+void main() {
+  late MockVitalSignRepository mockRepository;
+
+  setUpAll(() {
+    registerFallbackValue(FakeVitalSign());
+  });
+
+  setUp(() {
+    mockRepository = MockVitalSignRepository();
+  });
+
+  group('VitalSignRepository Interface', () {
+    test('can be mocked and called', () async {
+      final tVital = VitalSign(
+        type: VitalSignType.heartRate,
+        value: 70,
+        unit: 'bpm',
+        dateTime: DateTime.now(),
+      );
+
+      when(() => mockRepository.getAllVitalSigns()).thenAnswer((_) async => [tVital]);
+      when(() => mockRepository.saveVitalSign(any())).thenAnswer((_) async {});
+      when(() => mockRepository.saveVitalSigns(any())).thenAnswer((_) async {});
+      when(() => mockRepository.getLatestVitals()).thenAnswer((_) async => {VitalSignType.heartRate: tVital});
+
+      final vitals = await mockRepository.getAllVitalSigns();
+      await mockRepository.saveVitalSign(tVital);
+      await mockRepository.saveVitalSigns([tVital]);
+      final latest = await mockRepository.getLatestVitals();
+
+      expect(vitals, [tVital]);
+      expect(latest[VitalSignType.heartRate], tVital);
+
+      verify(() => mockRepository.getAllVitalSigns()).called(1);
+      verify(() => mockRepository.saveVitalSign(tVital)).called(1);
+      verify(() => mockRepository.saveVitalSigns([tVital])).called(1);
+      verify(() => mockRepository.getLatestVitals()).called(1);
+    });
+  });
+}

--- a/test/features/vitals/domain/usecases/get_all_vital_signs_usecase_test.dart
+++ b/test/features/vitals/domain/usecases/get_all_vital_signs_usecase_test.dart
@@ -1,0 +1,37 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+import 'package:orionhealth_health/features/vitals/domain/repositories/vital_sign_repository.dart';
+import 'package:orionhealth_health/features/vitals/domain/usecases/get_all_vital_signs_usecase.dart';
+
+class MockVitalSignRepository extends Mock implements VitalSignRepository {}
+
+void main() {
+  late GetAllVitalSignsUseCase useCase;
+  late MockVitalSignRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockVitalSignRepository();
+    useCase = GetAllVitalSignsUseCase(mockRepository);
+  });
+
+  group('GetAllVitalSignsUseCase', () {
+    test('should return all vitals from repository', () async {
+      final tVitals = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 70,
+          unit: 'bpm',
+          dateTime: DateTime.now(),
+        ),
+      ];
+
+      when(() => mockRepository.getAllVitalSigns()).thenAnswer((_) async => tVitals);
+
+      final result = await useCase();
+
+      expect(result, tVitals);
+      verify(() => mockRepository.getAllVitalSigns()).called(1);
+    });
+  });
+}

--- a/test/features/vitals/domain/usecases/save_vital_signs_usecase_test.dart
+++ b/test/features/vitals/domain/usecases/save_vital_signs_usecase_test.dart
@@ -1,0 +1,36 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
+import 'package:orionhealth_health/features/vitals/domain/repositories/vital_sign_repository.dart';
+import 'package:orionhealth_health/features/vitals/domain/usecases/save_vital_signs_usecase.dart';
+
+class MockVitalSignRepository extends Mock implements VitalSignRepository {}
+
+void main() {
+  late SaveVitalSignsUseCase useCase;
+  late MockVitalSignRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockVitalSignRepository();
+    useCase = SaveVitalSignsUseCase(mockRepository);
+  });
+
+  group('SaveVitalSignsUseCase', () {
+    test('should save vitals in repository', () async {
+      final tVitals = [
+        VitalSign(
+          type: VitalSignType.heartRate,
+          value: 70,
+          unit: 'bpm',
+          dateTime: DateTime.now(),
+        ),
+      ];
+
+      when(() => mockRepository.saveVitalSigns(any())).thenAnswer((_) async {});
+
+      await useCase(tVitals);
+
+      verify(() => mockRepository.saveVitalSigns(tVitals)).called(1);
+    });
+  });
+}


### PR DESCRIPTION
This PR introduces a comprehensive batch of domain-level unit tests for several core features, including auth, network, local_agent, vitals, appointments, and health_data_import. These tests cover entities, repositories (interface mocks), and use cases, following the requested Clean Architecture pattern. All tests have been verified to pass alongside existing ones.

Fixes #1345

---
*PR created automatically by Jules for task [7344300147524841143](https://jules.google.com/task/7344300147524841143) started by @iberi22*