### PR TITLE
fix: add missing test imports in medical_standards package

### DIFF
--- a/packages/medical_standards/test/medications_test.dart
+++ b/packages/medical_standards/test/medications_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 void main() {

--- a/packages/medical_standards/test/onboarding_test.dart
+++ b/packages/medical_standards/test/onboarding_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 void main() {

--- a/packages/medical_standards/test/snomed_test.dart
+++ b/packages/medical_standards/test/snomed_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 void main() {

--- a/packages/medical_standards/test/standards_test.dart
+++ b/packages/medical_standards/test/standards_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 void main() {


### PR DESCRIPTION
Add missing/correct test imports in the `medical_standards` package. The issue was that several test files were using `package:test/test.dart` instead of `package:flutter_test/flutter_test.dart`, causing loading errors when running tests in a Flutter environment. I've updated these imports and verified that all tests in the package now pass.

Fixes #1461

---
*PR created automatically by Jules for task [3577271399117231311](https://jules.google.com/task/3577271399117231311) started by @iberi22*