### PR TITLE
Implement CitasListTile and widget tests for email-citas

### DIFF
--- a/lib/features/email-citas/presentation/widgets/citas_list_tile.dart
+++ b/lib/features/email-citas/presentation/widgets/citas_list_tile.dart
@@ -1,0 +1,96 @@
+// SPDX-License-Identifier: AGPL-3.0-only
+// SPDX-FileCopyrightText: 2025 SouthWest AI Labs
+
+import 'package:flutter/material.dart';
+import 'package:intl/intl.dart';
+import '../../../appointments/domain/entities/appointment.dart';
+import '../../../../core/theme/cyber_theme.dart';
+import '../../../../core/widgets/glassmorphic_card.dart';
+
+class CitasListTile extends StatelessWidget {
+  final Appointment appointment;
+  final VoidCallback? onTap;
+
+  const CitasListTile({
+    super.key,
+    required this.appointment,
+    this.onTap,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = _getStatusColor(appointment.status);
+
+    return Padding(
+      padding: const EdgeInsets.symmetric(horizontal: 16.0, vertical: 6.0),
+      child: GlassmorphicCard(
+        child: ListTile(
+          onTap: onTap,
+          leading: Container(
+            padding: const EdgeInsets.all(8),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.1),
+              shape: BoxShape.circle,
+            ),
+            child: Icon(
+              Icons.calendar_today,
+              color: color,
+              size: 20,
+            ),
+          ),
+          title: Text(
+            appointment.doctorName,
+            style: const TextStyle(fontWeight: FontWeight.bold),
+          ),
+          subtitle: Column(
+            crossAxisAlignment: CrossAxisAlignment.start,
+            children: [
+              Text(
+                appointment.specialty,
+                style: const TextStyle(color: Colors.white70),
+              ),
+              const SizedBox(height: 4),
+              Row(
+                children: [
+                  const Icon(Icons.access_time, size: 14, color: CyberTheme.secondary),
+                  const SizedBox(width: 4),
+                  Text(
+                    DateFormat('dd MMM yyyy, hh:mm a', 'es').format(appointment.dateTime),
+                    style: const TextStyle(color: CyberTheme.secondary, fontSize: 12),
+                  ),
+                ],
+              ),
+            ],
+          ),
+          trailing: Container(
+            padding: const EdgeInsets.symmetric(horizontal: 8, vertical: 4),
+            decoration: BoxDecoration(
+              color: color.withValues(alpha: 0.1),
+              borderRadius: BorderRadius.circular(8),
+              border: Border.all(color: color.withValues(alpha: 0.5)),
+            ),
+            child: Text(
+              appointment.status.name.toUpperCase(),
+              style: TextStyle(
+                color: color,
+                fontSize: 10,
+                fontWeight: FontWeight.bold,
+              ),
+            ),
+          ),
+        ),
+      ),
+    );
+  }
+
+  Color _getStatusColor(AppointmentStatus status) {
+    switch (status) {
+      case AppointmentStatus.upcoming:
+        return Colors.teal;
+      case AppointmentStatus.completed:
+        return Colors.green;
+      case AppointmentStatus.cancelled:
+        return Colors.grey;
+    }
+  }
+}

--- a/test/features/email-citas/presentation/widgets/citas_list_tile_test.dart
+++ b/test/features/email-citas/presentation/widgets/citas_list_tile_test.dart
@@ -1,0 +1,96 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:intl/date_symbol_data_local.dart';
+import 'package:intl/intl.dart';
+import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
+import 'package:orionhealth_health/features/email-citas/presentation/widgets/citas_list_tile.dart';
+
+void main() {
+  setUpAll(() async {
+    await initializeDateFormatting('es', null);
+  });
+
+  group('CitasListTile', () {
+    final appointment = Appointment(
+      doctorName: 'Dr. John Doe',
+      specialty: 'Cardiología',
+      dateTime: DateTime(2025, 5, 20, 10, 30),
+      status: AppointmentStatus.upcoming,
+    );
+
+    testWidgets('renders appointment information correctly', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CitasListTile(appointment: appointment),
+          ),
+        ),
+      );
+
+      expect(find.text('Dr. John Doe'), findsOneWidget);
+      expect(find.text('Cardiología'), findsOneWidget);
+
+      final expectedDate = DateFormat('dd MMM yyyy, hh:mm a', 'es').format(appointment.dateTime);
+      expect(find.text(expectedDate), findsOneWidget);
+    });
+
+    testWidgets('displays appointment status', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CitasListTile(appointment: appointment),
+          ),
+        ),
+      );
+
+      expect(find.text('UPCOMING'), findsOneWidget);
+    });
+
+    testWidgets('renders within a ListView', (tester) async {
+      final appointments = [
+        appointment,
+        Appointment(
+          doctorName: 'Dra. Jane Smith',
+          specialty: 'Pediatría',
+          dateTime: DateTime(2025, 5, 21, 15, 00),
+          status: AppointmentStatus.completed,
+        ),
+      ];
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ListView.builder(
+              itemCount: appointments.length,
+              itemBuilder: (context, index) => CitasListTile(
+                appointment: appointments[index],
+              ),
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byType(CitasListTile), findsNWidgets(2));
+      expect(find.text('Dr. John Doe'), findsOneWidget);
+      expect(find.text('Dra. Jane Smith'), findsOneWidget);
+      expect(find.text('COMPLETED'), findsOneWidget);
+    });
+
+    testWidgets('triggers onTap callback', (tester) async {
+      bool tapped = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: CitasListTile(
+              appointment: appointment,
+              onTap: () => tapped = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.byType(CitasListTile));
+      expect(tapped, isTrue);
+    });
+  });
+}


### PR DESCRIPTION
This PR adds the `CitasListTile` widget to the `email-citas` feature and provides a set of widget tests to verify its rendering and functionality. The widget displays the doctor's name, specialty, status, and date/time of an appointment. The tests cover individual rendering, status display, list-view integration, and interaction. Unrelated changes to dependency injection and other test files were reverted to keep the PR focused.

Fixes #1358

---
*PR created automatically by Jules for task [15218007680024771165](https://jules.google.com/task/15218007680024771165) started by @iberi22*