### PR TITLE
Add Network Connection Status Badge and Widget Tests

### DIFF
--- a/lib/features/network/presentation/network.dart
+++ b/lib/features/network/presentation/network.dart
@@ -13,4 +13,5 @@ export '../network_health/presentation/pages/network_health_page.dart';
 export '../network_health/presentation/widgets/network_stats_card.dart';
 export '../network_health/presentation/widgets/node_list_item.dart';
 export 'pages/network_overview_page.dart';
+export 'widgets/connection_status_badge.dart';
 export 'widgets/peer_list_item.dart';

--- a/lib/features/network/presentation/widgets/connection_status_badge.dart
+++ b/lib/features/network/presentation/widgets/connection_status_badge.dart
@@ -1,0 +1,69 @@
+import 'package:flutter/material.dart';
+import '../../../../core/utils/connectivity_manager.dart';
+
+class ConnectionStatusBadge extends StatelessWidget {
+  final ConnectivityStatus? initialStatus;
+  final Stream<ConnectivityStatus>? statusStream;
+
+  const ConnectionStatusBadge({
+    super.key,
+    this.initialStatus,
+    this.statusStream,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return StreamBuilder<ConnectivityStatus>(
+      stream: statusStream ?? ConnectivityManager().statusStream,
+      initialData: initialStatus ?? ConnectivityManager().currentStatus,
+      builder: (context, snapshot) {
+        final status = snapshot.data ?? ConnectivityStatus.unknown;
+        final isOnline = status == ConnectivityStatus.connected;
+        final isUnknown = status == ConnectivityStatus.unknown;
+
+        final color = isUnknown
+            ? Colors.grey
+            : (isOnline ? Colors.green : Colors.red);
+
+        final icon = isUnknown
+            ? Icons.help_outline
+            : (isOnline ? Icons.wifi : Icons.wifi_off);
+
+        final label = isUnknown
+            ? 'UNKNOWN'
+            : (isOnline ? 'ONLINE' : 'OFFLINE');
+
+        return Container(
+          padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+          decoration: BoxDecoration(
+            color: color.withValues(alpha: 0.1),
+            borderRadius: BorderRadius.circular(16),
+            border: Border.all(
+              color: color,
+              width: 1,
+            ),
+          ),
+          child: Row(
+            mainAxisSize: MainAxisSize.min,
+            children: [
+              Icon(
+                icon,
+                size: 16,
+                color: color,
+              ),
+              const SizedBox(width: 6),
+              Text(
+                label,
+                style: TextStyle(
+                  color: color,
+                  fontSize: 12,
+                  fontWeight: FontWeight.bold,
+                ),
+              ),
+            ],
+          ),
+        );
+      },
+    );
+  }
+}

--- a/test/features/network/presentation/widgets/connection_status_badge_test.dart
+++ b/test/features/network/presentation/widgets/connection_status_badge_test.dart
@@ -1,0 +1,112 @@
+import 'dart:async';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/utils/connectivity_manager.dart';
+import 'package:orionhealth_health/features/network/presentation/widgets/connection_status_badge.dart';
+
+void main() {
+  group('ConnectionStatusBadge', () {
+    testWidgets('shows ONLINE status correctly', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ConnectionStatusBadge(
+              initialStatus: ConnectivityStatus.connected,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('ONLINE'), findsOneWidget);
+      expect(find.byIcon(Icons.wifi), findsOneWidget);
+
+      final container = tester.widget<Container>(
+        find.ancestor(
+          of: find.text('ONLINE'),
+          matching: find.byType(Container),
+        ).first,
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, Colors.green);
+    });
+
+    testWidgets('shows OFFLINE status correctly', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ConnectionStatusBadge(
+              initialStatus: ConnectivityStatus.disconnected,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('OFFLINE'), findsOneWidget);
+      expect(find.byIcon(Icons.wifi_off), findsOneWidget);
+
+      final container = tester.widget<Container>(
+        find.ancestor(
+          of: find.text('OFFLINE'),
+          matching: find.byType(Container),
+        ).first,
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, Colors.red);
+    });
+
+    testWidgets('responds to connectivity changes', (tester) async {
+      final controller = StreamController<ConnectivityStatus>();
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ConnectionStatusBadge(
+              initialStatus: ConnectivityStatus.disconnected,
+              statusStream: controller.stream,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('OFFLINE'), findsOneWidget);
+
+      controller.add(ConnectivityStatus.connected);
+      await tester.pumpAndSettle();
+
+      expect(find.text('ONLINE'), findsOneWidget);
+      expect(find.byIcon(Icons.wifi), findsOneWidget);
+
+      controller.add(ConnectivityStatus.disconnected);
+      await tester.pumpAndSettle();
+
+      expect(find.text('OFFLINE'), findsOneWidget);
+      expect(find.byIcon(Icons.wifi_off), findsOneWidget);
+
+      controller.close();
+    });
+
+    testWidgets('shows UNKNOWN status correctly', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: ConnectionStatusBadge(
+              initialStatus: ConnectivityStatus.unknown,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('UNKNOWN'), findsOneWidget);
+      expect(find.byIcon(Icons.help_outline), findsOneWidget);
+
+      final container = tester.widget<Container>(
+        find.ancestor(
+          of: find.text('UNKNOWN'),
+          matching: find.byType(Container),
+        ).first,
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, Colors.grey);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds the `ConnectionStatusBadge` widget to the network feature's presentation layer and includes a suite of widget tests to verify its behavior.

The widget displays the current network connectivity status (ONLINE/OFFLINE/UNKNOWN) with appropriate icons and colors. It is designed to be reactive to connectivity changes using a `StreamBuilder`.

Widget tests in `test/features/network/presentation/widgets/connection_status_badge_test.dart` verify:
- Correct rendering of ONLINE status (green, wifi icon).
- Correct rendering of OFFLINE status (red, wifi_off icon).
- Correct rendering of UNKNOWN status (grey, help icon).
- Reactive updates when the connectivity status stream emits new values.

The widget supports testability by allowing optional `initialStatus` and `statusStream` injection via its constructor.

Fixes #1360

---
*PR created automatically by Jules for task [15484093225003197812](https://jules.google.com/task/15484093225003197812) started by @iberi22*