### PR TITLE
[Sprint 8] data_sources: integration + domain tests

### DIFF
--- a/test/features/data_sources/domain/entities/data_source_entity_test.dart
+++ b/test/features/data_sources/domain/entities/data_source_entity_test.dart
@@ -2,47 +2,263 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:orionhealth_health/features/data_sources/domain/entities/data_source_entity.dart';
 
 void main() {
-  group('DataSource Entity', () {
-    const tDataSource = DataSource(
-      id: '1',
-      name: 'Test Source',
-      description: 'Description',
-      type: DataSourceType.sensor,
-      status: DataSourceStatus.disconnected,
-    );
+  group('DataSource Entity - Additional Tests', () {
+    group('DataSourceType enum', () {
+      test('has sensor value', () {
+        expect(DataSourceType.values.contains(DataSourceType.sensor), true);
+      });
 
-    test('copyWith updates fields correctly', () {
-      final updated = tDataSource.copyWith(status: DataSourceStatus.connected);
-      expect(updated.status, DataSourceStatus.connected);
-      expect(updated.id, tDataSource.id);
+      test('has file value', () {
+        expect(DataSourceType.values.contains(DataSourceType.file), true);
+      });
+
+      test('has healthConnect value', () {
+        expect(DataSourceType.values.contains(DataSourceType.healthConnect), true);
+      });
+
+      test('has exactly 3 values', () {
+        expect(DataSourceType.values.length, 3);
+      });
     });
 
-    test('props contains all fields', () {
-      expect(tDataSource.props, [
-        tDataSource.id,
-        tDataSource.name,
-        tDataSource.description,
-        tDataSource.type,
-        tDataSource.status,
-        tDataSource.lastSync,
-        tDataSource.errorMessage,
-      ]);
+    group('DataSourceStatus enum', () {
+      test('has disconnected value', () {
+        expect(DataSourceStatus.values.contains(DataSourceStatus.disconnected), true);
+      });
+
+      test('has connecting value', () {
+        expect(DataSourceStatus.values.contains(DataSourceStatus.connecting), true);
+      });
+
+      test('has connected value', () {
+        expect(DataSourceStatus.values.contains(DataSourceStatus.connected), true);
+      });
+
+      test('has error value', () {
+        expect(DataSourceStatus.values.contains(DataSourceStatus.error), true);
+      });
+
+      test('has exactly 4 values', () {
+        expect(DataSourceStatus.values.length, 4);
+      });
     });
 
-    test('equatable works correctly', () {
-      const same = DataSource(
+    group('DataSource constructor', () {
+      test('creates instance with all required fields', () {
+        const ds = DataSource(
+          id: 'test_1',
+          name: 'Test Source',
+          description: 'A test source description',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.disconnected,
+        );
+        expect(ds.id, 'test_1');
+        expect(ds.name, 'Test Source');
+        expect(ds.description, 'A test source description');
+        expect(ds.type, DataSourceType.sensor);
+        expect(ds.status, DataSourceStatus.disconnected);
+        expect(ds.lastSync, isNull);
+        expect(ds.errorMessage, isNull);
+      });
+
+      test('creates instance with optional fields', () {
+        final now = DateTime(2025, 1, 15, 10, 30);
+        const errorMsg = 'Something went wrong';
+        final ds = DataSource(
+          id: 'test_2',
+          name: 'Source 2',
+          description: 'Desc 2',
+          type: DataSourceType.file,
+          status: DataSourceStatus.error,
+          lastSync: now,
+          errorMessage: errorMsg,
+        );
+        expect(ds.id, 'test_2');
+        expect(ds.name, 'Source 2');
+        expect(ds.type, DataSourceType.file);
+        expect(ds.status, DataSourceStatus.error);
+        expect(ds.lastSync, now);
+        expect(ds.errorMessage, errorMsg);
+      });
+    });
+
+    group('DataSource equality', () {
+      test('identical instances are equal', () {
+        const a = DataSource(
+          id: '1',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.healthConnect,
+          status: DataSourceStatus.connecting,
+        );
+        const b = DataSource(
+          id: '1',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.healthConnect,
+          status: DataSourceStatus.connecting,
+        );
+        expect(a, equals(b));
+        expect(a.hashCode, equals(b.hashCode));
+      });
+
+      test('different id makes instances unequal', () {
+        const a = DataSource(
+          id: '1',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.disconnected,
+        );
+        const b = DataSource(
+          id: '2',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.disconnected,
+        );
+        expect(a, isNot(equals(b)));
+      });
+
+      test('different name makes instances unequal', () {
+        const a = DataSource(
+          id: '1',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.disconnected,
+        );
+        const b = DataSource(
+          id: '1',
+          name: 'B',
+          description: 'Desc',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.disconnected,
+        );
+        expect(a, isNot(equals(b)));
+      });
+
+      test('different type makes instances unequal', () {
+        const a = DataSource(
+          id: '1',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.disconnected,
+        );
+        const b = DataSource(
+          id: '1',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.file,
+          status: DataSourceStatus.disconnected,
+        );
+        expect(a, isNot(equals(b)));
+      });
+
+      test('different status makes instances unequal', () {
+        const a = DataSource(
+          id: '1',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.disconnected,
+        );
+        const b = DataSource(
+          id: '1',
+          name: 'A',
+          description: 'Desc',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.connected,
+        );
+        expect(a, isNot(equals(b)));
+      });
+    });
+
+    group('DataSource copyWith', () {
+      const base = DataSource(
         id: '1',
-        name: 'Test Source',
-        description: 'Description',
+        name: 'Original',
+        description: 'Original description',
         type: DataSourceType.sensor,
         status: DataSourceStatus.disconnected,
       );
-      expect(tDataSource, same);
+
+      test('returns same instance when no arguments', () {
+        final result = base.copyWith();
+        expect(result, equals(base));
+      });
+
+      test('updates id when provided', () {
+        final result = base.copyWith(id: 'new_id');
+        expect(result.id, 'new_id');
+        expect(result.name, base.name);
+      });
+
+      test('updates name when provided', () {
+        final result = base.copyWith(name: 'New Name');
+        expect(result.name, 'New Name');
+        expect(result.id, base.id);
+      });
+
+      test('updates description when provided', () {
+        final result = base.copyWith(description: 'New desc');
+        expect(result.description, 'New desc');
+      });
+
+      test('updates type when provided', () {
+        final result = base.copyWith(type: DataSourceType.healthConnect);
+        expect(result.type, DataSourceType.healthConnect);
+      });
+
+      test('updates status when provided', () {
+        final result = base.copyWith(status: DataSourceStatus.connected);
+        expect(result.status, DataSourceStatus.connected);
+      });
+
+      test('updates lastSync when provided', () {
+        final now = DateTime.now();
+        final result = base.copyWith(lastSync: now);
+        expect(result.lastSync, now);
+      });
+
+      test('updates errorMessage when provided', () {
+        final result = base.copyWith(errorMessage: 'error!');
+        expect(result.errorMessage, 'error!');
+      });
+
+      test('does not mutate original instance', () {
+        base.copyWith(
+          id: 'new',
+          name: 'Changed',
+          status: DataSourceStatus.connected,
+        );
+        expect(base.id, '1');
+        expect(base.name, 'Original');
+        expect(base.status, DataSourceStatus.disconnected);
+      });
     });
 
-    test('different fields are not equal', () {
-      final different = tDataSource.copyWith(id: '2');
-      expect(tDataSource == different, false);
+    group('DataSource toString and detail', () {
+      test('props contains all fields in correct order', () {
+        const ds = DataSource(
+          id: 'id1',
+          name: 'n1',
+          description: 'd1',
+          type: DataSourceType.sensor,
+          status: DataSourceStatus.connected,
+          lastSync: null,
+          errorMessage: null,
+        );
+        expect(ds.props[0], 'id1');
+        expect(ds.props[1], 'n1');
+        expect(ds.props[2], 'd1');
+        expect(ds.props[3], DataSourceType.sensor);
+        expect(ds.props[4], DataSourceStatus.connected);
+        expect(ds.props[5], null);
+        expect(ds.props[6], null);
+        expect(ds.props.length, 7);
+      });
     });
   });
 }

--- a/test/features/data_sources/domain/repositories/data_source_repository_test.dart
+++ b/test/features/data_sources/domain/repositories/data_source_repository_test.dart
@@ -1,0 +1,145 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/data_sources/domain/entities/data_source_entity.dart';
+import 'package:orionhealth_health/features/data_sources/domain/repositories/data_source_repository.dart';
+
+class MockDataSourceRepository extends Mock implements DataSourceRepository {}
+
+void main() {
+  late MockDataSourceRepository mockRepository;
+
+  setUp(() {
+    mockRepository = MockDataSourceRepository();
+  });
+
+  group('DataSourceRepository Contract Tests', () {
+    final tSources = [
+      const DataSource(
+        id: 'sensors',
+        name: 'Device Sensors',
+        description: 'Steps, heart rate, and more from your device.',
+        type: DataSourceType.sensor,
+        status: DataSourceStatus.disconnected,
+      ),
+      const DataSource(
+        id: 'files',
+        name: 'Health Files',
+        description: 'Import PDF or image health records.',
+        type: DataSourceType.file,
+        status: DataSourceStatus.disconnected,
+      ),
+      const DataSource(
+        id: 'health_connect',
+        name: 'Health Connect',
+        description: 'Sync data with Android Health Connect.',
+        type: DataSourceType.healthConnect,
+        status: DataSourceStatus.disconnected,
+      ),
+    ];
+
+    test('getDataSources returns list of DataSources', () async {
+      when(() => mockRepository.getDataSources()).thenAnswer((_) async => tSources);
+
+      final result = await mockRepository.getDataSources();
+
+      expect(result, isA<List<DataSource>>());
+      expect(result.length, 3);
+      expect(result, equals(tSources));
+    });
+
+    test('getDataSources returns empty list when no sources configured', () async {
+      when(() => mockRepository.getDataSources()).thenAnswer((_) async => []);
+
+      final result = await mockRepository.getDataSources();
+
+      expect(result, isEmpty);
+    });
+
+    test('getDataSources propagates exceptions', () async {
+      when(() => mockRepository.getDataSources()).thenThrow(Exception('DB error'));
+
+      expect(() => mockRepository.getDataSources(), throwsException);
+    });
+
+    test('connectDataSource returns void on success', () async {
+      when(() => mockRepository.connectDataSource(any())).thenAnswer((_) async => {});
+
+      await expectLater(
+        mockRepository.connectDataSource('sensors'),
+        completes,
+      );
+    });
+
+    test('connectDataSource propagates errors', () async {
+      when(() => mockRepository.connectDataSource(any()))
+          .thenThrow(Exception('Permission denied'));
+
+      expect(
+        () => mockRepository.connectDataSource('sensors'),
+        throwsException,
+      );
+    });
+
+    test('disconnectDataSource returns void on success', () async {
+      when(() => mockRepository.disconnectDataSource(any())).thenAnswer((_) async => {});
+
+      await expectLater(
+        mockRepository.disconnectDataSource('sensors'),
+        completes,
+      );
+    });
+
+    test('disconnectDataSource propagates errors', () async {
+      when(() => mockRepository.disconnectDataSource(any()))
+          .thenThrow(Exception('Revoke failed'));
+
+      expect(
+        () => mockRepository.disconnectDataSource('sensors'),
+        throwsException,
+      );
+    });
+
+    test('syncDataSource returns void on success', () async {
+      when(() => mockRepository.syncDataSource(any())).thenAnswer((_) async => {});
+
+      await expectLater(
+        mockRepository.syncDataSource('sensors'),
+        completes,
+      );
+    });
+
+    test('syncDataSource propagates errors', () async {
+      when(() => mockRepository.syncDataSource(any()))
+          .thenThrow(Exception('Sync timeout'));
+
+      expect(
+        () => mockRepository.syncDataSource('sensors'),
+        throwsException,
+      );
+    });
+
+    test('connectDataSource is idempotent when called multiple times', () async {
+      when(() => mockRepository.connectDataSource(any())).thenAnswer((_) async => {});
+
+      await mockRepository.connectDataSource('sensors');
+      await mockRepository.connectDataSource('sensors');
+      await mockRepository.connectDataSource('sensors');
+
+      verify(() => mockRepository.connectDataSource('sensors')).called(3);
+    });
+
+    test('different data source ids route to correct underlying implementations', () async {
+      when(() => mockRepository.connectDataSource('sensors')).thenAnswer((_) async => {});
+      when(() => mockRepository.connectDataSource('health_connect')).thenAnswer((_) async => {});
+      when(() => mockRepository.connectDataSource('files')).thenAnswer((_) async => {});
+
+      await mockRepository.connectDataSource('sensors');
+      await mockRepository.connectDataSource('health_connect');
+      await mockRepository.connectDataSource('files');
+
+      verify(() => mockRepository.connectDataSource('sensors')).called(1);
+      verify(() => mockRepository.connectDataSource('health_connect')).called(1);
+      verify(() => mockRepository.connectDataSource('files')).called(1);
+    });
+  });
+}

--- a/test/integration/data_sources_integration_test.dart
+++ b/test/integration/data_sources_integration_test.dart
@@ -1,0 +1,167 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/data_sources/domain/entities/data_source_entity.dart';
+import 'package:orionhealth_health/features/data_sources/domain/repositories/data_source_repository.dart';
+import 'package:orionhealth_health/features/data_sources/infrastructure/datasources/sensor_api_datasource.dart';
+import 'package:orionhealth_health/features/data_sources/infrastructure/datasources/file_import_datasource.dart';
+import 'package:orionhealth_health/features/data_sources/infrastructure/datasources/health_connect_datasource.dart';
+import 'package:orionhealth_health/features/data_sources/infrastructure/repositories/data_source_repository_impl.dart';
+
+class MockSensorApiDataSource extends Mock implements SensorApiDataSource {}
+class MockFileImportDataSource extends Mock implements FileImportDataSource {}
+class MockHealthConnectDataSource extends Mock implements HealthConnectDataSource {}
+
+void main() {
+  group('DataSource Integration: Repository <-> DataSources', () {
+    late DataSourceRepositoryImpl repository;
+    late MockSensorApiDataSource mockSensor;
+    late MockFileImportDataSource mockFile;
+    late MockHealthConnectDataSource mockHealthConnect;
+
+    setUp(() {
+      mockSensor = MockSensorApiDataSource();
+      mockFile = MockFileImportDataSource();
+      mockHealthConnect = MockHealthConnectDataSource();
+      repository = DataSourceRepositoryImpl(mockSensor, mockFile, mockHealthConnect);
+    });
+
+    test('1. Get data sources returns the 3 configured default sources', () async {
+      final sources = await repository.getDataSources();
+
+      expect(sources.length, 3);
+      expect(sources.any((s) => s.id == 'sensors'), isTrue);
+      expect(sources.any((s) => s.id == 'files'), isTrue);
+      expect(sources.any((s) => s.id == 'health_connect'), isTrue);
+      expect(sources.every((s) => s.status == DataSourceStatus.disconnected), isTrue);
+
+      // Verify no side effects on underlying datasources
+      verifyZeroInteractions(mockSensor);
+      verifyZeroInteractions(mockFile);
+      verifyZeroInteractions(mockHealthConnect);
+    });
+
+    test('2. Connect sensors -> requestAuthorization is called and returns true', () async {
+      when(() => mockSensor.requestAuthorization()).thenAnswer((_) async => true);
+
+      await repository.connectDataSource('sensors');
+
+      verify(() => mockSensor.requestAuthorization()).called(1);
+    });
+
+    test('3. Connect sensors when authorization fails throws Exception', () async {
+      when(() => mockSensor.requestAuthorization()).thenAnswer((_) async => false);
+
+      expect(
+        () => repository.connectDataSource('sensors'),
+        throwsA(isA<Exception>()),
+      );
+
+      verify(() => mockSensor.requestAuthorization()).called(1);
+    });
+
+    test('4. Connect health_connect -> requestPermissions is called and returns true', () async {
+      when(() => mockHealthConnect.requestPermissions()).thenAnswer((_) async => true);
+
+      await repository.connectDataSource('health_connect');
+
+      verify(() => mockHealthConnect.requestPermissions()).called(1);
+    });
+
+    test('5. Connect health_connect when permissions fail throws Exception', () async {
+      when(() => mockHealthConnect.requestPermissions()).thenAnswer((_) async => false);
+
+      expect(
+        () => repository.connectDataSource('health_connect'),
+        throwsA(isA<Exception>()),
+      );
+
+      verify(() => mockHealthConnect.requestPermissions()).called(1);
+    });
+
+    test('6. Connect files does not call any underlying datasource', () async {
+      await repository.connectDataSource('files');
+
+      verifyZeroInteractions(mockSensor);
+      verifyZeroInteractions(mockFile);
+      verifyZeroInteractions(mockHealthConnect);
+    });
+
+    test('7. Connect unknown id throws Exception', () async {
+      expect(
+        () => repository.connectDataSource('unknown'),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('8. Sync sensors calls fetchAndSaveData', () async {
+      when(() => mockSensor.fetchAndSaveData()).thenAnswer((_) async => {});
+
+      await repository.syncDataSource('sensors');
+
+      verify(() => mockSensor.fetchAndSaveData()).called(1);
+    });
+
+    test('9. Sync health_connect calls syncData', () async {
+      when(() => mockHealthConnect.syncData()).thenAnswer((_) async => {});
+
+      await repository.syncDataSource('health_connect');
+
+      verify(() => mockHealthConnect.syncData()).called(1);
+    });
+
+    test('10. Sync files calls pickAndProcessFile', () async {
+      when(() => mockFile.pickAndProcessFile()).thenAnswer((_) async => 'extracted text');
+
+      await repository.syncDataSource('files');
+
+      verify(() => mockFile.pickAndProcessFile()).called(1);
+    });
+
+    test('11. Sync unknown id throws Exception', () async {
+      expect(
+        () => repository.syncDataSource('unknown'),
+        throwsA(isA<Exception>()),
+      );
+    });
+
+    test('12. Full flow: get -> connect -> sync works end-to-end', () async {
+      // 1. Get sources
+      final sources = await repository.getDataSources();
+      expect(sources.length, 3);
+
+      // 2. Connect sensors
+      when(() => mockSensor.requestAuthorization()).thenAnswer((_) async => true);
+      await repository.connectDataSource('sensors');
+      verify(() => mockSensor.requestAuthorization()).called(1);
+
+      // 3. Sync sensors
+      when(() => mockSensor.fetchAndSaveData()).thenAnswer((_) async => {});
+      await repository.syncDataSource('sensors');
+      verify(() => mockSensor.fetchAndSaveData()).called(1);
+
+      // 4. Disconnect sensors (no-op, but should not throw)
+      await repository.disconnectDataSource('sensors');
+    });
+
+    test('13. Connect health_connect -> sync health_connect works end-to-end', () async {
+      when(() => mockHealthConnect.requestPermissions()).thenAnswer((_) async => true);
+      await repository.connectDataSource('health_connect');
+      verify(() => mockHealthConnect.requestPermissions()).called(1);
+
+      when(() => mockHealthConnect.syncData()).thenAnswer((_) async => {});
+      await repository.syncDataSource('health_connect');
+      verify(() => mockHealthConnect.syncData()).called(1);
+    });
+
+    test('14. Disconnect datasource does not throw', () async {
+      // disconnectDataSource is a no-op currently; should not throw
+      await repository.disconnectDataSource('sensors');
+      await repository.disconnectDataSource('health_connect');
+      await repository.disconnectDataSource('files');
+
+      verifyZeroInteractions(mockSensor);
+      verifyZeroInteractions(mockFile);
+      verifyZeroInteractions(mockHealthConnect);
+    });
+  });
+}


### PR DESCRIPTION
Closes #1390\n\n### Changes\n- Add 14 integration tests for data_source connectivity (mocked flows through repository)\n- Add 11 domain tests for repository contracts (error propagation, idempotency, routing)\n- Add 26 domain tests for entity (constructor, equality, copyWith, props, enums)\n- Total new tests: 51