### PR TITLE
Implement ShareCard and Widget Tests for Health Sharing

### DIFF
--- a/lib/features/health_sharing/presentation/widgets/share_card.dart
+++ b/lib/features/health_sharing/presentation/widgets/share_card.dart
@@ -1,0 +1,127 @@
+import 'package:flutter/material.dart';
+import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../domain/entities/shared_health_package.dart';
+
+class ShareCard extends StatelessWidget {
+  final TransferMethod method;
+  final Set<DataCategory> categories;
+  final bool isSharing;
+  final double progress;
+  final String? statusMessage;
+  final VoidCallback onShare;
+  final VoidCallback onCancel;
+
+  const ShareCard({
+    super.key,
+    required this.method,
+    required this.categories,
+    this.isSharing = false,
+    this.progress = 0,
+    this.statusMessage,
+    required this.onShare,
+    required this.onCancel,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassmorphicCard(
+      child: Padding(
+        padding: const EdgeInsets.all(16.0),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.start,
+          mainAxisSize: MainAxisSize.min,
+          children: [
+            Row(
+              children: [
+                _buildMethodIcon(),
+                const SizedBox(width: 12),
+                Expanded(
+                  child: Column(
+                    crossAxisAlignment: CrossAxisAlignment.start,
+                    children: [
+                      Text(
+                        'Compartir vía ${method.displayName}',
+                        style: const TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white,
+                        ),
+                      ),
+                      Text(
+                        '${categories.length} categorías seleccionadas',
+                        style: TextStyle(
+                          fontSize: 14,
+                          color: Colors.white.withOpacity(0.7),
+                        ),
+                      ),
+                    ],
+                  ),
+                ),
+              ],
+            ),
+            const SizedBox(height: 16),
+            if (isSharing) ...[
+              Text(
+                statusMessage ?? 'Transferiendo...',
+                style: const TextStyle(color: Colors.white),
+              ),
+              const SizedBox(height: 8),
+              LinearProgressIndicator(value: progress),
+              const SizedBox(height: 16),
+              SizedBox(
+                width: double.infinity,
+                child: OutlinedButton(
+                  onPressed: onCancel,
+                  style: OutlinedButton.styleFrom(
+                    foregroundColor: Colors.white,
+                    side: const BorderSide(color: Colors.white24),
+                  ),
+                  child: const Text('Cancelar'),
+                ),
+              ),
+            ] else ...[
+              const Divider(color: Colors.white24),
+              const SizedBox(height: 8),
+              SizedBox(
+                width: double.infinity,
+                child: ElevatedButton.icon(
+                  onPressed: categories.isEmpty ? null : onShare,
+                  icon: const Icon(Icons.share),
+                  label: const Text('Compartir Ahora'),
+                  style: ElevatedButton.styleFrom(
+                    backgroundColor: Theme.of(context).primaryColor,
+                    foregroundColor: Colors.white,
+                  ),
+                ),
+              ),
+            ],
+          ],
+        ),
+      ),
+    );
+  }
+
+  Widget _buildMethodIcon() {
+    IconData iconData;
+    switch (method) {
+      case TransferMethod.nfc:
+        iconData = Icons.nfc;
+        break;
+      case TransferMethod.ble:
+        iconData = Icons.bluetooth;
+        break;
+      case TransferMethod.wifi:
+        iconData = Icons.wifi;
+        break;
+    }
+
+    return Container(
+      padding: const EdgeInsets.all(8),
+      decoration: BoxDecoration(
+        color: Colors.white.withOpacity(0.1),
+        shape: BoxShape.circle,
+      ),
+      child: Icon(iconData, color: Colors.white, size: 28),
+    );
+  }
+}

--- a/test/features/health_sharing/presentation/widgets/share_card_test.dart
+++ b/test/features/health_sharing/presentation/widgets/share_card_test.dart
@@ -1,0 +1,124 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
+import 'package:orionhealth_health/features/health_sharing/presentation/widgets/share_card.dart';
+
+void main() {
+  group('ShareCard Widget Tests', () {
+    testWidgets('should render correctly in inactive state', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ShareCard(
+              method: TransferMethod.nfc,
+              categories: const {DataCategory.labResults, DataCategory.vitalSigns},
+              isSharing: false,
+              onShare: () {},
+              onCancel: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Compartir vía NFC'), findsOneWidget);
+      expect(find.text('2 categorías seleccionadas'), findsOneWidget);
+      expect(find.text('Compartir Ahora'), findsOneWidget);
+      expect(find.byIcon(Icons.nfc), findsOneWidget);
+      expect(find.byType(LinearProgressIndicator), findsNothing);
+      expect(find.text('Cancelar'), findsNothing);
+    });
+
+    testWidgets('should render correctly in active sharing state', (tester) async {
+      const statusMsg = 'Enviando datos...';
+      const progress = 0.45;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ShareCard(
+              method: TransferMethod.ble,
+              categories: const {DataCategory.medications},
+              isSharing: true,
+              progress: progress,
+              statusMessage: statusMsg,
+              onShare: () {},
+              onCancel: () {},
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Compartir vía Bluetooth'), findsOneWidget);
+      expect(find.text(statusMsg), findsOneWidget);
+      expect(find.text('Cancelar'), findsOneWidget);
+
+      final progressIndicator = tester.widget<LinearProgressIndicator>(
+        find.byType(LinearProgressIndicator)
+      );
+      expect(progressIndicator.value, progress);
+
+      expect(find.text('Compartir Ahora'), findsNothing);
+    });
+
+    testWidgets('should call onShare when button is pressed', (tester) async {
+      bool shareCalled = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ShareCard(
+              method: TransferMethod.wifi,
+              categories: const {DataCategory.labResults},
+              isSharing: false,
+              onShare: () => shareCalled = true,
+              onCancel: () {},
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Compartir Ahora'));
+      expect(shareCalled, isTrue);
+    });
+
+    testWidgets('should call onCancel when cancel button is pressed', (tester) async {
+      bool cancelCalled = false;
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ShareCard(
+              method: TransferMethod.wifi,
+              categories: const {DataCategory.labResults},
+              isSharing: true,
+              onShare: () {},
+              onCancel: () => cancelCalled = true,
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Cancelar'));
+      expect(cancelCalled, isTrue);
+    });
+
+    testWidgets('should disable share button when no categories are selected', (tester) async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Scaffold(
+            body: ShareCard(
+              method: TransferMethod.nfc,
+              categories: const {},
+              isSharing: false,
+              onShare: () {},
+              onCancel: () {},
+            ),
+          ),
+        ),
+      );
+
+      final shareButton = tester.widget<ElevatedButton>(
+        find.widgetWithText(ElevatedButton, 'Compartir Ahora')
+      );
+      expect(shareButton.onPressed, isNull);
+    });
+  });
+}


### PR DESCRIPTION
Implemented the `ShareCard` widget to encapsulate health sharing UI logic and added a complete set of widget tests to verify its functionality, including state management for active/inactive sharing.

Fixes #1361

---
*PR created automatically by Jules for task [16487569155386784986](https://jules.google.com/task/16487569155386784986) started by @iberi22*