### PR TITLE
Sprint 8: Local Agent Status Card and Widget Tests

### DIFF
--- a/lib/features/local_agent/domain/entities/agent_status.dart
+++ b/lib/features/local_agent/domain/entities/agent_status.dart
@@ -1,0 +1,5 @@
+enum AgentStatus {
+  online,
+  offline,
+  busy,
+}

--- a/lib/features/local_agent/presentation/widgets/agent_status_card.dart
+++ b/lib/features/local_agent/presentation/widgets/agent_status_card.dart
@@ -1,0 +1,159 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../domain/entities/agent_status.dart';
+
+class AgentStatusCard extends StatefulWidget {
+  final String agentName;
+  final AgentStatus status;
+
+  const AgentStatusCard({
+    super.key,
+    required this.agentName,
+    required this.status,
+  });
+
+  @override
+  State<AgentStatusCard> createState() => _AgentStatusCardState();
+}
+
+class _AgentStatusCardState extends State<AgentStatusCard>
+    with SingleTickerProviderStateMixin {
+  late AnimationController _controller;
+  late Animation<double> _animation;
+
+  @override
+  void initState() {
+    super.initState();
+    _controller = AnimationController(
+      duration: const Duration(seconds: 2),
+      vsync: this,
+    );
+    _animation = Tween<double>(begin: 0.5, end: 1.0).animate(
+      CurvedAnimation(parent: _controller, curve: Curves.easeInOut),
+    );
+
+    if (widget.status != AgentStatus.offline) {
+      _controller.repeat(reverse: true);
+    }
+  }
+
+  @override
+  void didUpdateWidget(AgentStatusCard oldWidget) {
+    super.didUpdateWidget(oldWidget);
+    if (widget.status != oldWidget.status) {
+      if (widget.status == AgentStatus.offline) {
+        _controller.stop();
+      } else if (!_controller.isAnimating) {
+        _controller.repeat(reverse: true);
+      }
+    }
+  }
+
+  @override
+  void dispose() {
+    _controller.dispose();
+    super.dispose();
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final statusColor = _getStatusColor(widget.status);
+    final statusLabel = _getStatusLabel(widget.status);
+
+    return GlassmorphicCard(
+      child: Row(
+        children: [
+          Stack(
+            alignment: Alignment.center,
+            children: [
+              if (widget.status != AgentStatus.offline)
+                ScaleTransition(
+                  key: const Key('agent_status_pulse'),
+                  scale: _animation,
+                  child: Container(
+                    width: 12,
+                    height: 12,
+                    decoration: BoxDecoration(
+                      shape: BoxShape.circle,
+                      color: statusColor.withValues(alpha: 0.5),
+                    ),
+                  ),
+                ),
+              Container(
+                width: 8,
+                height: 8,
+                decoration: BoxDecoration(
+                  shape: BoxShape.circle,
+                  color: statusColor,
+                ),
+              ),
+            ],
+          ),
+          const SizedBox(width: 12),
+          Expanded(
+            child: Column(
+              crossAxisAlignment: CrossAxisAlignment.start,
+              mainAxisSize: MainAxisSize.min,
+              children: [
+                Text(
+                  widget.agentName,
+                  style: const TextStyle(
+                    color: Colors.white,
+                    fontWeight: FontWeight.bold,
+                    fontSize: 16,
+                  ),
+                ),
+                Text(
+                  statusLabel,
+                  style: TextStyle(
+                    color: statusColor,
+                    fontSize: 12,
+                  ),
+                ),
+              ],
+            ),
+          ),
+          Icon(
+            _getStatusIcon(widget.status),
+            color: Colors.white70,
+            size: 20,
+          ),
+        ],
+      ),
+    );
+  }
+
+  Color _getStatusColor(AgentStatus status) {
+    switch (status) {
+      case AgentStatus.online:
+        return AppColors.primary;
+      case AgentStatus.offline:
+        return Colors.grey;
+      case AgentStatus.busy:
+        return Colors.orangeAccent;
+    }
+  }
+
+  String _getStatusLabel(AgentStatus status) {
+    switch (status) {
+      case AgentStatus.online:
+        return 'En línea';
+      case AgentStatus.offline:
+        return 'Desconectado';
+      case AgentStatus.busy:
+        return 'En uso';
+    }
+  }
+
+  IconData _getStatusIcon(AgentStatus status) {
+    switch (status) {
+      case AgentStatus.online:
+        return Icons.check_circle_outline;
+      case AgentStatus.offline:
+        return Icons.cloud_off;
+      case AgentStatus.busy:
+        return Icons.hourglass_empty;
+    }
+  }
+}

