### PR TITLE
Add EpsStatusBadge widget and tests

### DIFF
--- a/lib/features/eps_connection/presentation/widgets/eps_status_badge.dart
+++ b/lib/features/eps_connection/presentation/widgets/eps_status_badge.dart
@@ -1,0 +1,64 @@
+import 'package:flutter/material.dart';
+
+enum EpsStatus { connected, disconnected, error }
+
+class EpsStatusBadge extends StatelessWidget {
+  final EpsStatus status;
+
+  const EpsStatusBadge({
+    super.key,
+    required this.status,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    final color = switch (status) {
+      EpsStatus.connected => Colors.green,
+      EpsStatus.disconnected => Colors.grey,
+      EpsStatus.error => Colors.red,
+    };
+
+    final icon = switch (status) {
+      EpsStatus.connected => Icons.check_circle,
+      EpsStatus.disconnected => Icons.info_outline,
+      EpsStatus.error => Icons.error_outline,
+    };
+
+    final label = switch (status) {
+      EpsStatus.connected => 'CONECTADO',
+      EpsStatus.disconnected => 'DESCONECTADO',
+      EpsStatus.error => 'ERROR',
+    };
+
+    return Container(
+      padding: const EdgeInsets.symmetric(horizontal: 12, vertical: 6),
+      decoration: BoxDecoration(
+        color: color.withValues(alpha: 0.1),
+        borderRadius: BorderRadius.circular(16),
+        border: Border.all(
+          color: color,
+          width: 1,
+        ),
+      ),
+      child: Row(
+        mainAxisSize: MainAxisSize.min,
+        children: [
+          Icon(
+            icon,
+            size: 16,
+            color: color,
+          ),
+          const SizedBox(width: 6),
+          Text(
+            label,
+            style: TextStyle(
+              color: color,
+              fontSize: 12,
+              fontWeight: FontWeight.bold,
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/test/features/eps_connection/presentation/widgets/eps_status_badge_test.dart
+++ b/test/features/eps_connection/presentation/widgets/eps_status_badge_test.dart
@@ -1,0 +1,79 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/eps_connection/presentation/widgets/eps_status_badge.dart';
+
+void main() {
+  group('EpsStatusBadge', () {
+    testWidgets('shows CONECTADO status correctly', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EpsStatusBadge(
+              status: EpsStatus.connected,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('CONECTADO'), findsOneWidget);
+      expect(find.byIcon(Icons.check_circle), findsOneWidget);
+
+      final container = tester.widget<Container>(
+        find.ancestor(
+          of: find.text('CONECTADO'),
+          matching: find.byType(Container),
+        ).first,
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, Colors.green);
+    });
+
+    testWidgets('shows DESCONECTADO status correctly', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EpsStatusBadge(
+              status: EpsStatus.disconnected,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('DESCONECTADO'), findsOneWidget);
+      expect(find.byIcon(Icons.info_outline), findsOneWidget);
+
+      final container = tester.widget<Container>(
+        find.ancestor(
+          of: find.text('DESCONECTADO'),
+          matching: find.byType(Container),
+        ).first,
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, Colors.grey);
+    });
+
+    testWidgets('shows ERROR status correctly', (tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: EpsStatusBadge(
+              status: EpsStatus.error,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('ERROR'), findsOneWidget);
+      expect(find.byIcon(Icons.error_outline), findsOneWidget);
+
+      final container = tester.widget<Container>(
+        find.ancestor(
+          of: find.text('ERROR'),
+          matching: find.byType(Container),
+        ).first,
+      );
+      final decoration = container.decoration as BoxDecoration;
+      expect(decoration.border!.top.color, Colors.red);
+    });
+  });
+}


### PR DESCRIPTION
Implementation of the EpsStatusBadge widget for the eps_connection feature, including widget tests to verify its rendering and state transitions.

Fixes #1379

---
*PR created automatically by Jules for task [15370667934068951428](https://jules.google.com/task/15370667934068951428) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new status badge for EPS connections with clear visual states for connected, disconnected, and error.
  * Each state shows a distinct icon, color, and Spanish label for easier at-a-glance status recognition.

* **Tests**
  * Added widget coverage to verify the badge renders the correct text, icon, and styling for each status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->