### PR TITLE
[Sprint 8] Widget tests: settings profile section

### DIFF
--- a/lib/features/settings/presentation/widgets/profile_section.dart
+++ b/lib/features/settings/presentation/widgets/profile_section.dart
@@ -1,0 +1,108 @@
+import 'package:flutter/material.dart';
+import '../../../../core/theme/app_colors.dart';
+import '../../../../core/widgets/glassmorphic_card.dart';
+import '../../../user_profile/domain/entities/user_profile.dart';
+
+class ProfileSection extends StatelessWidget {
+  final UserProfile? userProfile;
+  final bool isDarkMode;
+  final VoidCallback? onEditPressed;
+  final ValueChanged<bool>? onDarkModeChanged;
+
+  const ProfileSection({
+    super.key,
+    this.userProfile,
+    required this.isDarkMode,
+    this.onEditPressed,
+    this.onDarkModeChanged,
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    return GlassmorphicCard(
+      padding: const EdgeInsets.all(16),
+      child: Column(
+        children: [
+          Row(
+            children: [
+              _buildAvatar(),
+              const SizedBox(width: 16),
+              Expanded(
+                child: Column(
+                  crossAxisAlignment: CrossAxisAlignment.start,
+                  children: [
+                    Text(
+                      userProfile?.name ?? 'Usuario',
+                      style: const TextStyle(
+                        fontSize: 18,
+                        fontWeight: FontWeight.bold,
+                        color: Colors.white,
+                      ),
+                    ),
+                    const SizedBox(height: 4),
+                    Text(
+                      userProfile?.email ?? 'Sin correo electrónico',
+                      style: const TextStyle(
+                        fontSize: 14,
+                        color: Colors.white70,
+                      ),
+                    ),
+                  ],
+                ),
+              ),
+              IconButton(
+                key: const Key('edit_profile_button'),
+                icon: const Icon(Icons.edit_outlined, color: AppColors.primary),
+                onPressed: onEditPressed,
+              ),
+            ],
+          ),
+          const SizedBox(height: 16),
+          const Divider(color: Colors.white12),
+          const SizedBox(height: 8),
+          Row(
+            mainAxisAlignment: MainAxisAlignment.spaceBetween,
+            children: [
+              const Row(
+                children: [
+                  Icon(Icons.dark_mode_outlined, color: AppColors.secondary, size: 20),
+                  const SizedBox(width: 12),
+                  Text(
+                    'Modo Oscuro',
+                    style: TextStyle(color: Colors.white, fontSize: 15),
+                  ),
+                ],
+              ),
+              Switch(
+                key: const Key('dark_mode_switch'),
+                value: isDarkMode,
+                onChanged: onDarkModeChanged,
+                activeColor: AppColors.primary,
+              ),
+            ],
+          ),
+        ],
+      ),
+    );
+  }
+
+  Widget _buildAvatar() {
+    final hasAvatar = userProfile?.avatarUrl != null && userProfile!.avatarUrl!.isNotEmpty;
+
+    return Container(
+      key: const Key('profile_avatar_container'),
+      width: 60,
+      height: 60,
+      decoration: BoxDecoration(
+        shape: BoxShape.circle,
+        border: Border.all(color: AppColors.primary.withValues(alpha: 0.5), width: 2),
+        image: DecorationImage(
+          image: hasAvatar
+            ? NetworkImage(userProfile!.avatarUrl!)
+            : const AssetImage('assets/images/user_placeholder.png') as ImageProvider,
+          fit: BoxFit.cover,
+        ),
+      ),
+    );
+  }
+}

--- a/test/features/settings/presentation/widgets/profile_section_test.dart
+++ b/test/features/settings/presentation/widgets/profile_section_test.dart
@@ -1,0 +1,154 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:orionhealth_health/features/settings/presentation/widgets/profile_section.dart';
+import 'package:orionhealth_health/features/user_profile/domain/entities/user_profile.dart';
+
+void main() {
+  Widget wrapWithMaterial(Widget child) {
+    return MaterialApp(
+      home: Scaffold(
+        body: child,
+      ),
+    );
+  }
+
+  group('ProfileSection Widget Tests', () {
+    final testProfile = UserProfile(
+      name: 'John Doe',
+      email: 'john.doe@example.com',
+    );
+
+    testWidgets('renders profile data correctly', (WidgetTester tester) async {
+      await tester.pumpWidget(wrapWithMaterial(
+        ProfileSection(
+          userProfile: testProfile,
+          isDarkMode: true,
+        ),
+      ));
+
+      expect(find.text('John Doe'), findsOneWidget);
+      expect(find.text('john.doe@example.com'), findsOneWidget);
+    });
+
+    testWidgets('triggers onEditPressed when edit button is tapped', (WidgetTester tester) async {
+      bool editPressed = false;
+      await tester.pumpWidget(wrapWithMaterial(
+        ProfileSection(
+          userProfile: testProfile,
+          isDarkMode: true,
+          onEditPressed: () => editPressed = true,
+        ),
+      ));
+
+      await tester.tap(find.byKey(const Key('edit_profile_button')));
+      expect(editPressed, isTrue);
+    });
+
+    testWidgets('triggers onDarkModeChanged when switch is toggled', (WidgetTester tester) async {
+      bool darkModeValue = false;
+      await tester.pumpWidget(wrapWithMaterial(
+        ProfileSection(
+          userProfile: testProfile,
+          isDarkMode: false,
+          onDarkModeChanged: (value) => darkModeValue = value,
+        ),
+      ));
+
+      await tester.tap(find.byKey(const Key('dark_mode_switch')));
+      await tester.pump();
+
+      expect(darkModeValue, isTrue);
+    });
+
+    testWidgets('shows placeholders when userProfile is null', (WidgetTester tester) async {
+      await tester.pumpWidget(wrapWithMaterial(
+        const ProfileSection(
+          userProfile: null,
+          isDarkMode: true,
+        ),
+      ));
+
+      expect(find.text('Usuario'), findsOneWidget);
+      expect(find.text('Sin correo electrónico'), findsOneWidget);
+    });
+
+    testWidgets('shows placeholders when profile fields are empty', (WidgetTester tester) async {
+      await tester.pumpWidget(wrapWithMaterial(
+        ProfileSection(
+          userProfile: UserProfile(),
+          isDarkMode: true,
+        ),
+      ));
+
+      expect(find.text('Usuario'), findsOneWidget);
+      expect(find.text('Sin correo electrónico'), findsOneWidget);
+    });
+
+    testWidgets('reflects dark mode state in the switch', (WidgetTester tester) async {
+      await tester.pumpWidget(wrapWithMaterial(
+        ProfileSection(
+          userProfile: testProfile,
+          isDarkMode: true,
+        ),
+      ));
+
+      final Switch darkSwitch = tester.widget(find.byKey(const Key('dark_mode_switch')));
+      expect(darkSwitch.value, isTrue);
+
+      await tester.pumpWidget(wrapWithMaterial(
+        ProfileSection(
+          userProfile: testProfile,
+          isDarkMode: false,
+        ),
+      ));
+
+      final Switch lightSwitch = tester.widget(find.byKey(const Key('dark_mode_switch')));
+      expect(lightSwitch.value, isFalse);
+    });
+
+    group('Image Rendering', () {
+      testWidgets('renders NetworkImage when avatarUrl is provided', (tester) async {
+        final profileWithAvatar = UserProfile(
+          name: 'John Doe',
+          email: 'john.doe@example.com',
+          avatarUrl: 'https://example.com/avatar.png',
+        );
+
+        await tester.pumpWidget(wrapWithMaterial(
+          ProfileSection(
+            userProfile: profileWithAvatar,
+            isDarkMode: true,
+          ),
+        ));
+
+        final containerFinder = find.byKey(const Key('profile_avatar_container'));
+        final container = tester.widget<Container>(containerFinder);
+        final decoration = container.decoration as BoxDecoration;
+        final image = decoration.image!.image;
+
+        expect(image, isA<NetworkImage>());
+        expect((image as NetworkImage).url, 'https://example.com/avatar.png');
+
+        // Clear exceptions caused by NetworkImage failing to load in tests
+        tester.binding.takeException();
+      });
+
+      testWidgets('renders AssetImage when avatarUrl is null', (tester) async {
+        await tester.pumpWidget(wrapWithMaterial(
+          ProfileSection(
+            userProfile: UserProfile(),
+            isDarkMode: true,
+          ),
+        ));
+
+        final containerFinder = find.byKey(const Key('profile_avatar_container'));
+        final container = tester.widget<Container>(containerFinder);
+        final decoration = container.decoration as BoxDecoration;
+        final image = decoration.image!.image;
+
+        expect(image, isA<AssetImage>());
+        expect((image as AssetImage).assetName, 'assets/images/user_placeholder.png');
+      });
+    });
+  });
+}


### PR DESCRIPTION
Implemented the `ProfileSection` widget in the settings feature and added corresponding widget tests as part of Sprint 8. The widget displays user profile information (name, email, avatar), an "Edit" button, and a "Modo Oscuro" (Dark Mode) toggle. Tests cover successful rendering, callback execution for both edit and toggle actions, and graceful handling of missing profile data. Corrected collateral deletions of generated files and lockfile changes during the process.

Fixes #1381

---
*PR created automatically by Jules for task [13168931300927970563](https://jules.google.com/task/13168931300927970563) started by @iberi22*