### PR TITLE
PWA: Add Offline Fallback Page and Update Service Worker

### DIFF
--- a/docs/public/offline.html
+++ b/docs/public/offline.html
@@ -1,0 +1,172 @@
+<!DOCTYPE html>
+<html lang="es" class="scroll-smooth">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=5.0">
+  <title>Modo Offline | OrionHealth</title>
+  <meta name="theme-color" content="#121212">
+  <link rel="icon" type="image/svg+xml" href="/OrionHealth/favicon.svg">
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fira+Code:wght@300;400;500;600;700&display=swap" rel="stylesheet">
+
+  <style>
+    * {
+      font-family: 'Fira Code', monospace;
+      box-sizing: border-box;
+      transition: all 0.5s cubic-bezier(0.19, 1, 0.22, 1);
+    }
+
+    body {
+      background-color: #121212;
+      color: #F5F5DC;
+      margin: 0;
+      padding: 0;
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      min-height: 100vh;
+      text-align: center;
+      overflow: hidden;
+    }
+
+    /* Noise Overlay */
+    .bg-noise {
+      position: fixed;
+      top: 0;
+      left: 0;
+      width: 100%;
+      height: 100%;
+      opacity: 0.05;
+      z-index: -1;
+      pointer-events: none;
+      background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 400 400' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='4' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+    }
+
+    /* Grid Pattern */
+    .bg-grid {
+      position: fixed;
+      inset: 0;
+      z-index: -10;
+      background-image:
+        linear-gradient(rgba(16, 185, 129, 0.02) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(16, 185, 129, 0.02) 1px, transparent 1px);
+      background-size: 40px 40px;
+    }
+
+    .container {
+      max-width: 600px;
+      padding: 2rem;
+      position: relative;
+    }
+
+    .glass {
+      background: rgba(30, 30, 30, 0.6);
+      backdrop-filter: blur(20px) saturate(180%);
+      border: 1px solid rgba(255, 255, 255, 0.05);
+      border-radius: 24px;
+      padding: 3rem 2rem;
+      box-shadow: 0 20px 50px rgba(0, 0, 0, 0.3);
+    }
+
+    .icon-container {
+      margin-bottom: 2rem;
+      color: #10B981;
+    }
+
+    .title {
+      font-size: 2rem;
+      font-weight: 700;
+      margin-bottom: 1rem;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+    }
+
+    .message {
+      font-size: 1rem;
+      color: rgba(245, 245, 220, 0.7);
+      margin-bottom: 2.5rem;
+      line-height: 1.6;
+    }
+
+    .btn-group {
+      display: flex;
+      flex-direction: column;
+      gap: 1rem;
+    }
+
+    .btn-primary {
+      background: linear-gradient(135deg, #10B981 0%, #059669 100%);
+      color: #0A0A0A;
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      border-radius: 9999px;
+      padding: 1rem 2rem;
+      text-decoration: none;
+      border: none;
+      cursor: pointer;
+      display: inline-block;
+    }
+
+    .btn-primary:hover {
+      transform: scale(1.05);
+      box-shadow: 0 0 24px rgba(16, 185, 129, 0.4);
+    }
+
+    .btn-secondary {
+      background: transparent;
+      color: #F5F5DC;
+      border: 1px solid rgba(255, 255, 255, 0.1);
+      font-weight: 700;
+      text-transform: uppercase;
+      letter-spacing: 0.05em;
+      border-radius: 9999px;
+      padding: 1rem 2rem;
+      text-decoration: none;
+      cursor: pointer;
+    }
+
+    .btn-secondary:hover {
+      background: rgba(255, 255, 255, 0.05);
+      border-color: rgba(16, 185, 129, 0.5);
+    }
+
+    @media (min-width: 640px) {
+      .btn-group {
+        flex-direction: row;
+        justify-content: center;
+      }
+    }
+  </style>
+</head>
+<body>
+  <div class="bg-noise"></div>
+  <div class="bg-grid"></div>
+
+  <div class="container">
+    <div class="glass">
+      <div class="icon-container">
+        <svg xmlns="http://www.w3.org/2000/svg" width="64" height="64" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <path d="M1 1l22 22"></path>
+          <path d="M16.72 11.06A10.94 10.94 0 0 1 19 12.55"></path>
+          <path d="M5 12.55a10.94 10.94 0 0 1 5.17-2.39"></path>
+          <path d="M10.71 5.05A16 16 0 0 1 22.58 9"></path>
+          <path d="M1.42 9a15.91 15.91 0 0 1 4.7-2.88"></path>
+          <path d="M8.53 16.11a6 6 0 0 1 6.95 0"></path>
+          <line x1="12" y1="20" x2="12.01" y2="20"></line>
+        </svg>
+      </div>
+      <h1 class="title">Modo Offline</h1>
+      <p class="message">
+        Parece que no tienes conexión a internet.<br>
+        Esta página no ha sido guardada para uso offline todavía.
+      </p>
+      <div class="btn-group">
+        <button onclick="window.location.reload()" class="btn-primary">Reintentar</button>
+        <a href="/OrionHealth/" class="btn-secondary">Volver al Inicio</a>
+      </div>
+    </div>
+  </div>
+</body>
+</html>

--- a/docs/public/sw.js
+++ b/docs/public/sw.js
@@ -11,7 +11,8 @@ const STATIC_ASSETS = [
   '/OrionHealth/about',
   '/OrionHealth/privacy',
   '/OrionHealth/favicon.svg',
-  '/OrionHealth/manifest.json'
+  '/OrionHealth/manifest.json',
+  '/OrionHealth/offline.html'
 ];
 
 const MEDICAL_DATA = [
@@ -101,15 +102,17 @@ self.addEventListener('fetch', (event) => {
     return;
   }
 
-  // HTML pages: network-first, fallback to cache
+  // HTML pages: network-first, fallback to cache, then to offline page
   if (event.request.mode === 'navigate') {
-    event.respondWith(
-      fetch(event.request).catch(() => {
-        return caches.match(event.request).then((cached) => {
-          return cached || caches.match('/OrionHealth/');
-        });
-      })
-    );
+    event.respondWith((async () => {
+      try {
+        return await fetch(event.request);
+      } catch (err) {
+        return await caches.match(event.request) ||
+               await caches.match('/OrionHealth/') ||
+               await caches.match('/OrionHealth/offline.html');
+      }
+    })());
     return;
   }
 


### PR DESCRIPTION
This PR adds a custom offline fallback page to the OrionHealth PWA documentation site. 

Key changes:
1.  **New Offline Page**: Created `docs/public/offline.html` which matches the site's cyber-minimalist aesthetic. It provides a clear message in Spanish and options to retry or return home.
2.  **Service Worker Enhancement**: Updated `docs/public/sw.js` to include the offline page in its static assets cache.
3.  **Fallback Logic**: Refactored the `fetch` event handler for navigation requests to use an `async` function. This ensures that if a network request fails and the page is not in the cache, the Service Worker correctly falls back to the site root or the new offline page.

Verified with `npm run build` and visual inspection via Playwright.

Fixes #1363

---
*PR created automatically by Jules for task [2653792438136600578](https://jules.google.com/task/2653792438136600578) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a Spanish offline experience with a dedicated “Modo Offline” page.
  * Included clear actions to retry loading or return to the home page.
* **Bug Fixes**
  * Improved offline handling so navigation requests now fall back more reliably when the network is unavailable.
  * Ensured the offline page is available from the app’s cached content for better access without connectivity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->