### PR TITLE
Add DashboardStatsCard widget and tests

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -24,30 +24,30 @@ import 'package:just_audio/just_audio.dart' as _i13;
 import 'package:medical_standards/medical_standards.dart' as _i68;
 import 'package:shared_preferences/shared_preferences.dart' as _i51;
 
-import '../../features/about/application/about_cubit.dart' as _i139;
+import '../../features/about/application/about_cubit.dart' as _i141;
 import '../../features/about/domain/repositories/i_about_repository.dart'
     as _i53;
 import '../../features/about/domain/usecases/get_about_info_usecase.dart'
-    as _i164;
+    as _i167;
 import '../../features/about/infrastructure/datasources/about_local_datasource.dart'
     as _i4;
 import '../../features/about/infrastructure/datasources/about_remote_datasource.dart'
-    as _i140;
+    as _i142;
 import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
     as _i54;
-import '../../features/allergies/application/allergies_cubit.dart' as _i227;
-import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i228;
+import '../../features/allergies/application/allergies_cubit.dart' as _i228;
+import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i229;
 import '../../features/allergies/data/datasources/allergy_local_datasource.dart'
-    as _i141;
-import '../../features/allergies/data/repositories/allergy_repository_impl.dart'
     as _i143;
+import '../../features/allergies/data/repositories/allergy_repository_impl.dart'
+    as _i145;
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i142;
+    as _i144;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i6;
 import '../../features/allergies/domain/usecases/get_allergies_usecase.dart'
-    as _i167;
+    as _i170;
 import '../../features/allergies/domain/usecases/save_allergy_usecase.dart'
-    as _i207;
+    as _i210;
 import '../../features/appointments/application/appointments_cubit.dart'
     as _i10;
 import '../../features/appointments/application/bloc/appointment_bloc.dart'
@@ -62,35 +62,35 @@ import '../../features/appointments/domain/usecases/get_all_appointments_usecase
     as _i44;
 import '../../features/appointments/domain/usecases/save_appointment_usecase.dart'
     as _i109;
-import '../../features/auth/application/auth_cubit.dart' as _i229;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i230;
+import '../../features/auth/application/auth_cubit.dart' as _i230;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i231;
 import '../../features/auth/data/datasources/auth_local_datasource.dart'
-    as _i144;
-import '../../features/auth/data/repositories/auth_repository_impl.dart'
     as _i146;
-import '../../features/auth/domain/auth_service.dart' as _i147;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i145;
+import '../../features/auth/data/repositories/auth_repository_impl.dart'
+    as _i148;
+import '../../features/auth/domain/auth_service.dart' as _i149;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i147;
 import '../../features/auth/domain/usecases/get_credentials_usecase.dart'
-    as _i171;
-import '../../features/auth/domain/usecases/login_usecase.dart' as _i193;
-import '../../features/auth/domain/usecases/logout_usecase.dart' as _i194;
+    as _i174;
+import '../../features/auth/domain/usecases/login_usecase.dart' as _i196;
+import '../../features/auth/domain/usecases/logout_usecase.dart' as _i197;
 import '../../features/auth/domain/usecases/save_credentials_usecase.dart'
-    as _i208;
-import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i215;
+    as _i211;
+import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i218;
 import '../../features/auth/domain/usecases/validate_session_usecase.dart'
-    as _i223;
+    as _i224;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i15;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
     as _i34;
 import '../../features/calendar_import/application/calendar_import_cubit.dart'
-    as _i233;
+    as _i234;
 import '../../features/calendar_import/domain/repositories/calendar_import_repository.dart'
     as _i20;
 import '../../features/calendar_import/domain/services/calendar_parser_service.dart'
     as _i22;
 import '../../features/calendar_import/domain/usecases/import_calendar_usecase.dart'
-    as _i186;
+    as _i189;
 import '../../features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart'
     as _i18;
 import '../../features/calendar_import/infrastructure/repositories/calendar_import_repository_impl.dart'
@@ -99,66 +99,66 @@ import '../../features/calendar_import/infrastructure/services/calendar_parser_s
     as _i23;
 import '../../features/dashboard/application/dashboard_cubit.dart' as _i262;
 import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
-    as _i235;
+    as _i236;
 import '../../features/dashboard/domain/usecases/get_dashboard_stats_usecase.dart'
     as _i245;
 import '../../features/dashboard/domain/usecases/get_recent_activity_usecase.dart'
     as _i247;
 import '../../features/dashboard/infrastructure/datasources/dashboard_local_datasource.dart'
-    as _i154;
+    as _i156;
 import '../../features/dashboard/infrastructure/datasources/dashboard_remote_datasource.dart'
     as _i26;
 import '../../features/dashboard/infrastructure/repositories/dashboard_repository_impl.dart'
-    as _i236;
+    as _i237;
 import '../../features/data_sources/application/data_source_cubit.dart'
     as _i263;
 import '../../features/data_sources/domain/repositories/data_source_repository.dart'
-    as _i237;
+    as _i238;
 import '../../features/data_sources/infrastructure/datasources/file_import_datasource.dart'
-    as _i163;
+    as _i166;
 import '../../features/data_sources/infrastructure/datasources/health_connect_datasource.dart'
     as _i45;
 import '../../features/data_sources/infrastructure/datasources/sensor_api_datasource.dart'
     as _i114;
 import '../../features/data_sources/infrastructure/repositories/data_source_repository_impl.dart'
-    as _i238;
+    as _i239;
 import '../../features/doctor_verification/application/badge_cubit.dart'
-    as _i232;
+    as _i233;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
-    as _i160;
+    as _i162;
 import '../../features/doctor_verification/application/second_opinion_cubit.dart'
-    as _i213;
+    as _i216;
 import '../../features/doctor_verification/application/vouch_cubit.dart'
-    as _i226;
+    as _i227;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
-    as _i158;
+    as _i160;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
     as _i103;
 import '../../features/doctor_verification/domain/repositories/second_opinion_repository.dart'
     as _i111;
 import '../../features/doctor_verification/domain/repositories/vouch_repository.dart'
-    as _i136;
+    as _i138;
 import '../../features/doctor_verification/domain/services/badge_calculator.dart'
-    as _i231;
+    as _i232;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
     as _i62;
 import '../../features/doctor_verification/domain/usecases/get_all_doctors_usecase.dart'
-    as _i165;
+    as _i168;
 import '../../features/doctor_verification/domain/usecases/get_doctor_profile_usecase.dart'
-    as _i172;
+    as _i175;
 import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
     as _i61;
 import '../../features/doctor_verification/infrastructure/repositories/isar_doctor_profile_repository.dart'
-    as _i159;
+    as _i161;
 import '../../features/doctor_verification/infrastructure/repositories/isar_rating_repository.dart'
     as _i104;
 import '../../features/doctor_verification/infrastructure/repositories/isar_second_opinion_repository.dart'
     as _i112;
 import '../../features/doctor_verification/infrastructure/repositories/isar_vouch_repository.dart'
-    as _i137;
+    as _i139;
 import '../../features/email-citas/application/bloc/email_citas_bloc.dart'
-    as _i161;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i162;
+    as _i163;
+import '../../features/email-citas/application/email_citas_cubit.dart' as _i164;
 import '../../features/email-citas/domain/repositories/email_repository.dart'
     as _i31;
 import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
@@ -166,17 +166,17 @@ import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
 import '../../features/email-citas/infrastructure/repositories/email_repository_impl.dart'
     as _i32;
 import '../../features/eps_connection/application/bloc/eps_connection_bloc.dart'
-    as _i240;
-import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
     as _i241;
+import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
+    as _i242;
 import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
     as _i97;
 import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
-    as _i153;
-import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
     as _i155;
+import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
+    as _i157;
 import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
-    as _i170;
+    as _i173;
 import '../../features/eps_connection/infrastructure/datasources/oauth_local_datasource.dart'
     as _i96;
 import '../../features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart'
@@ -186,7 +186,7 @@ import '../../features/health_data_import/application/bloc/health_import_bloc.da
 import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i249;
 import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i182;
+    as _i185;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i46;
 import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
@@ -194,17 +194,17 @@ import '../../features/health_data_import/domain/usecases/health_import_usecases
 import '../../features/health_data_import/infrastructure/data_source.dart'
     as _i115;
 import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i183;
+    as _i186;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
     as _i250;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i184;
+    as _i187;
 import '../../features/health_record/domain/usecases/get_all_records_usecase.dart'
     as _i244;
 import '../../features/health_record/domain/usecases/save_record_usecase.dart'
-    as _i210;
+    as _i213;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i185;
+    as _i188;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i37;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
@@ -215,13 +215,13 @@ import '../../features/health_sharing/application/sharing_cubit.dart' as _i261;
 import '../../features/health_sharing/domain/repositories/sharing_repository.dart'
     as _i119;
 import '../../features/health_sharing/domain/usecases/cancel_sharing_usecase.dart'
-    as _i149;
+    as _i151;
 import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
-    as _i217;
+    as _i220;
 import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
