### PR TITLE
Enable 80% Coverage Threshold CI Gate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,13 +33,11 @@ jobs:
           echo "All analyzes complete"
         continue-on-error: true
 
-      - name: Flutter Test
-        continue-on-error: true
-        run: |
-          flutter test --reporter expanded | tee test_output.txt || echo "Tests had non-fatal failures"
-
       - name: Flutter Test (root)
-        run: flutter test --reporter expanded | tee test_output.txt || echo "Root tests had non-fatal failures"
+        run: flutter test --coverage --reporter expanded | tee test_output.txt
+
+      - name: Check Coverage Threshold
+        run: python3 coverage_checker.py
 
       - name: Flutter Test (packages)
         run: |

--- a/coverage_checker.py
+++ b/coverage_checker.py
@@ -1,8 +1,13 @@
 import sys
+import os
 
-def parse_lcov(file_path, prefix="lib/features/meditation/"):
+def parse_lcov(file_path, prefix=""):
     coverage = {}
     current_file = None
+    if not os.path.exists(file_path):
+        print(f"Error: {file_path} not found.")
+        sys.exit(1)
+
     with open(file_path, 'r') as f:
         for line in f:
             line = line.strip()
@@ -12,10 +17,11 @@ def parse_lcov(file_path, prefix="lib/features/meditation/"):
                     coverage[current_file] = {'found': 0, 'hit': 0, 'missed_lines': []}
             elif line.startswith('DA:') and current_file in coverage:
                 parts = line.split('DA:')[1].split(',')
-                line_num = int(parts[0])
-                count = int(parts[1])
-                if count == 0:
-                    coverage[current_file]['missed_lines'].append(line_num)
+                if len(parts) >= 2:
+                    line_num = int(parts[0])
+                    count = int(parts[1])
+                    if count == 0:
+                        coverage[current_file]['missed_lines'].append(line_num)
             elif line.startswith('LF:') and current_file in coverage:
                 coverage[current_file]['found'] = int(line.split('LF:')[1])
             elif line.startswith('LH:') and current_file in coverage:
@@ -23,14 +29,31 @@ def parse_lcov(file_path, prefix="lib/features/meditation/"):
     return coverage
 
 def main():
-    coverage = parse_lcov('coverage/lcov.info')
+    lcov_file = 'coverage/lcov.info'
+    coverage = parse_lcov(lcov_file)
+
+    total_found = 0
+    total_hit = 0
+
     for file, data in coverage.items():
-        found = data['found']
-        hit = data['hit']
-        percentage = (hit / found * 100) if found > 0 else 100
-        print(f"{file}: {hit}/{found} ({percentage:.2f}%)")
-        if data['missed_lines']:
-            print(f"  Missed lines: {data['missed_lines']}")
+        total_found += data['found']
+        total_hit += data['hit']
+
+    if total_found == 0:
+        print("No coverage data found or all files have 0 lines.")
+        overall_percentage = 0.0
+    else:
+        overall_percentage = (total_hit / total_found) * 100
+
+    print(f"Overall Coverage: {overall_percentage:.2f}% ({total_hit}/{total_found})")
+
+    threshold = 80.0
+    if overall_percentage < threshold:
+        print(f"FAILED: Coverage {overall_percentage:.2f}% is below threshold {threshold}%")
+        sys.exit(1)
+    else:
+        print(f"PASSED: Coverage {overall_percentage:.2f}% is above threshold {threshold}%")
+        sys.exit(0)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
Enabled a CI gate that fails if test coverage drops below 80%. This was achieved by:
1. Updating `coverage_checker.py` to parse `coverage/lcov.info` and calculate project-wide line coverage without exclusions.
2. Modifying `.github/workflows/ci.yml` to include `--coverage` in the `flutter test` command and adding a verification step that executes the updated script.
3. Ensuring the CI pipeline correctly fails on threshold violations while maintaining standard testing for packages.

Fixes #1443

---
*PR created automatically by Jules for task [5149214407753888674](https://jules.google.com/task/5149214407753888674) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CI test handling so failures now stop the workflow as expected.
  * Added coverage validation to catch low test coverage during builds.

* **New Features**
  * Test runs now collect coverage data and report an overall coverage result.
  * CI now enforces a minimum coverage threshold before passing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->