--- a/test/features/local_agent/presentation/widgets/agent_status_card_test.dart
+++ b/test/features/local_agent/presentation/widgets/agent_status_card_test.dart
@@ -1,0 +1,125 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/core/theme/app_colors.dart';
+import 'package:orionhealth_health/features/local_agent/domain/entities/agent_status.dart';
+import 'package:orionhealth_health/features/local_agent/presentation/widgets/agent_status_card.dart';
+
+void main() {
+  group('AgentStatusCard Widget Tests', () {
+    testWidgets('renders agent name correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AgentStatusCard(
+              agentName: 'Orion Assistant',
+              status: AgentStatus.online,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Orion Assistant'), findsOneWidget);
+    });
+
+    testWidgets('displays correct label and color for online status',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AgentStatusCard(
+              agentName: 'Orion Assistant',
+              status: AgentStatus.online,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('En línea'), findsOneWidget);
+
+      final textWidget = tester.widget<Text>(find.text('En línea'));
+      expect(textWidget.style?.color, AppColors.primary);
+    });
+
+    testWidgets('displays correct label and color for offline status',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AgentStatusCard(
+              agentName: 'Orion Assistant',
+              status: AgentStatus.offline,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('Desconectado'), findsOneWidget);
+
+      final textWidget = tester.widget<Text>(find.text('Desconectado'));
+      expect(textWidget.style?.color, Colors.grey);
+    });
+
+    testWidgets('displays correct label and color for busy status',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AgentStatusCard(
+              agentName: 'Orion Assistant',
+              status: AgentStatus.busy,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.text('En uso'), findsOneWidget);
+
+      final textWidget = tester.widget<Text>(find.text('En uso'));
+      expect(textWidget.style?.color, Colors.orangeAccent);
+    });
+
+    testWidgets('shows scale animation for online status',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AgentStatusCard(
+              agentName: 'Orion Assistant',
+              status: AgentStatus.online,
+            ),
+          ),
+        ),
+      );
+
+      // Verify ScaleTransition is present
+      final finder = find.byKey(const Key('agent_status_pulse'));
+      expect(finder, findsOneWidget);
+
+      // Get initial scale
+      final scaleTransition = tester.widget<ScaleTransition>(finder);
+      final initialScale = scaleTransition.scale.value;
+
+      // Pump for some time
+      await tester.pump(const Duration(seconds: 1));
+
+      final midScale = scaleTransition.scale.value;
+      expect(midScale, isNot(initialScale));
+    });
+
+    testWidgets('does not show scale animation for offline status',
+        (WidgetTester tester) async {
+      await tester.pumpWidget(
+        const MaterialApp(
+          home: Scaffold(
+            body: AgentStatusCard(
+              agentName: 'Orion Assistant',
+              status: AgentStatus.offline,
+            ),
+          ),
+        ),
+      );
+
+      expect(find.byKey(const Key('agent_status_pulse')), findsNothing);
+    });
+  });
+}


### PR DESCRIPTION
This PR implements the AgentStatusCard widget and its corresponding widget tests for the local_agent feature.

Key changes:
- Defined `AgentStatus` enum (online, offline, busy).
- Implemented `AgentStatusCard` using `GlassmorphicCard` and `AppColors`.
- Added a pulsing scale animation for active agent states.
- Created widget tests covering name rendering, status label/color mapping, and animation behavior.
- Ensured consistent Spanish localization for status labels ("En línea", "Desconectado", "En uso").

Fixes #1378

---
*PR created automatically by Jules for task [6880825132410400430](https://jules.google.com/task/6880825132410400430) started by @iberi22*