-    as _i218;
+    as _i221;
 import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
-    as _i148;
+    as _i150;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i16;
 import '../../features/health_sharing/infrastructure/datasources/health_sharing_local_datasource.dart'
     as _i47;
@@ -233,7 +233,7 @@ import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
 import '../../features/health_sharing/infrastructure/repositories/health_sharing_repository_impl.dart'
     as _i120;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i138;
+    as _i140;
 import '../../features/home/application/home_cubit.dart' as _i266;
 import '../../features/home/domain/repositories/home_repository.dart' as _i251;
 import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
@@ -247,45 +247,45 @@ import '../../features/home/infrastructure/datasources/home_remote_datasource.da
 import '../../features/home/infrastructure/repositories/home_repository_impl.dart'
     as _i252;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i216;
+    as _i219;
 import '../../features/local_agent/data/datasources/chat_message_local_datasource.dart'
-    as _i150;
+    as _i152;
 import '../../features/local_agent/data/datasources/local_model_local_datasource.dart'
     as _i67;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i69;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i63;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i129;
+    as _i131;
 import '../../features/local_agent/domain/usecases/get_chat_history_usecase.dart'
-    as _i168;
+    as _i172;
 import '../../features/local_agent/domain/usecases/send_chat_message_usecase.dart'
     as _i113;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i64;
+    as _i65;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i40;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i187;
+    as _i190;
 import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i42;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i188;
-import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i65;
-import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
     as _i191;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i190;
+import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
+    as _i64;
+import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
+    as _i194;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i193;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
     as _i253;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i70;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i71;
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
+    as _i70;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i130;
+    as _i132;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i189;
+    as _i192;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i66;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
@@ -293,7 +293,7 @@ import '../../features/local_agent/infrastructure/services/medical_indexing_serv
 import '../../features/local_agent/infrastructure/services/model_download_service.dart'
     as _i84;
 import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i204;
+    as _i207;
 import '../../features/medical_research/application/medical_research_cubit.dart'
     as _i267;
 import '../../features/medical_research/domain/repositories/medical_research_repository.dart'
@@ -311,7 +311,7 @@ import '../../features/medical_research/domain/usecases/search_medical_research.
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i17;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i195;
+    as _i198;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i73;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
@@ -322,34 +322,34 @@ import '../../features/medical_research/infrastructure/repositories/medical_rese
     as _i256;
 import '../../features/medications/application/bloc/medication_bloc.dart'
     as _i257;
-import '../../features/medications/application/medications_cubit.dart' as _i198;
+import '../../features/medications/application/medications_cubit.dart' as _i201;
 import '../../features/medications/domain/repositories/medication_adherence_repository.dart'
     as _i78;
 import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i196;
+    as _i199;
 import '../../features/medications/domain/usecases/get_all_medications_usecase.dart'
     as _i243;
 import '../../features/medications/domain/usecases/save_medication_usecase.dart'
-    as _i209;
+    as _i212;
 import '../../features/medications/infrastructure/datasources/adherence_sqlite_datasource.dart'
     as _i5;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i197;
+    as _i200;
 import '../../features/medications/infrastructure/repositories/sqlite_medication_adherence_repository.dart'
     as _i79;
 import '../../features/medications/infrastructure/services/pharmacy_api_service.dart'
     as _i100;
 import '../../features/medications/infrastructure/services/rxnorm_api_service.dart'
     as _i101;
-import '../../features/meditation/application/meditation_cubit.dart' as _i199;
+import '../../features/meditation/application/meditation_cubit.dart' as _i202;
 import '../../features/meditation/domain/repositories/meditation_repository.dart'
     as _i81;
 import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
-    as _i151;
+    as _i153;
 import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
-    as _i175;
+    as _i178;
 import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
-    as _i177;
+    as _i180;
 import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
     as _i105;
 import '../../features/meditation/domain/usecases/start_session_usecase.dart'
@@ -358,15 +358,15 @@ import '../../features/meditation/infrastructure/datasources/meditation_local_da
     as _i80;
 import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
     as _i82;
-import '../../features/network/application/network_cubit.dart' as _i200;
+import '../../features/network/application/network_cubit.dart' as _i203;
 import '../../features/network/domain/repositories/network_peer_repository.dart'
     as _i87;
 import '../../features/network/governance/domain/repositories/governance_repository.dart'
-    as _i180;
+    as _i183;
 import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
-    as _i179;
+    as _i182;
 import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
-    as _i181;
+    as _i184;
 import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
     as _i57;
 import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
@@ -378,45 +378,45 @@ import '../../features/network/infrastructure/datasources/network_p2p_api.dart'
 import '../../features/network/infrastructure/repositories/network_peer_repository_impl.dart'
     as _i88;
 import '../../features/network/network_health/application/network_health_cubit.dart'
-    as _i201;
+    as _i204;
 import '../../features/network/network_health/domain/repositories/network_repository.dart'
     as _i89;
 import '../../features/network/network_health/domain/usecases/connect_node.dart'
-    as _i152;
+    as _i154;
 import '../../features/network/network_health/domain/usecases/get_network_health.dart'
-    as _i173;
+    as _i176;
 import '../../features/network/network_health/domain/usecases/get_node_stats.dart'
-    as _i174;
+    as _i177;
 import '../../features/network/network_health/infrastructure/datasources/network_datasource.dart'
     as _i85;
 import '../../features/network/network_health/infrastructure/repositories/network_repository_impl.dart'
     as _i90;
 import '../../features/onboarding/application/onboarding_cubit.dart' as _i258;
-import '../../features/onboarding/application/sync_cubit.dart' as _i219;
+import '../../features/onboarding/application/sync_cubit.dart' as _i222;
 import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i202;
+    as _i205;
 import '../../features/onboarding/domain/usecases/complete_onboarding_usecase.dart'
-    as _i234;
+    as _i235;
 import '../../features/onboarding/domain/usecases/get_onboarding_profile_usecase.dart'
     as _i246;
 import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
-    as _i203;
+    as _i206;
 import '../../features/reports/application/bloc/report_bloc.dart' as _i259;
 import '../../features/reports/domain/repositories/report_repository.dart'
     as _i106;
 import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i205;
+    as _i208;
 import '../../features/reports/domain/usecases/get_reports_usecase.dart'
-    as _i176;
+    as _i179;
 import '../../features/reports/domain/usecases/save_report_usecase.dart'
     as _i110;
 import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i107;
 import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i206;
+    as _i209;
 import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i83;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i192;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i195;
 import '../../features/settings/domain/repositories/settings_repository.dart'
     as _i117;
 import '../../features/settings/domain/services/device_capability_service.dart'
@@ -425,15 +425,15 @@ import '../../features/settings/infrastructure/datasources/settings_local_dataso
     as _i116;
 import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
     as _i118;
-import '../../features/sync/application/sync_cubit.dart' as _i242;
+import '../../features/sync/application/sync_cubit.dart' as _i165;
 import '../../features/sync/domain/repositories/sync_repository.dart' as _i123;
 import '../../features/sync/domain/services/distributed_storage_service.dart'
-    as _i156;
+    as _i158;
 import '../../features/sync/domain/services/node_discovery_service.dart'
     as _i94;
-import '../../features/sync/domain/services/sync_service.dart' as _i220;
+import '../../features/sync/domain/services/sync_service.dart' as _i125;
 import '../../features/sync/domain/usecases/distributed_cache_usecase.dart'
-    as _i239;
+    as _i240;
 import '../../features/sync/infrastructure/datasources/filecoin_datasource.dart'
     as _i38;
 import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
@@ -441,46 +441,46 @@ import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
 import '../../features/sync/infrastructure/repositories/sync_repository_impl.dart'
     as _i124;
 import '../../features/sync/infrastructure/services/fhir_client.dart' as _i36;
-import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i157;
+import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i159;
 import '../../features/sync/infrastructure/services/node_discovery_service.dart'
     as _i95;
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
-    as _i221;
-import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i222;
-import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
-    as _i125;
-import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
     as _i126;
-import '../../features/user_profile/domain/services/user_profile_service.dart'
-    as _i128;
-import '../../features/user_profile/domain/usecases/get_user_profile_usecase.dart'
-    as _i178;
-import '../../features/user_profile/domain/usecases/save_user_profile_usecase.dart'
-    as _i211;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i223;
+import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
     as _i127;
-import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i224;
-import '../../features/vitals/application/vitals_cubit.dart' as _i133;
-import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i131;
-import '../../features/vitals/domain/usecases/get_all_vital_signs_usecase.dart'
-    as _i166;
-import '../../features/vitals/domain/usecases/save_vital_signs_usecase.dart'
-    as _i212;
-import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
-    as _i132;
-import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i225;
-import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
-    as _i134;
-import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
-    as _i169;
-import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
+import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
+    as _i128;
+import '../../features/user_profile/domain/services/user_profile_service.dart'
+    as _i130;
+import '../../features/user_profile/domain/usecases/get_user_profile_usecase.dart'
+    as _i181;
+import '../../features/user_profile/domain/usecases/save_user_profile_usecase.dart'
     as _i214;
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+    as _i129;
+import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i225;
+import '../../features/vitals/application/vitals_cubit.dart' as _i135;
+import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
+    as _i133;
+import '../../features/vitals/domain/usecases/get_all_vital_signs_usecase.dart'
+    as _i169;
+import '../../features/vitals/domain/usecases/save_vital_signs_usecase.dart'
+    as _i215;
+import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
+    as _i134;
+import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i226;
+import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
+    as _i136;
+import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
+    as _i171;
+import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
+    as _i217;
 import '../../features/voice_chat/infrastructure/datasources/chat_ai_datasource.dart'
     as _i24;
 import '../../features/voice_chat/infrastructure/repositories/voice_chat_repository_impl.dart'
-    as _i135;
+    as _i137;
 import '../services/aicore_service.dart' as _i3;
 import '../services/asr/asr_service.dart' as _i11;
 import '../services/audio/audio_player_service.dart' as _i12;
@@ -582,12 +582,13 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i47.HealthSharingLocalDataSource>(
         () => _i47.HealthSharingLocalDataSource());
     gh.lazySingleton<_i48.HealthSharingRemoteDataSource>(
-        () => _i48.HealthSharingRemoteDataSource());
+        () => _i48.HealthSharingRemoteDataSource(gh<_i30.Dio>()));
     gh.factory<_i49.HealthSummaryDatasource>(
         () => _i49.HealthSummaryDatasource());
     gh.factory<_i50.HomeLocalDataSource>(
         () => _i50.HomeLocalDataSource(gh<_i51.SharedPreferences>()));
-    gh.factory<_i52.HomeRemoteDataSource>(() => _i52.HomeRemoteDataSource());
+    gh.factory<_i52.HomeRemoteDataSource>(
+        () => _i52.HomeRemoteDataSource(gh<_i30.Dio>()));
     gh.lazySingleton<_i53.IAboutRepository>(
         () => _i54.AboutRepositoryImpl(gh<_i4.AboutLocalDataSource>()));
     gh.lazySingleton<_i55.ImagePickerService>(
@@ -610,12 +611,12 @@ extension GetItInjectableX on _i1.GetIt {
         _i62.LicenseVerifier(
             await getAsync<_i61.LicenseRegistryLocalDataSource>()));
     gh.lazySingleton<_i63.LlmAdapter>(
-      () => _i64.FlutterGemmaAdapter(wrapper: gh<_i40.FlutterGemmaWrapper>()),
-      instanceName: 'gemma',
+      () => _i64.OpenaiCompatibleAdapter(),
+      instanceName: 'openai',
     );
     gh.lazySingleton<_i63.LlmAdapter>(
-      () => _i65.OpenaiCompatibleAdapter(),
-      instanceName: 'openai',
+      () => _i65.FlutterGemmaAdapter(wrapper: gh<_i40.FlutterGemmaWrapper>()),
+      instanceName: 'gemma',
     );
     gh.lazySingleton<_i66.LocalLlmService>(() => _i66.LocalLlmService());
     gh.lazySingleton<_i67.LocalModelLocalDataSource>(
@@ -623,15 +624,15 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i68.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
     gh.factory<_i69.MedicalKnowledgeRepository>(
-      () => _i70.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
-    );
-    gh.factory<_i69.MedicalKnowledgeRepository>(
-      () => _i71.JsonMedicalKnowledgeRepository(),
+      () => _i70.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
+    );
+    gh.factory<_i69.MedicalKnowledgeRepository>(
+      () => _i71.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
     );
     gh.lazySingleton<_i72.MedicalScraperService>(
         () => _i73.MedicalScraperServiceImpl(
@@ -663,7 +664,7 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i84.ModelDownloadService>(
         () => _i84.ModelDownloadService());
     gh.lazySingleton<_i85.NetworkDatasource>(
-        () => _i85.NetworkDatasourceImpl());
+        () => _i85.NetworkDatasourceImpl(gh<_i30.Dio>()));
     gh.lazySingleton<_i86.NetworkP2PApi>(() => _i86.NetworkP2PApiImpl());
     gh.lazySingleton<_i87.NetworkPeerRepository>(
         () => _i88.NetworkPeerRepositoryImpl(gh<_i60.Isar>()));
@@ -727,356 +728,356 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i94.NodeDiscoveryService>(),
         ));
     gh.lazySingleton<_i68.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i125.UserProfileLocalDataSource>(
-        () => _i125.UserProfileLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i126.UserProfileRepository>(
-        () => _i127.UserProfileRepositoryImpl(gh<_i60.Isar>()));
-    gh.lazySingleton<_i128.UserProfileService>(
-        () => _i128.UserProfileService(gh<_i126.UserProfileRepository>()));
-    gh.lazySingleton<_i129.VectorStoreService>(
-        () => _i130.IsarVectorStoreService(
+    gh.lazySingleton<_i125.SyncService>(() => _i126.SyncServiceImpl(
+          gh<_i123.SyncRepository>(),
+          gh<_i68.SyncService>(),
+        ));
+    gh.lazySingleton<_i127.UserProfileLocalDataSource>(
+        () => _i127.UserProfileLocalDataSource(gh<_i60.Isar>()));
+    gh.lazySingleton<_i128.UserProfileRepository>(
+        () => _i129.UserProfileRepositoryImpl(gh<_i60.Isar>()));
+    gh.lazySingleton<_i130.UserProfileService>(
+        () => _i130.UserProfileService(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i131.VectorStoreService>(
+        () => _i132.IsarVectorStoreService(
               gh<_i33.MemoryGraph>(),
               gh<_i69.MedicalKnowledgeRepository>(),
             ));
-    gh.lazySingleton<_i131.VitalSignRepository>(
-        () => _i132.VitalSignRepositoryImpl(gh<_i60.Isar>()));
-    gh.factory<_i133.VitalsCubit>(
-        () => _i133.VitalsCubit(gh<_i131.VitalSignRepository>()));
-    gh.lazySingleton<_i134.VoiceChatRepository>(
-        () => _i135.VoiceChatRepositoryImpl(gh<_i24.ChatAiDatasource>()));
-    gh.lazySingleton<_i136.VouchRepository>(
-        () => _i137.IsarVouchRepository(gh<_i60.Isar>()));
+    gh.lazySingleton<_i133.VitalSignRepository>(
+        () => _i134.VitalSignRepositoryImpl(gh<_i60.Isar>()));
+    gh.factory<_i135.VitalsCubit>(
+        () => _i135.VitalsCubit(gh<_i133.VitalSignRepository>()));
+    gh.lazySingleton<_i136.VoiceChatRepository>(
+        () => _i137.VoiceChatRepositoryImpl(gh<_i24.ChatAiDatasource>()));
+    gh.lazySingleton<_i138.VouchRepository>(
+        () => _i139.IsarVouchRepository(gh<_i60.Isar>()));
     gh.lazySingleton<_i35.WalletService>(() => databaseModule.walletService(
           gh<_i60.Isar>(),
           gh<_i35.EncryptionService>(),
         ));
-    gh.lazySingleton<_i138.WifiDirectService>(() => _i138.WifiDirectService());
-    gh.factory<_i139.AboutCubit>(
-        () => _i139.AboutCubit(gh<_i53.IAboutRepository>()));
-    gh.lazySingleton<_i140.AboutRemoteDataSource>(
-        () => _i140.AboutRemoteDataSource(gh<_i30.Dio>()));
-    gh.lazySingleton<_i141.AllergyLocalDataSource>(
-        () => _i141.AllergyLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i142.AllergyRepository>(
-        () => _i143.AllergyRepositoryImpl(gh<_i141.AllergyLocalDataSource>()));
-    gh.lazySingleton<_i144.AuthLocalDataSource>(
-        () => _i144.AuthLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i145.AuthRepository>(
-        () => _i146.AuthRepositoryImpl(gh<_i144.AuthLocalDataSource>()));
-    gh.lazySingleton<_i147.AuthService>(
-        () => _i147.AuthServiceImpl(gh<_i34.EncryptionService>()));
-    gh.lazySingleton<_i148.BleSharingService>(
-        () => _i148.BleSharingService(gh<_i16.BleWrapper>()));
-    gh.lazySingleton<_i149.CancelSharingUseCase>(
-        () => _i149.CancelSharingUseCase(
-              gh<_i148.BleSharingService>(),
+    gh.lazySingleton<_i140.WifiDirectService>(() => _i140.WifiDirectService());
+    gh.factory<_i141.AboutCubit>(
+        () => _i141.AboutCubit(gh<_i53.IAboutRepository>()));
+    gh.lazySingleton<_i142.AboutRemoteDataSource>(
+        () => _i142.AboutRemoteDataSource(gh<_i30.Dio>()));
+    gh.lazySingleton<_i143.AllergyLocalDataSource>(
+        () => _i143.AllergyLocalDataSource(gh<_i60.Isar>()));
+    gh.lazySingleton<_i144.AllergyRepository>(
+        () => _i145.AllergyRepositoryImpl(gh<_i143.AllergyLocalDataSource>()));
+    gh.lazySingleton<_i146.AuthLocalDataSource>(
+        () => _i146.AuthLocalDataSource(gh<_i60.Isar>()));
+    gh.lazySingleton<_i147.AuthRepository>(
+        () => _i148.AuthRepositoryImpl(gh<_i146.AuthLocalDataSource>()));
+    gh.lazySingleton<_i149.AuthService>(
+        () => _i149.AuthServiceImpl(gh<_i34.EncryptionService>()));
+    gh.lazySingleton<_i150.BleSharingService>(
+        () => _i150.BleSharingService(gh<_i16.BleWrapper>()));
+    gh.lazySingleton<_i151.CancelSharingUseCase>(
+        () => _i151.CancelSharingUseCase(
+              gh<_i150.BleSharingService>(),
               gh<_i93.NfcSharingService>(),
-              gh<_i138.WifiDirectService>(),
+              gh<_i140.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i150.ChatMessageLocalDataSource>(
-        () => _i150.ChatMessageLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i151.CompleteSessionUseCase>(
-        () => _i151.CompleteSessionUseCase(gh<_i81.MeditationRepository>()));
+    gh.lazySingleton<_i152.ChatMessageLocalDataSource>(
+        () => _i152.ChatMessageLocalDataSource(gh<_i60.Isar>()));
+    gh.lazySingleton<_i153.CompleteSessionUseCase>(
+        () => _i153.CompleteSessionUseCase(gh<_i81.MeditationRepository>()));
     gh.factory<_i122.ConnectEmailProviderUseCase>(
         () => _i122.ConnectEmailProviderUseCase(gh<_i31.EmailRepository>()));
-    gh.lazySingleton<_i152.ConnectNode>(
-        () => _i152.ConnectNode(gh<_i89.NetworkRepository>()));
-    gh.factory<_i153.ConnectProviderUseCase>(() => _i153.ConnectProviderUseCase(
+    gh.lazySingleton<_i154.ConnectNode>(
+        () => _i154.ConnectNode(gh<_i89.NetworkRepository>()));
+    gh.factory<_i155.ConnectProviderUseCase>(() => _i155.ConnectProviderUseCase(
           gh<_i97.OAuthRepository>(),
-          gh<_i126.UserProfileRepository>(),
+          gh<_i128.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i154.DashboardLocalDataSource>(
-        () => _i154.DashboardLocalDataSource(gh<_i60.Isar>()));
-    gh.factory<_i155.DisconnectProviderUseCase>(
-        () => _i155.DisconnectProviderUseCase(
+    gh.lazySingleton<_i156.DashboardLocalDataSource>(
+        () => _i156.DashboardLocalDataSource(gh<_i60.Isar>()));
+    gh.factory<_i157.DisconnectProviderUseCase>(
+        () => _i157.DisconnectProviderUseCase(
               gh<_i97.OAuthRepository>(),
-              gh<_i126.UserProfileRepository>(),
+              gh<_i128.UserProfileRepository>(),
             ));
-    gh.lazySingleton<_i156.DistributedStorageService>(() => _i157.IpfsService(
+    gh.lazySingleton<_i158.DistributedStorageService>(() => _i159.IpfsService(
           gh<_i59.IpfsDatasource>(),
           gh<_i38.FilecoinDatasource>(),
         ));
-    gh.lazySingleton<_i158.DoctorProfileRepository>(
-        () => _i159.IsarDoctorProfileRepository(gh<_i60.Isar>()));
-    gh.factoryAsync<_i160.DoctorVerificationCubit>(
-        () async => _i160.DoctorVerificationCubit(
-              gh<_i158.DoctorProfileRepository>(),
+    gh.lazySingleton<_i160.DoctorProfileRepository>(
+        () => _i161.IsarDoctorProfileRepository(gh<_i60.Isar>()));
+    gh.factoryAsync<_i162.DoctorVerificationCubit>(
+        () async => _i162.DoctorVerificationCubit(
+              gh<_i160.DoctorProfileRepository>(),
               gh<_i103.RatingRepository>(),
               await getAsync<_i62.LicenseVerifier>(),
             ));
-    gh.factory<_i161.EmailCitasBloc>(() => _i161.EmailCitasBloc(
+    gh.factory<_i163.EmailCitasBloc>(() => _i163.EmailCitasBloc(
           gh<_i122.ConnectEmailProviderUseCase>(),
           gh<_i122.SyncEmailAppointmentsUseCase>(),
           gh<_i31.EmailRepository>(),
           gh<_i8.AppointmentRepository>(),
         ));
-    gh.factory<_i162.EmailCitasCubit>(() => _i162.EmailCitasCubit(
+    gh.factory<_i164.EmailCitasCubit>(() => _i164.EmailCitasCubit(
           gh<_i31.EmailRepository>(),
           gh<_i8.AppointmentRepository>(),
+        ));
+    gh.factory<_i165.FhirSyncCubit>(() => _i165.FhirSyncCubit(
+          gh<_i125.SyncService>(),
+          gh<_i94.NodeDiscoveryService>(),
         ));
     gh.lazySingleton<_i115.FileHealthDataSource>(
         () => _i115.FileHealthDataSourceImpl(
               gh<_i37.FilePickerService>(),
               gh<_i99.OcrService>(),
             ));
-    gh.lazySingleton<_i163.FileImportDataSource>(
-        () => _i163.FileImportDataSourceImpl(
+    gh.lazySingleton<_i166.FileImportDataSource>(
+        () => _i166.FileImportDataSourceImpl(
               gh<_i37.FilePickerService>(),
               gh<_i99.OcrService>(),
             ));
-    gh.factory<_i164.GetAboutInfoUseCase>(
-        () => _i164.GetAboutInfoUseCase(gh<_i53.IAboutRepository>()));
-    gh.factory<_i165.GetAllDoctorsUseCase>(
-        () => _i165.GetAllDoctorsUseCase(gh<_i158.DoctorProfileRepository>()));
-    gh.factory<_i166.GetAllVitalSignsUseCase>(
-        () => _i166.GetAllVitalSignsUseCase(gh<_i131.VitalSignRepository>()));
-    gh.factory<_i167.GetAllergiesUseCase>(
-        () => _i167.GetAllergiesUseCase(gh<_i142.AllergyRepository>()));
+    gh.factory<_i167.GetAboutInfoUseCase>(
+        () => _i167.GetAboutInfoUseCase(gh<_i53.IAboutRepository>()));
+    gh.factory<_i168.GetAllDoctorsUseCase>(
+        () => _i168.GetAllDoctorsUseCase(gh<_i160.DoctorProfileRepository>()));
+    gh.factory<_i169.GetAllVitalSignsUseCase>(
+        () => _i169.GetAllVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i170.GetAllergiesUseCase>(
+        () => _i170.GetAllergiesUseCase(gh<_i144.AllergyRepository>()));
     gh.factory<_i108.GetAvailableSourcesUseCase>(() =>
         _i108.GetAvailableSourcesUseCase(gh<_i46.HealthDataImportService>()));
-    gh.factory<_i168.GetChatHistoryUseCase>(
-        () => _i168.GetChatHistoryUseCase(gh<_i129.VectorStoreService>()));
-    gh.factory<_i169.GetChatHistoryUseCase>(
-        () => _i169.GetChatHistoryUseCase(gh<_i134.VoiceChatRepository>()));
-    gh.factory<_i170.GetConnectionsUseCase>(
-        () => _i170.GetConnectionsUseCase(gh<_i97.OAuthRepository>()));
-    gh.factory<_i171.GetCredentialsUseCase>(
-        () => _i171.GetCredentialsUseCase(gh<_i145.AuthRepository>()));
-    gh.factory<_i172.GetDoctorProfileUseCase>(() =>
-        _i172.GetDoctorProfileUseCase(gh<_i158.DoctorProfileRepository>()));
-    gh.lazySingleton<_i173.GetNetworkHealth>(
-        () => _i173.GetNetworkHealth(gh<_i89.NetworkRepository>()));
-    gh.lazySingleton<_i174.GetNodeStats>(
-        () => _i174.GetNodeStats(gh<_i89.NetworkRepository>()));
-    gh.lazySingleton<_i175.GetProgressUseCase>(
-        () => _i175.GetProgressUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i176.GetReportsUseCase>(
-        () => _i176.GetReportsUseCase(gh<_i106.ReportRepository>()));
-    gh.lazySingleton<_i177.GetScriptsUseCase>(
-        () => _i177.GetScriptsUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i178.GetUserProfileUseCase>(
-        () => _i178.GetUserProfileUseCase(gh<_i126.UserProfileRepository>()));
-    gh.lazySingleton<_i179.GovernanceIpfsDatasource>(
-        () => _i179.GovernanceIpfsDatasource(gh<_i59.IpfsDatasource>()));
-    gh.lazySingleton<_i180.GovernanceRepository>(() =>
-        _i181.GovernanceRepositoryImpl(gh<_i179.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i182.HealthDataImportRepository>(
-        () => _i183.HealthDataImportRepositoryImpl(
+    gh.factory<_i171.GetChatHistoryUseCase>(
+        () => _i171.GetChatHistoryUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i172.GetChatHistoryUseCase>(
+        () => _i172.GetChatHistoryUseCase(gh<_i131.VectorStoreService>()));
+    gh.factory<_i173.GetConnectionsUseCase>(
+        () => _i173.GetConnectionsUseCase(gh<_i97.OAuthRepository>()));
+    gh.factory<_i174.GetCredentialsUseCase>(
+        () => _i174.GetCredentialsUseCase(gh<_i147.AuthRepository>()));
+    gh.factory<_i175.GetDoctorProfileUseCase>(() =>
+        _i175.GetDoctorProfileUseCase(gh<_i160.DoctorProfileRepository>()));
+    gh.lazySingleton<_i176.GetNetworkHealth>(
+        () => _i176.GetNetworkHealth(gh<_i89.NetworkRepository>()));
+    gh.lazySingleton<_i177.GetNodeStats>(
+        () => _i177.GetNodeStats(gh<_i89.NetworkRepository>()));
+    gh.lazySingleton<_i178.GetProgressUseCase>(
+        () => _i178.GetProgressUseCase(gh<_i81.MeditationRepository>()));
+    gh.factory<_i179.GetReportsUseCase>(
+        () => _i179.GetReportsUseCase(gh<_i106.ReportRepository>()));
+    gh.lazySingleton<_i180.GetScriptsUseCase>(
+        () => _i180.GetScriptsUseCase(gh<_i81.MeditationRepository>()));
+    gh.factory<_i181.GetUserProfileUseCase>(
+        () => _i181.GetUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i182.GovernanceIpfsDatasource>(
+        () => _i182.GovernanceIpfsDatasource(gh<_i59.IpfsDatasource>()));
+    gh.lazySingleton<_i183.GovernanceRepository>(() =>
+        _i184.GovernanceRepositoryImpl(gh<_i182.GovernanceIpfsDatasource>()));
+    gh.lazySingleton<_i185.HealthDataImportRepository>(
+        () => _i186.HealthDataImportRepositoryImpl(
               gh<_i115.SensorHealthDataSource>(),
               gh<_i115.FileHealthDataSource>(),
             ));
-    gh.lazySingleton<_i184.HealthRecordRepository>(
-        () => _i185.HealthRecordRepositoryImpl(gh<_i60.Isar>()));
-    gh.factory<_i186.ImportCalendarUseCase>(() => _i186.ImportCalendarUseCase(
+    gh.lazySingleton<_i187.HealthRecordRepository>(
+        () => _i188.HealthRecordRepositoryImpl(gh<_i60.Isar>()));
+    gh.factory<_i189.ImportCalendarUseCase>(() => _i189.ImportCalendarUseCase(
           gh<_i20.CalendarImportRepository>(),
           gh<_i8.AppointmentRepository>(),
-          gh<_i126.UserProfileRepository>(),
+          gh<_i128.UserProfileRepository>(),
         ));
     gh.factory<_i108.ImportHealthDataUseCase>(
         () => _i108.ImportHealthDataUseCase(
               gh<_i46.HealthDataImportService>(),
-              gh<_i131.VitalSignRepository>(),
+              gh<_i133.VitalSignRepository>(),
             ));
     gh.lazySingleton<_i63.LlmAdapter>(
-      () => _i187.GeminiLlmAdapter(
+      () => _i190.GeminiLlmAdapter(
         scrubber: gh<_i102.PromptScrubber>(),
-        userProfileRepository: gh<_i126.UserProfileRepository>(),
+        userProfileRepository: gh<_i128.UserProfileRepository>(),
         modelWrapper: gh<_i42.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
     );
     gh.factory<_i63.LlmAdapter>(
-      () => _i188.MockLlmAdapter(gh<_i102.PromptScrubber>()),
+      () => _i191.MockLlmAdapter(gh<_i102.PromptScrubber>()),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i189.LlmAdapterFactory>(
-        () => _i189.LlmAdapterFactory(gh<_i117.SettingsRepository>()));
-    gh.lazySingleton<_i190.LlmService>(() => _i191.GemmaLlmService(
-          gh<_i129.VectorStoreService>(),
-          gh<_i126.UserProfileRepository>(),
+    gh.lazySingleton<_i192.LlmAdapterFactory>(
+        () => _i192.LlmAdapterFactory(gh<_i117.SettingsRepository>()));
+    gh.lazySingleton<_i193.LlmService>(() => _i194.GemmaLlmService(
+          gh<_i131.VectorStoreService>(),
+          gh<_i128.UserProfileRepository>(),
           gh<_i63.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i192.LlmSettingsCubit>(() => _i192.LlmSettingsCubit(
+    gh.factory<_i195.LlmSettingsCubit>(() => _i195.LlmSettingsCubit(
           gh<_i117.SettingsRepository>(),
           gh<_i28.DeviceCapabilityService>(),
           gh<_i63.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i193.LoginUseCase>(() => _i193.LoginUseCase(
-          gh<_i145.AuthRepository>(),
+    gh.factory<_i196.LoginUseCase>(() => _i196.LoginUseCase(
+          gh<_i147.AuthRepository>(),
           gh<_i34.EncryptionService>(),
           gh<_i15.BiometricService>(),
         ));
-    gh.factory<_i194.LogoutUseCase>(
-        () => _i194.LogoutUseCase(gh<_i145.AuthRepository>()));
-    gh.lazySingleton<_i195.MedicalResearchService>(
-        () => _i195.MedicalResearchService(
+    gh.factory<_i197.LogoutUseCase>(
+        () => _i197.LogoutUseCase(gh<_i147.AuthRepository>()));
+    gh.lazySingleton<_i198.MedicalResearchService>(
+        () => _i198.MedicalResearchService(
               gh<_i76.MedicalWebSearchService>(),
               gh<_i72.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i196.MedicationRepository>(
-        () => _i197.IsarMedicationRepository(
+    gh.lazySingleton<_i199.MedicationRepository>(
+        () => _i200.IsarMedicationRepository(
               gh<_i60.Isar>(),
               gh<_i100.PharmacyApiService>(),
             ));
-    gh.factory<_i198.MedicationsCubit>(
-        () => _i198.MedicationsCubit(gh<_i196.MedicationRepository>()));
-    gh.factory<_i199.MeditationCubit>(() => _i199.MeditationCubit(
+    gh.factory<_i201.MedicationsCubit>(
+        () => _i201.MedicationsCubit(gh<_i199.MedicationRepository>()));
+    gh.factory<_i202.MeditationCubit>(() => _i202.MeditationCubit(
           gh<_i105.RecommendScriptUseCase>(),
           gh<_i121.StartSessionUseCase>(),
-          gh<_i151.CompleteSessionUseCase>(),
-          gh<_i175.GetProgressUseCase>(),
+          gh<_i153.CompleteSessionUseCase>(),
+          gh<_i178.GetProgressUseCase>(),
           gh<_i12.AudioService>(),
         ));
-    gh.factory<_i200.NetworkCubit>(() => _i200.NetworkCubit(
+    gh.factory<_i203.NetworkCubit>(() => _i203.NetworkCubit(
           gh<_i87.NetworkPeerRepository>(),
           gh<_i86.NetworkP2PApi>(),
         ));
-    gh.factory<_i201.NetworkHealthCubit>(() => _i201.NetworkHealthCubit(
-          gh<_i173.GetNetworkHealth>(),
-          gh<_i152.ConnectNode>(),
+    gh.factory<_i204.NetworkHealthCubit>(() => _i204.NetworkHealthCubit(
+          gh<_i176.GetNetworkHealth>(),
+          gh<_i154.ConnectNode>(),
           gh<_i89.NetworkRepository>(),
         ));
-    gh.lazySingleton<_i202.OnboardingRepository>(() =>
-        _i203.OnboardingRepositoryImpl(gh<_i126.UserProfileRepository>()));
-    gh.lazySingleton<_i204.PatientContextIndexer>(
-      () => _i204.PatientContextIndexer(
+    gh.lazySingleton<_i205.OnboardingRepository>(() =>
+        _i206.OnboardingRepositoryImpl(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i207.PatientContextIndexer>(
+      () => _i207.PatientContextIndexer(
         gh<_i60.Isar>(),
-        gh<_i129.VectorStoreService>(),
-        gh<_i184.HealthRecordRepository>(),
-        gh<_i196.MedicationRepository>(),
-        gh<_i142.AllergyRepository>(),
-        gh<_i131.VitalSignRepository>(),
+        gh<_i131.VectorStoreService>(),
+        gh<_i187.HealthRecordRepository>(),
+        gh<_i199.MedicationRepository>(),
+        gh<_i144.AllergyRepository>(),
+        gh<_i133.VitalSignRepository>(),
         gh<_i8.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.lazySingleton<_i205.ReportGenerationService>(
-        () => _i206.GemmaReportGenerationService(
+    gh.lazySingleton<_i208.ReportGenerationService>(
+        () => _i209.GemmaReportGenerationService(
               gh<_i63.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i129.VectorStoreService>(),
-              gh<_i126.UserProfileRepository>(),
+              gh<_i131.VectorStoreService>(),
+              gh<_i128.UserProfileRepository>(),
               gh<_i102.PromptScrubber>(),
             ));
-    gh.factory<_i207.SaveAllergyUseCase>(
-        () => _i207.SaveAllergyUseCase(gh<_i142.AllergyRepository>()));
-    gh.factory<_i208.SaveCredentialsUseCase>(
-        () => _i208.SaveCredentialsUseCase(gh<_i145.AuthRepository>()));
-    gh.factory<_i209.SaveMedicationUseCase>(
-        () => _i209.SaveMedicationUseCase(gh<_i196.MedicationRepository>()));
-    gh.factory<_i210.SaveRecordUseCase>(
-        () => _i210.SaveRecordUseCase(gh<_i184.HealthRecordRepository>()));
-    gh.factory<_i211.SaveUserProfileUseCase>(
-        () => _i211.SaveUserProfileUseCase(gh<_i126.UserProfileRepository>()));
-    gh.factory<_i212.SaveVitalSignsUseCase>(
-        () => _i212.SaveVitalSignsUseCase(gh<_i131.VitalSignRepository>()));
-    gh.factory<_i213.SecondOpinionCubit>(
-        () => _i213.SecondOpinionCubit(gh<_i111.SecondOpinionRepository>()));
-    gh.factory<_i214.SendMessageUseCase>(
-        () => _i214.SendMessageUseCase(gh<_i134.VoiceChatRepository>()));
-    gh.factory<_i215.SetPinUseCase>(() => _i215.SetPinUseCase(
-          gh<_i145.AuthRepository>(),
+    gh.factory<_i210.SaveAllergyUseCase>(
+        () => _i210.SaveAllergyUseCase(gh<_i144.AllergyRepository>()));
+    gh.factory<_i211.SaveCredentialsUseCase>(
+        () => _i211.SaveCredentialsUseCase(gh<_i147.AuthRepository>()));
+    gh.factory<_i212.SaveMedicationUseCase>(
+        () => _i212.SaveMedicationUseCase(gh<_i199.MedicationRepository>()));
+    gh.factory<_i213.SaveRecordUseCase>(
+        () => _i213.SaveRecordUseCase(gh<_i187.HealthRecordRepository>()));
+    gh.factory<_i214.SaveUserProfileUseCase>(
+        () => _i214.SaveUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.factory<_i215.SaveVitalSignsUseCase>(
+        () => _i215.SaveVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i216.SecondOpinionCubit>(
+        () => _i216.SecondOpinionCubit(gh<_i111.SecondOpinionRepository>()));
+    gh.factory<_i217.SendMessageUseCase>(
+        () => _i217.SendMessageUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i218.SetPinUseCase>(() => _i218.SetPinUseCase(
+          gh<_i147.AuthRepository>(),
           gh<_i34.EncryptionService>(),
         ));
-    gh.lazySingleton<_i216.SmartSearchUseCase>(
-        () => _i216.SmartSearchUseCase(gh<_i129.VectorStoreService>()));
-    gh.lazySingleton<_i217.StartListeningUseCase>(
-        () => _i217.StartListeningUseCase(
-              gh<_i148.BleSharingService>(),
+    gh.lazySingleton<_i219.SmartSearchUseCase>(
+        () => _i219.SmartSearchUseCase(gh<_i131.VectorStoreService>()));
+    gh.lazySingleton<_i220.StartListeningUseCase>(
+        () => _i220.StartListeningUseCase(
+              gh<_i150.BleSharingService>(),
               gh<_i93.NfcSharingService>(),
-              gh<_i138.WifiDirectService>(),
+              gh<_i140.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i218.StartSharingUseCase>(() => _i218.StartSharingUseCase(
-          gh<_i148.BleSharingService>(),
+    gh.lazySingleton<_i221.StartSharingUseCase>(() => _i221.StartSharingUseCase(
+          gh<_i150.BleSharingService>(),
           gh<_i93.NfcSharingService>(),
-          gh<_i138.WifiDirectService>(),
+          gh<_i140.WifiDirectService>(),
         ));
-    gh.factory<_i219.SyncCubit>(() => _i219.SyncCubit(
+    gh.factory<_i222.SyncCubit>(() => _i222.SyncCubit(
           gh<_i68.SyncService>(),
-          gh<_i129.VectorStoreService>(),
+          gh<_i131.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i220.SyncService>(() => _i221.SyncServiceImpl(
-          gh<_i123.SyncRepository>(),
-          gh<_i68.SyncService>(),
-        ));
-    gh.factory<_i222.UserProfileCubit>(
-        () => _i222.UserProfileCubit(gh<_i126.UserProfileRepository>()));
-    gh.factory<_i223.ValidateSessionUseCase>(
-        () => _i223.ValidateSessionUseCase(gh<_i145.AuthRepository>()));
-    gh.factory<_i224.VitalSignBloc>(
-        () => _i224.VitalSignBloc(gh<_i131.VitalSignRepository>()));
-    gh.factory<_i225.VoiceChatCubit>(() => _i225.VoiceChatCubit(
-          gh<_i214.SendMessageUseCase>(),
-          gh<_i169.GetChatHistoryUseCase>(),
-          gh<_i134.VoiceChatRepository>(),
+    gh.factory<_i223.UserProfileCubit>(
+        () => _i223.UserProfileCubit(gh<_i128.UserProfileRepository>()));
+    gh.factory<_i224.ValidateSessionUseCase>(
+        () => _i224.ValidateSessionUseCase(gh<_i147.AuthRepository>()));
+    gh.factory<_i225.VitalSignBloc>(
+        () => _i225.VitalSignBloc(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i226.VoiceChatCubit>(() => _i226.VoiceChatCubit(
+          gh<_i217.SendMessageUseCase>(),
+          gh<_i171.GetChatHistoryUseCase>(),
+          gh<_i136.VoiceChatRepository>(),
           gh<_i12.AudioService>(),
         ));
-    gh.factory<_i226.VouchCubit>(
-        () => _i226.VouchCubit(gh<_i136.VouchRepository>()));
-    gh.factory<_i227.AllergiesCubit>(
-        () => _i227.AllergiesCubit(gh<_i142.AllergyRepository>()));
-    gh.factory<_i228.AllergyBloc>(
-        () => _i228.AllergyBloc(gh<_i142.AllergyRepository>()));
-    gh.factory<_i229.AuthCubit>(() => _i229.AuthCubit(gh<_i147.AuthService>()));
-    gh.factory<_i230.AuthCubit>(() => _i230.AuthCubit(
-          gh<_i145.AuthRepository>(),
+    gh.factory<_i227.VouchCubit>(
+        () => _i227.VouchCubit(gh<_i138.VouchRepository>()));
+    gh.factory<_i228.AllergiesCubit>(
+        () => _i228.AllergiesCubit(gh<_i144.AllergyRepository>()));
+    gh.factory<_i229.AllergyBloc>(
+        () => _i229.AllergyBloc(gh<_i144.AllergyRepository>()));
+    gh.factory<_i230.AuthCubit>(() => _i230.AuthCubit(gh<_i149.AuthService>()));
+    gh.factory<_i231.AuthCubit>(() => _i231.AuthCubit(
+          gh<_i147.AuthRepository>(),
           gh<_i15.BiometricService>(),
-          gh<_i193.LoginUseCase>(),
-          gh<_i194.LogoutUseCase>(),
-          gh<_i223.ValidateSessionUseCase>(),
-          gh<_i215.SetPinUseCase>(),
+          gh<_i196.LoginUseCase>(),
+          gh<_i197.LogoutUseCase>(),
+          gh<_i224.ValidateSessionUseCase>(),
+          gh<_i218.SetPinUseCase>(),
         ));
-    gh.lazySingleton<_i231.BadgeCalculator>(() => _i231.BadgeCalculator(
-          gh<_i158.DoctorProfileRepository>(),
+    gh.lazySingleton<_i232.BadgeCalculator>(() => _i232.BadgeCalculator(
+          gh<_i160.DoctorProfileRepository>(),
           gh<_i103.RatingRepository>(),
-          gh<_i136.VouchRepository>(),
+          gh<_i138.VouchRepository>(),
         ));
-    gh.factory<_i232.BadgeCubit>(
-        () => _i232.BadgeCubit(gh<_i231.BadgeCalculator>()));
-    gh.factory<_i233.CalendarImportCubit>(() => _i233.CalendarImportCubit(
+    gh.factory<_i233.BadgeCubit>(
+        () => _i233.BadgeCubit(gh<_i232.BadgeCalculator>()));
+    gh.factory<_i234.CalendarImportCubit>(() => _i234.CalendarImportCubit(
           gh<_i20.CalendarImportRepository>(),
-          gh<_i186.ImportCalendarUseCase>(),
+          gh<_i189.ImportCalendarUseCase>(),
         ));
-    gh.factory<_i234.CompleteOnboardingUseCase>(() =>
-        _i234.CompleteOnboardingUseCase(gh<_i202.OnboardingRepository>()));
-    gh.lazySingleton<_i235.DashboardRepository>(
-        () => _i236.DashboardRepositoryImpl(
+    gh.factory<_i235.CompleteOnboardingUseCase>(() =>
+        _i235.CompleteOnboardingUseCase(gh<_i205.OnboardingRepository>()));
+    gh.lazySingleton<_i236.DashboardRepository>(
+        () => _i237.DashboardRepositoryImpl(
               gh<_i26.DashboardRemoteDataSource>(),
-              gh<_i131.VitalSignRepository>(),
-              gh<_i196.MedicationRepository>(),
+              gh<_i133.VitalSignRepository>(),
+              gh<_i199.MedicationRepository>(),
               gh<_i106.ReportRepository>(),
             ));
-    gh.lazySingleton<_i237.DataSourceRepository>(
-        () => _i238.DataSourceRepositoryImpl(
+    gh.lazySingleton<_i238.DataSourceRepository>(
+        () => _i239.DataSourceRepositoryImpl(
               gh<_i114.SensorApiDataSource>(),
-              gh<_i163.FileImportDataSource>(),
+              gh<_i166.FileImportDataSource>(),
               gh<_i45.HealthConnectDataSource>(),
             ));
-    gh.lazySingleton<_i239.DistributedCacheUsecase>(() =>
-        _i239.DistributedCacheUsecase(gh<_i156.DistributedStorageService>()));
-    gh.factory<_i240.EpsConnectionBloc>(() => _i240.EpsConnectionBloc(
-          gh<_i170.GetConnectionsUseCase>(),
-          gh<_i153.ConnectProviderUseCase>(),
-          gh<_i155.DisconnectProviderUseCase>(),
+    gh.lazySingleton<_i240.DistributedCacheUsecase>(() =>
+        _i240.DistributedCacheUsecase(gh<_i158.DistributedStorageService>()));
+    gh.factory<_i241.EpsConnectionBloc>(() => _i241.EpsConnectionBloc(
+          gh<_i173.GetConnectionsUseCase>(),
+          gh<_i155.ConnectProviderUseCase>(),
+          gh<_i157.DisconnectProviderUseCase>(),
         ));
-    gh.factory<_i241.EpsConnectionCubit>(() => _i241.EpsConnectionCubit(
-          gh<_i170.GetConnectionsUseCase>(),
-          gh<_i153.ConnectProviderUseCase>(),
-          gh<_i155.DisconnectProviderUseCase>(),
-        ));
-    gh.factory<_i242.FhirSyncCubit>(() => _i242.FhirSyncCubit(
-          gh<_i220.SyncService>(),
-          gh<_i94.NodeDiscoveryService>(),
+    gh.factory<_i242.EpsConnectionCubit>(() => _i242.EpsConnectionCubit(
+          gh<_i173.GetConnectionsUseCase>(),
+          gh<_i155.ConnectProviderUseCase>(),
+          gh<_i157.DisconnectProviderUseCase>(),
         ));
     gh.factory<_i243.GetAllMedicationsUseCase>(
-        () => _i243.GetAllMedicationsUseCase(gh<_i196.MedicationRepository>()));
+        () => _i243.GetAllMedicationsUseCase(gh<_i199.MedicationRepository>()));
     gh.factory<_i244.GetAllRecordsUseCase>(
-        () => _i244.GetAllRecordsUseCase(gh<_i184.HealthRecordRepository>()));
+        () => _i244.GetAllRecordsUseCase(gh<_i187.HealthRecordRepository>()));
     gh.factory<_i245.GetDashboardStatsUseCase>(
-        () => _i245.GetDashboardStatsUseCase(gh<_i235.DashboardRepository>()));
+        () => _i245.GetDashboardStatsUseCase(gh<_i236.DashboardRepository>()));
     gh.factory<_i246.GetOnboardingProfileUseCase>(() =>
-        _i246.GetOnboardingProfileUseCase(gh<_i202.OnboardingRepository>()));
+        _i246.GetOnboardingProfileUseCase(gh<_i205.OnboardingRepository>()));
     gh.factory<_i247.GetRecentActivityUseCase>(
-        () => _i247.GetRecentActivityUseCase(gh<_i235.DashboardRepository>()));
+        () => _i247.GetRecentActivityUseCase(gh<_i236.DashboardRepository>()));
     gh.factory<_i248.HealthImportBloc>(() => _i248.HealthImportBloc(
           gh<_i108.GetAvailableSourcesUseCase>(),
           gh<_i108.RequestHealthAuthUseCase>(),
@@ -1088,25 +1089,25 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i108.ImportHealthDataUseCase>(),
         ));
     gh.factory<_i250.HealthRecordCubit>(() => _i250.HealthRecordCubit(
-          gh<_i184.HealthRecordRepository>(),
+          gh<_i187.HealthRecordRepository>(),
           gh<_i37.FilePickerService>(),
           gh<_i55.ImagePickerService>(),
           gh<_i99.OcrService>(),
-          gh<_i129.VectorStoreService>(),
+          gh<_i131.VectorStoreService>(),
         ));
     gh.lazySingleton<_i251.HomeRepository>(() => _i252.HomeRepositoryImpl(
-          gh<_i131.VitalSignRepository>(),
+          gh<_i133.VitalSignRepository>(),
           gh<_i8.AppointmentRepository>(),
-          gh<_i196.MedicationRepository>(),
+          gh<_i199.MedicationRepository>(),
           gh<_i50.HomeLocalDataSource>(),
           gh<_i52.HomeRemoteDataSource>(),
           gh<_i49.HealthSummaryDatasource>(),
         ));
-    gh.lazySingleton<_i190.LlmService>(
+    gh.lazySingleton<_i193.LlmService>(
       () => _i253.RagLlmService(
-        gh<_i129.VectorStoreService>(),
-        gh<_i195.MedicalResearchService>(),
-        gh<_i126.UserProfileRepository>(),
+        gh<_i131.VectorStoreService>(),
+        gh<_i198.MedicalResearchService>(),
+        gh<_i128.UserProfileRepository>(),
         gh<_i63.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
@@ -1114,31 +1115,31 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i254.MedicalIndexingService>(
         () => _i254.MedicalIndexingService(
               gh<_i69.MedicalKnowledgeRepository>(),
-              gh<_i129.VectorStoreService>(),
-              gh<_i204.PatientContextIndexer>(),
+              gh<_i131.VectorStoreService>(),
+              gh<_i207.PatientContextIndexer>(),
             ));
     gh.lazySingleton<_i255.MedicalResearchRepository>(
         () => _i256.MedicalResearchRepositoryImpl(
-              gh<_i195.MedicalResearchService>(),
+              gh<_i198.MedicalResearchService>(),
               gh<_i60.Isar>(),
             ));
     gh.factory<_i257.MedicationBloc>(
-        () => _i257.MedicationBloc(gh<_i196.MedicationRepository>()));
+        () => _i257.MedicationBloc(gh<_i199.MedicationRepository>()));
     gh.factory<_i258.OnboardingCubit>(
-        () => _i258.OnboardingCubit(gh<_i202.OnboardingRepository>()));
+        () => _i258.OnboardingCubit(gh<_i205.OnboardingRepository>()));
     gh.factory<_i259.ReportBloc>(() => _i259.ReportBloc(
           gh<_i106.ReportRepository>(),
-          gh<_i205.ReportGenerationService>(),
+          gh<_i208.ReportGenerationService>(),
         ));
     gh.factory<_i260.SearchMedicalResearch>(() =>
         _i260.SearchMedicalResearch(gh<_i255.MedicalResearchRepository>()));
     gh.factory<_i261.SharingCubit>(() => _i261.SharingCubit(
-          bleService: gh<_i148.BleSharingService>(),
+          bleService: gh<_i150.BleSharingService>(),
           nfcService: gh<_i93.NfcSharingService>(),
-          wifiService: gh<_i138.WifiDirectService>(),
-          startSharingUseCase: gh<_i218.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i217.StartListeningUseCase>(),
-          cancelSharingUseCase: gh<_i149.CancelSharingUseCase>(),
+          wifiService: gh<_i140.WifiDirectService>(),
+          startSharingUseCase: gh<_i221.StartSharingUseCase>(),
+          startListeningUseCase: gh<_i220.StartListeningUseCase>(),
+          cancelSharingUseCase: gh<_i151.CancelSharingUseCase>(),
           walletService: gh<_i35.WalletService>(),
           walletEncryption: gh<_i35.EncryptionService>(),
         ));
@@ -1147,7 +1148,7 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i247.GetRecentActivityUseCase>(),
         ));
     gh.factory<_i263.DataSourceCubit>(
-        () => _i263.DataSourceCubit(gh<_i237.DataSourceRepository>()));
+        () => _i263.DataSourceCubit(gh<_i238.DataSourceRepository>()));
     gh.factory<_i264.GetHealthSummaryUseCase>(
         () => _i264.GetHealthSummaryUseCase(gh<_i251.HomeRepository>()));
     gh.factory<_i265.GetResearchHistory>(

--- a/lib/features/dashboard/presentation/pages/home_dashboard_page.dart
+++ b/lib/features/dashboard/presentation/pages/home_dashboard_page.dart
@@ -10,6 +10,7 @@ import 'package:orionhealth_health/features/medications/presentation/pages/medic
 import 'package:orionhealth_health/features/reports/presentation/pages/reports_page.dart';
 import 'package:orionhealth_health/features/health_record/presentation/pages/timeline_page.dart';
 import 'package:orionhealth_health/features/medical_research/presentation/pages/medical_research_page.dart';
+import 'package:orionhealth_health/features/dashboard/presentation/widgets/dashboard_stats_card.dart';
 import 'package:orionhealth_health/features/dashboard/application/dashboard_cubit.dart';
 import 'package:orionhealth_health/features/dashboard/application/dashboard_state.dart';
 import 'package:orionhealth_health/features/dashboard/domain/entities/activity_item.dart';
@@ -72,6 +73,11 @@ class _HomeDashboardPageState extends State<HomeDashboardPage> {
                     padding: const EdgeInsets.all(16.0),
                     sliver: SliverList(
                       delegate: SliverChildListDelegate([
+                        KeyedSubtree(
+                          key: const Key('dashboard_stats_card'),
+                          child: DashboardStatsCard(stats: state.stats),
+                        ),
+                        const SizedBox(height: 24),
                         _buildQuickActionsHeader(context),
                         const SizedBox(height: 16),
                         _buildQuickActionsGrid(context),

--- a/lib/features/dashboard/presentation/widgets/dashboard_stats_card.dart
+++ b/lib/features/dashboard/presentation/widgets/dashboard_stats_card.dart
@@ -1,0 +1,121 @@
+import 'package:flutter/material.dart';
+import 'package:orionhealth_health/core/theme/cyber_theme.dart';
+import 'package:orionhealth_health/core/widgets/glassmorphic_card.dart';
+import '../../domain/entities/dashboard_stats.dart';
+
+class DashboardStatsCard extends StatelessWidget {
+  final DashboardStats stats;
+
+  const DashboardStatsCard({
+    super.key,
+    required this.stats,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassmorphicCard(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          children: [
+            const Row(
+              children: [
+                Icon(Icons.analytics, color: CyberTheme.primary, size: 20),
+                SizedBox(width: 8),
+                Expanded(
+                  child: Text(
+                    'RESUMEN DE SALUD',
+                    style: TextStyle(
+                      color: Colors.white,
+                      fontWeight: FontWeight.bold,
+                      letterSpacing: 1.2,
+                    ),
+                    overflow: TextOverflow.ellipsis,
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            Row(
+              mainAxisAlignment: MainAxisAlignment.spaceAround,
+              children: [
+                Expanded(
+                  child: _StatItem(
+                    label: 'Medicamentos',
+                    value: stats.totalMedications.toString(),
+                    icon: Icons.medication,
+                    color: Colors.orangeAccent,
+                  ),
+                ),
+                Expanded(
+                  child: _StatItem(
+                    label: 'Informes',
+                    value: stats.reportsCount.toString(),
+                    icon: Icons.description,
+                    color: CyberTheme.secondary,
+                  ),
+                ),
+                Expanded(
+                  child: _StatItem(
+                    label: 'Último Control',
+                    value: stats.lastVitalCheck != null
+                        ? _formatDate(stats.lastVitalCheck!)
+                        : 'N/A',
+                    icon: Icons.monitor_heart,
+                    color: Colors.redAccent,
+                  ),
+                ),
+              ],
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+
+  String _formatDate(DateTime date) {
+    return '${date.day}/${date.month}';
+  }
+}
+
+class _StatItem extends StatelessWidget {
+  final String label;
+  final String value;
+  final IconData icon;
+  final Color color;
+
+  const _StatItem({
+    required this.label,
+    required this.value,
+    required this.icon,
+    required this.color,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return Column(
+      children: [
+        Icon(icon, color: color, size: 28),
+        const SizedBox(height: 8),
+        Text(
+          value,
+          style: const TextStyle(
+            fontSize: 18,
+            fontWeight: FontWeight.bold,
+            color: Colors.white,
+          ),
+          textAlign: TextAlign.center,
+        ),
+        Text(
+          label,
+          style: const TextStyle(
+            fontSize: 10,
+            color: Colors.white70,
+          ),
+          textAlign: TextAlign.center,
+        ),
+      ],
+    );
+  }
+}

--- a/test/features/dashboard/presentation/pages/home_dashboard_page_test.dart
+++ b/test/features/dashboard/presentation/pages/home_dashboard_page_test.dart
@@ -90,7 +90,16 @@ void main() {
     await tester.pumpWidget(createWidgetUnderTest(DashboardLoaded(stats: stats, activities: activities)));
     await tester.pumpAndSettle();
 
+    expect(find.byKey(const Key('dashboard_stats_card')), findsOneWidget);
+
     expect(find.text('ORION HEALTH'), findsOneWidget);
+
+    expect(find.text('RESUMEN DE SALUD'), findsOneWidget);
+    expect(find.text('2'), findsOneWidget);
+    expect(find.text('1'), findsOneWidget);
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -1000));
+    await tester.pumpAndSettle();
 
     expect(find.text('Vital check activity'), findsOneWidget);
     expect(find.text('Medication activity'), findsOneWidget);
@@ -109,6 +118,9 @@ void main() {
     final stats = DashboardStats(totalMedications: 0, reportsCount: 0);
 
     await tester.pumpWidget(createWidgetUnderTest(DashboardLoaded(stats: stats, activities: const [])));
+    await tester.pumpAndSettle();
+
+    await tester.drag(find.byType(CustomScrollView), const Offset(0, -1000));
     await tester.pumpAndSettle();
 
     expect(find.text('No hay actividad reciente'), findsOneWidget);

--- a/test/features/dashboard/presentation/widgets/dashboard_stats_card_test.dart
+++ b/test/features/dashboard/presentation/widgets/dashboard_stats_card_test.dart
@@ -1,0 +1,72 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/dashboard/domain/entities/dashboard_stats.dart';
+import 'package:orionhealth_health/features/dashboard/presentation/widgets/dashboard_stats_card.dart';
+
+void main() {
+  group('DashboardStatsCard', () {
+    testWidgets('renders stats correctly with valid data', (WidgetTester tester) async {
+      final now = DateTime(2023, 10, 27);
+      final stats = DashboardStats(
+        totalMedications: 5,
+        reportsCount: 3,
+        lastVitalCheck: now,
+      );
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: DashboardStatsCard(stats: stats),
+          ),
+        ),
+      );
+
+      expect(find.text('RESUMEN DE SALUD'), findsOneWidget);
+      expect(find.text('5'), findsOneWidget);
+      expect(find.text('3'), findsOneWidget);
+      expect(find.text('27/10'), findsOneWidget);
+
+      expect(find.byIcon(Icons.medication), findsOneWidget);
+      expect(find.byIcon(Icons.description), findsOneWidget);
+      expect(find.byIcon(Icons.monitor_heart), findsOneWidget);
+    });
+
+    testWidgets('handles null and zero values correctly', (WidgetTester tester) async {
+      const stats = DashboardStats(
+        totalMedications: 0,
+        reportsCount: 0,
+        lastVitalCheck: null,
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DashboardStatsCard(stats: stats),
+          ),
+        ),
+      );
+
+      expect(find.text('0'), findsNWidgets(2));
+      expect(find.text('N/A'), findsOneWidget);
+    });
+
+    testWidgets('displays correct labels', (WidgetTester tester) async {
+      const stats = DashboardStats(
+        totalMedications: 1,
+        reportsCount: 1,
+      );
+
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: DashboardStatsCard(stats: stats),
+          ),
+        ),
+      );
+
+      expect(find.text('Medicamentos'), findsOneWidget);
+      expect(find.text('Informes'), findsOneWidget);
+      expect(find.text('Último Control'), findsOneWidget);
+    });
+  });
+}


### PR DESCRIPTION
Implemented the `DashboardStatsCard` widget to display a summary of health data (medications, reports, and last vital check) on the home dashboard. Added a new suite of widget tests to verify its rendering, icon/value display, and handling of empty or null states. Integrated the card into the `HomeDashboardPage` and updated existing dashboard tests to ensure compatibility with the new UI structure and scrolling requirements.

Fixes #1357

---
*PR created automatically by Jules for task [17226443161970862653](https://jules.google.com/task/17226443161970862653) started by @iberi22*