### PR TITLE
Fix Flutter analysis warnings and errors

### DIFF
--- a/analyze_output.txt
+++ b/analyze_output.txt
@@ -1,0 +1,366 @@
+Resolving dependencies...
+Downloading packages...
+  _fe_analyzer_shared 61.0.0 (104.0.0 available)
+  analyzer 5.13.0 (14.0.0 available)
+  app_links 6.4.1 (7.2.1 available)
+  app_links_platform_interface 2.0.2 (2.0.4 available)
+  audio_session 0.2.3 (0.2.4 available)
+  build 2.4.1 (4.0.7 available)
+  build_config 1.1.2 (1.3.1 available)
+  build_daemon 4.1.1 (4.1.2 available)
+  build_resolvers 2.4.2 (3.0.4 available)
+  build_runner 2.4.13 (2.15.1 available)
+  build_runner_core 7.3.2 (9.3.2 available)
+  connectivity_plus 7.1.1 (7.2.0 available)
+  cross_file 0.3.5+2 (0.3.5+4 available)
+  dart_style 2.3.2 (3.1.11 available)
+  device_info_plus 12.4.0 (13.2.0 available)
+  device_info_plus_platform_interface 7.0.3 (8.1.0 available)
+  dio_web_adapter 2.1.2 (2.2.0 available)
+  file_picker 10.3.10 (11.0.2 available)
+  firebase_database 12.4.3 (12.4.4 available)
+  flat_buffers 23.5.26 (25.9.23 available)
+  flutter_appauth 12.0.1 (12.0.2 available)
+  flutter_blue_plus 2.3.8 (2.3.10 available)
+  flutter_blue_plus_android 9.0.2 (9.0.3 available)
+  flutter_blue_plus_darwin 9.0.2 (9.0.3 available)
+  flutter_blue_plus_linux 9.0.2 (9.0.3 available)
+  flutter_blue_plus_platform_interface 9.0.2 (9.0.3 available)
+  flutter_blue_plus_web 9.0.2 (9.0.3 available)
+  flutter_gemma 0.13.6 (1.2.2 available)
+  flutter_markdown 0.7.7+1 (discontinued replaced by flutter_markdown_plus)
+  flutter_secure_storage_darwin 0.3.2 (0.4.0 available)
+  flutter_secure_storage_windows 4.1.0 (4.2.2 available)
+  freezed 2.5.2 (3.2.5 available)
+  freezed_annotation 2.4.4 (3.1.0 available)
+  google_mlkit_commons 0.11.1 (0.12.0 available)
+  google_mlkit_text_recognition 0.15.1 (0.16.0 available)
+  googleai_dart 3.6.0 (9.0.0 available)
+  googleapis 15.0.0 (16.0.0 available)
+  googleapis_auth 2.3.2 (2.3.3 available)
+  image_picker 1.2.2 (1.2.3 available)
+  image_picker_android 0.8.13+17 (0.8.13+19 available)
+  injectable 2.7.1+4 (3.0.0 available)
+  injectable_generator 2.4.2 (3.1.0 available)
+  intl 0.20.2 (0.20.3 available)
+  js 0.6.7 (0.7.2 available)
+  just_audio 0.10.5 (0.10.6 available)
+  large_file_handler 0.3.1 (0.5.0 available)
+  local_auth 3.0.1 (3.0.2 available)
+  local_auth_android 2.0.8 (2.0.9 available)
+  matcher 0.12.18 (0.12.20 available)
+  meta 1.17.0 (1.19.0 available)
+  mobile_scanner 6.0.11 (7.2.0 available)
+  mockito 5.4.4 (5.7.0 available)
+  native_toolchain_c 0.19.1 (0.19.2 available)
+  objectbox 5.0.4 (5.3.2 available)
+  objectbox_flutter_libs 5.0.4 (5.3.2 available)
+  package_config 2.2.0 (3.0.0 available)
+  path_provider_linux 2.2.1 (2.2.2 available)
+  pointycastle 3.9.1 (4.0.0 available)
+  record 6.2.1 (7.1.1 available)
+  record_android 1.5.2 (2.1.2 available)
+  record_ios 1.2.1 (2.1.1 available)
+  record_linux 1.3.1 (2.1.1 available)
+  record_macos 1.2.2 (2.1.1 available)
+  record_platform_interface 1.6.0 (2.1.0 available)
+  record_web 1.3.0 (2.1.1 available)
+  record_windows 1.0.7 (2.2.2 available)
+  share_plus 12.0.2 (13.2.0 available)
+  share_plus_platform_interface 6.1.0 (7.1.0 available)
+  shared_preferences_android 2.4.23 (2.4.26 available)
+  shelf_web_socket 2.0.1 (3.0.0 available)
+  source_gen 1.5.0 (4.2.3 available)
+  sqflite 2.4.2+1 (2.4.3 available)
+  sqflite_android 2.4.2+3 (2.4.3 available)
+  sqflite_common 2.5.8 (2.5.11 available)
+  sqflite_darwin 2.4.2 (2.4.3+1 available)
+  sqflite_platform_interface 2.4.0 (2.4.1 available)
+  sqlite3 3.3.3 (3.3.4 available)
+  synchronized 3.4.0+1 (3.4.1 available)
+  test_api 0.7.9 (0.7.13 available)
+  timezone 0.9.4 (0.11.1 available)
+  url_launcher_android 6.3.30 (6.3.32 available)
+  vector_math 2.2.0 (2.4.0 available)
+  vertex_ai 0.2.1 (0.2.4 available)
+  web_socket_channel 2.4.0 (3.0.3 available)
+  win32 5.15.0 (6.3.0 available)
+  win32_registry 2.1.0 (3.0.3 available)
+  xml 6.6.1 (7.0.1 available)
+Got dependencies!
+1 package is discontinued.
+86 packages have newer versions incompatible with dependency constraints.
+Try `flutter pub outdated` for more information.
+Analyzing app...
+
+warning • Unused import: 'dart:async' • integration_test/about_e2e_test.dart:1:8 • unused_import
+warning • Unused import: 'dart:async' • integration_test/doctor_verification_e2e_test.dart:14:8 • unused_import
+  error • Invalid constant value • integration_test/doctor_verification_e2e_test.dart:131:40 • invalid_constant
+warning • Unused import: 'dart:async' • integration_test/email_citas_e2e_test.dart:4:8 • unused_import
+   info • 'setMockMethodCallHandler' is deprecated and shouldn't be used. Use tester.binding.defaultBinaryMessenger.setMockMethodCallHandler or TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler instead. Pass the channel as the first argument. This feature was deprecated after v3.9.0-19.0.pre • integration_test/health_data_import_e2e_test.dart:54:10 • deprecated_member_use
+  error • The name 'HealthDataImportService' isn't a type, so it can't be used as a type argument • integration_test/health_data_import_e2e_test.dart:69:26 • non_type_as_type_argument
+warning • Unused import: 'package:orionhealth_health/features/health_record/domain/repositories/health_record_repository.dart' • integration_test/health_record_e2e_test.dart:10:8 • unused_import
+warning • Unused import: 'package:orionhealth_health/features/health_sharing/application/sharing_cubit.dart' • integration_test/health_sharing_e2e_test.dart:7:8 • unused_import
+  error • The class 'BleSharingState' doesn't have an unnamed constant constructor • integration_test/health_sharing_e2e_test.dart:114:38 • const_with_undefined_constructor_default
+  error • The class 'BleSharingState' doesn't have an unnamed constant constructor • integration_test/health_sharing_e2e_test.dart:124:36 • const_with_undefined_constructor_default
+  error • The class 'NfcSharingState' doesn't have an unnamed constant constructor • integration_test/health_sharing_e2e_test.dart:148:38 • const_with_undefined_constructor_default
+  error • The class 'NfcSharingState' doesn't have an unnamed constructor • integration_test/health_sharing_e2e_test.dart:173:30 • new_with_undefined_constructor_default
+  error • The class 'NfcSharingState' doesn't have an unnamed constant constructor • integration_test/health_sharing_e2e_test.dart:189:36 • const_with_undefined_constructor_default
+  error • The class 'BleSharingState' doesn't have an unnamed constant constructor • integration_test/health_sharing_e2e_test.dart:213:38 • const_with_undefined_constructor_default
+  error • The class 'NfcSharingState' doesn't have an unnamed constant constructor • integration_test/health_sharing_e2e_test.dart:237:38 • const_with_undefined_constructor_default
+  error • The class 'NfcSharingState' doesn't have an unnamed constructor • integration_test/health_sharing_e2e_test.dart:259:30 • new_with_undefined_constructor_default
+  error • The named parameter 'summaryText' is required, but there's no corresponding argument • integration_test/medical_research_e2e_test.dart:88:87 • missing_required_argument
+  error • The method 'getHomeModules' isn't defined for the type 'MockMeditationRepository' • integration_test/meditation_e2e_test.dart:51:31 • undefined_method
+   info • Angle brackets will be interpreted as HTML • integration_test/screenshot_flow_e2e_test.dart:27:61 • unintended_html_in_doc_comment
+   info • Angle brackets will be interpreted as HTML • integration_test/screenshot_flow_e2e_test.dart:27:68 • unintended_html_in_doc_comment
+   info • Don't invoke 'print' in production code • integration_test/utils/video_recorder.dart:19:5 • avoid_print
+  error • The named parameter 'caseSensitive' isn't defined • integration_test/vitals_e2e_test.dart:76:52 • undefined_named_parameter
+   info • Use the null-aware marker '?' rather than a null check via an 'if' • lib/core/logging/audit_logger.dart:57:7 • use_null_aware_elements
+   info • 'encryptedSharedPreferences' is deprecated and shouldn't be used. EncryptedSharedPreferences is deprecated and will be removed in v11. The Jetpack Security library is deprecated by Google. Your data will be automatically migrated to custom ciphers on first access. Remove this parameter - it will be ignored • lib/core/services/secure_storage_service.dart:58:17 • deprecated_member_use
+   info • Use the null-aware marker '?' rather than a null check via an 'if' • lib/core/widgets/page_header.dart:62:15 • use_null_aware_elements
+   info • Constructors for public widgets should have a named 'key' parameter • lib/features/about/presentation/pages/about_page.dart:102:9 • use_key_in_widget_constructors
+warning • Unused import: 'package:injectable/injectable.dart' • lib/features/allergies/infrastructure/repositories/isar_allergy_repository.dart:1:8 • unused_import
+warning • Unused import: 'package:injectable/injectable.dart' • lib/features/appointments/infrastructure/repositories/isar_appointment_repository.dart:1:8 • unused_import
+   info • 'value' is deprecated and shouldn't be used. Use initialValue instead. This will set the initial value for the form field. This feature was deprecated after v3.33.0-1.0.pre • lib/features/appointments/presentation/widgets/appointment_form.dart:119:15 • deprecated_member_use
+   info • 'activeColor' is deprecated and shouldn't be used. Use activeThumbColor instead. This feature was deprecated after v3.31.0-2.0.pre • lib/features/data_sources/presentation/widgets/data_source_tile.dart:44:15 • deprecated_member_use
+   info • Unnecessary 'const' keyword • lib/features/eps_connection/presentation/pages/eps_connection_page.dart:99:18 • unnecessary_const
+warning • Unused import: '../entities/health_import_result.dart' • lib/features/health_data_import/domain/usecases/health_import_usecases.dart:5:8 • unused_import
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • lib/features/health_sharing/presentation/widgets/share_card.dart:54:47 • deprecated_member_use
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • lib/features/health_sharing/presentation/widgets/share_card.dart:121:29 • deprecated_member_use
+warning • Duplicate import • lib/features/local_agent/domain/services/llm_adapter.dart:8:8 • duplicate_import
+warning • Duplicate import • lib/features/local_agent/domain/services/llm_adapter.dart:9:8 • duplicate_import
+warning • Unused import: 'package:isar/isar.dart' • lib/features/local_agent/domain/services/vector_store_service.dart:1:8 • unused_import
+warning • Unused import: '../../../../core/widgets/glassmorphic_card.dart' • lib/features/medications/presentation/pages/medications_page.dart:6:8 • unused_import
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • lib/features/network/network_health/presentation/widgets/network_stats_card.dart:78:34 • deprecated_member_use
+warning • The declaration 'hasConsent' isn't referenced • lib/features/onboarding/presentation/pages/hipaa_consent_page.dart:375:23 • unused_element
+   info • Unnecessary 'const' keyword • lib/features/settings/presentation/widgets/profile_section.dart:69:19 • unnecessary_const
+   info • 'activeColor' is deprecated and shouldn't be used. Use activeThumbColor instead. This feature was deprecated after v3.31.0-2.0.pre • lib/features/settings/presentation/widgets/profile_section.dart:80:17 • deprecated_member_use
+warning • Unused import: 'features/home/presentation/pages/main_navigation_page.dart' • lib/main.dart:26:8 • unused_import
+   info • The imported package 'flutter_test' isn't a dependency of the importing package • packages/health_wallet/test/encryption_service_test.dart:2:8 • depend_on_referenced_packages
+   info • The imported package 'flutter_test' isn't a dependency of the importing package • packages/health_wallet/test/sync_service_test.dart:2:8 • depend_on_referenced_packages
+   info • The imported package 'flutter_test' isn't a dependency of the importing package • packages/health_wallet/test/wallet_service_test.dart:2:8 • depend_on_referenced_packages
+   info • The imported package 'path' isn't a dependency of the importing package • packages/health_wallet/test/wallet_service_test.dart:4:8 • depend_on_referenced_packages
+  error • Target of URI doesn't exist: 'package:test/test.dart' • packages/medical_standards/test/medications_test.dart:1:8 • uri_does_not_exist
+  error • The function 'group' isn't defined • packages/medical_standards/test/medications_test.dart:5:3 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:6:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:8:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/medications_test.dart:8:19 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:9:7 • undefined_function
+  error • The function 'equals' isn't defined • packages/medical_standards/test/medications_test.dart:9:25 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:12:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:14:7 • undefined_function
+  error • Undefined name 'isNull' • packages/medical_standards/test/medications_test.dart:14:19 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:17:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:19:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/medications_test.dart:19:25 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:20:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/medications_test.dart:20:52 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:23:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:26:7 • undefined_function
+  error • The function 'equals' isn't defined • packages/medical_standards/test/medications_test.dart:26:18 • undefined_function
+  error • The function 'group' isn't defined • packages/medical_standards/test/medications_test.dart:30:3 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:31:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:32:7 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/medications_test.dart:32:37 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:35:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:37:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/medications_test.dart:37:19 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:38:7 • undefined_function
+  error • The function 'equals' isn't defined • packages/medical_standards/test/medications_test.dart:38:25 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:41:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:43:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/medications_test.dart:43:19 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:44:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/medications_test.dart:44:46 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:47:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:50:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/medications_test.dart:50:20 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:51:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/medications_test.dart:51:20 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:52:7 • undefined_function
+  error • The function 'equals' isn't defined • packages/medical_standards/test/medications_test.dart:52:33 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:55:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:57:7 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/medications_test.dart:57:20 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:60:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:62:7 • undefined_function
+  error • Undefined name 'isEmpty' • packages/medical_standards/test/medications_test.dart:62:20 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/medications_test.dart:65:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/medications_test.dart:67:7 • undefined_function
+  error • Undefined name 'isNull' • packages/medical_standards/test/medications_test.dart:67:19 • undefined_identifier
+  error • Target of URI doesn't exist: 'package:test/test.dart' • packages/medical_standards/test/onboarding_test.dart:1:8 • uri_does_not_exist
+  error • The function 'group' isn't defined • packages/medical_standards/test/onboarding_test.dart:5:3 • undefined_function
+  error • The function 'setUp' isn't defined • packages/medical_standards/test/onboarding_test.dart:8:5 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/onboarding_test.dart:12:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:21:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/onboarding_test.dart:21:22 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:22:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/onboarding_test.dart:22:33 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:23:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/onboarding_test.dart:23:28 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/onboarding_test.dart:26:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:34:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/onboarding_test.dart:34:22 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:35:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/onboarding_test.dart:35:33 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:36:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/onboarding_test.dart:36:33 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:37:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/onboarding_test.dart:37:33 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/onboarding_test.dart:40:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:48:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/onboarding_test.dart:48:22 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:49:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/onboarding_test.dart:49:33 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:50:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/onboarding_test.dart:50:28 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/onboarding_test.dart:53:5 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/onboarding_test.dart:59:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/onboarding_test.dart:66:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/onboarding_test.dart:66:33 • undefined_function
+  error • Target of URI doesn't exist: 'package:test/test.dart' • packages/medical_standards/test/snomed_test.dart:1:8 • uri_does_not_exist
+  error • The function 'group' isn't defined • packages/medical_standards/test/snomed_test.dart:5:3 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/snomed_test.dart:6:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:8:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/snomed_test.dart:8:23 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:9:7 • undefined_function
+  error • The function 'equals' isn't defined • packages/medical_standards/test/snomed_test.dart:9:29 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/snomed_test.dart:12:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:14:7 • undefined_function
+  error • Undefined name 'isNull' • packages/medical_standards/test/snomed_test.dart:14:23 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/snomed_test.dart:17:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:19:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/snomed_test.dart:19:24 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:20:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/snomed_test.dart:20:51 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/snomed_test.dart:23:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:26:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/snomed_test.dart:26:24 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:27:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/snomed_test.dart:27:24 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:28:7 • undefined_function
+  error • The function 'equals' isn't defined • packages/medical_standards/test/snomed_test.dart:28:30 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/snomed_test.dart:31:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:34:7 • undefined_function
+  error • The function 'equals' isn't defined • packages/medical_standards/test/snomed_test.dart:34:18 • undefined_function
+  error • The function 'group' isn't defined • packages/medical_standards/test/snomed_test.dart:38:3 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/snomed_test.dart:39:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:40:7 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/snomed_test.dart:40:40 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/snomed_test.dart:43:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:46:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/snomed_test.dart:46:21 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/snomed_test.dart:49:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:51:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/snomed_test.dart:51:23 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/snomed_test.dart:52:7 • undefined_function
+  error • The function 'equals' isn't defined • packages/medical_standards/test/snomed_test.dart:52:29 • undefined_function
+  error • Target of URI doesn't exist: 'package:test/test.dart' • packages/medical_standards/test/standards_test.dart:1:8 • uri_does_not_exist
+  error • The function 'group' isn't defined • packages/medical_standards/test/standards_test.dart:5:3 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/standards_test.dart:6:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:8:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:8:21 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:11:7 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/standards_test.dart:11:26 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:18:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:18:22 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/standards_test.dart:21:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:23:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:23:23 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:24:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:24:36 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:27:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:27:25 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/standards_test.dart:30:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:32:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:32:25 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:36:7 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/standards_test.dart:36:33 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/standards_test.dart:39:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:50:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:50:22 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:51:7 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/standards_test.dart:51:33 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:52:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/standards_test.dart:52:33 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/standards_test.dart:55:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:58:9 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:58:26 • undefined_identifier
+  error • The function 'test' isn't defined • packages/medical_standards/test/standards_test.dart:62:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:64:9 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/standards_test.dart:64:32 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:65:9 • undefined_function
+  error • The function 'startsWith' isn't defined • packages/medical_standards/test/standards_test.dart:65:31 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:66:9 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/standards_test.dart:66:39 • undefined_identifier
+  error • The function 'group' isn't defined • packages/medical_standards/test/standards_test.dart:71:3 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/standards_test.dart:72:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:82:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/standards_test.dart:82:33 • undefined_function
+  error • The function 'test' isn't defined • packages/medical_standards/test/standards_test.dart:85:5 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:95:7 • undefined_function
+  error • Undefined name 'isNotNull' • packages/medical_standards/test/standards_test.dart:95:22 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:96:7 • undefined_function
+  error • Undefined name 'isNotEmpty' • packages/medical_standards/test/standards_test.dart:96:33 • undefined_identifier
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:97:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/standards_test.dart:97:33 • undefined_function
+  error • The function 'expect' isn't defined • packages/medical_standards/test/standards_test.dart:98:7 • undefined_function
+  error • The function 'contains' isn't defined • packages/medical_standards/test/standards_test.dart:98:33 • undefined_function
+   info • Don't invoke 'print' in production code • scripts/coverage_report.dart:7:5 • avoid_print
+warning • The value of the local variable 'testFeaturesDir' isn't used • scripts/coverage_report.dart:11:9 • unused_local_variable
+   info • Don't invoke 'print' in production code • scripts/coverage_report.dart:38:3 • avoid_print
+   info • Don't invoke 'print' in production code • scripts/coverage_report.dart:54:3 • avoid_print
+   info • The import of 'package:mocktail/mocktail.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter_test/flutter_test.dart' • test/core/logging/audit_logger_test.dart:7:8 • unnecessary_import
+   info • The imported package 'path_provider_platform_interface' isn't a dependency of the importing package • test/core/logging/audit_logger_test.dart:10:8 • depend_on_referenced_packages
+warning • Unused import: 'dart:io' • test/core/network/dio_behavior_test.dart:4:8 • unused_import
+   info • Don't invoke 'print' in production code • test/core/network/dio_behavior_test.dart:26:5 • avoid_print
+warning • Unused import: 'dart:io' • test/core/network/http_client_test.dart:4:8 • unused_import
+warning • The value of the local variable 'adapter' isn't used • test/core/network/http_client_test.dart:51:15 • unused_local_variable
+  error • The function 'MockEncryptionService' isn't defined • test/features/allergies/data/repositories/allergy_repository_impl_test.dart:21:80 • undefined_function
+   info • Don't return 'null' from a function with a return type of 'void' • test/features/auth/application/bloc/auth_cubit_test.dart:143:64 • avoid_returning_null_for_void
+   info • Don't return 'null' from a function with a return type of 'void' • test/features/auth/application/bloc/auth_cubit_test.dart:152:48 • avoid_returning_null_for_void
+warning • Unused import: 'package:flutter/material.dart' • test/features/auth/presentation/golden/auth_gate_golden_test.dart:2:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/auth/presentation/golden/auth_methods_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/auth/presentation/golden/auth_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/auth/presentation/golden/login_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/calendar_import/presentation/golden/calendar_import_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart' • test/features/calendar_import/presentation/golden/calendar_import_page_golden_test.dart:9:8 • unused_import
+   info • The imported package 'bloc_test' isn't a dependency of the importing package • test/features/data_sources/presentation/pages/config_page_test.dart:1:8 • depend_on_referenced_packages
+  error • Target of URI doesn't exist: 'package:bloc_test/bloc_test.dart' • test/features/data_sources/presentation/pages/config_page_test.dart:1:8 • uri_does_not_exist
+  error • Missing concrete implementations of 'BlocBase.addError', 'BlocBase.close', 'BlocBase.emit', 'BlocBase.onChange', and 7 more • test/features/data_sources/presentation/pages/config_page_test.dart:13:7 • non_abstract_class_inherits_abstract_member
+  error • Classes can only extend other classes • test/features/data_sources/presentation/pages/config_page_test.dart:13:35 • extends_non_class
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/doctor_verification/presentation/pages/doctor_detail_page_test.dart:3:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/doctor_verification/presentation/pages/doctor_list_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/email-citas/presentation/golden/email_connect_error_golden_test.dart:2:8 • unused_import
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • test/features/email-citas/presentation/widgets/citas_list_tile_test.dart:89:66 • deprecated_member_use
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • test/features/email-citas/presentation/widgets/citas_list_tile_test.dart:89:95 • deprecated_member_use
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • test/features/email-citas/presentation/widgets/citas_list_tile_test.dart:90:66 • deprecated_member_use
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • test/features/email-citas/presentation/widgets/citas_list_tile_test.dart:90:94 • deprecated_member_use
+   info • Unnecessary 'const' keyword • test/features/health_data_import/presentation/golden/data_source_card_golden_test.dart:49:26 • unnecessary_const
+warning • Unused import: 'package:flutter/material.dart' • test/features/health_data_import/presentation/golden/health_import_page_ready_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:get_it/get_it.dart' • test/features/health_data_import/presentation/golden/health_import_page_ready_golden_test.dart:4:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/health_data_import/presentation/golden/health_import_page_status_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:get_it/get_it.dart' • test/features/health_data_import/presentation/golden/health_import_page_status_golden_test.dart:4:8 • unused_import
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/health_data_import/presentation/pages/health_import_golden_test.dart:3:8 • unused_import
+warning • Unused import: 'package:orionhealth_health/features/health_data_import/domain/entities/health_import_result.dart' • test/features/health_data_import/presentation/pages/health_import_page_test.dart:10:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/health_record/presentation/golden/timeline_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:get_it/get_it.dart' • test/features/health_sharing/presentation/pages/health_sharing_page_golden_test.dart:5:8 • unused_import
+warning • Unused import: 'package:orionhealth_health/features/health_sharing/infrastructure/wifi_direct_service.dart' • test/features/health_sharing/presentation/pages/health_sharing_page_golden_test.dart:17:8 • unused_import
+  error • The named parameter 'result' is required, but there's no corresponding argument • test/features/medical_research/presentation/golden/research_result_card_golden_test.dart:8:46 • missing_required_argument
+warning • Unused import: 'package:flutter/material.dart' • test/features/network/governance/presentation/pages/governance_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/network/incentives/presentation/pages/incentives_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/network/incentives/presentation/pages/incentives_page_golden_test.dart:4:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/network/network_health/presentation/pages/network_health_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/network/presentation/golden/connection_status_badge_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/settings/presentation/golden/settings_page_golden_test.dart:2:8 • unused_import
+warning • Unused import: 'package:get_it/get_it.dart' • test/features/settings/presentation/golden/settings_page_golden_test.dart:5:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/sync/presentation/golden/sync_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/user_profile/presentation/golden/user_profile_page_golden_test.dart:1:8 • unused_import
+  error • The returned type 'Map<dynamic, dynamic>' isn't returnable from a 'Future<void>' function, as required by the closure's context • test/features/vitals/presentation/golden/vitals_monitor_page_golden_test.dart:21:80 • return_of_invalid_type_from_closure
+  error • The returned type 'String' isn't returnable from a 'Future<Transcript>' function, as required by the closure's context • test/features/voice_chat/domain/repositories/voice_chat_repository_test.dart:57:36 • return_of_invalid_type_from_closure
+warning • Unused import: 'package:flutter/material.dart' • test/features/voice_chat/presentation/golden/voice_chat_page_golden_test.dart:1:8 • unused_import
+   info • The local variable '_buildApp' starts with an underscore • test/integration/dashboard_integration_test.dart:43:10 • no_leading_underscores_for_local_identifiers
+  error • The constructor being called isn't a const constructor • test/integration/dashboard_integration_test.dart:195:35 • const_with_non_const
+warning • Unused import: 'package:orionhealth_health/features/data_sources/domain/repositories/data_source_repository.dart' • test/integration/data_sources_integration_test.dart:4:8 • unused_import
+
+269 issues found. (ran in 8.4s)

--- a/analyze_output_2.txt
+++ b/analyze_output_2.txt
@@ -1,0 +1,186 @@
+Resolving dependencies...
+Downloading packages...
+  _fe_analyzer_shared 61.0.0 (104.0.0 available)
+  analyzer 5.13.0 (14.0.0 available)
+  app_links 6.4.1 (7.2.1 available)
+  app_links_platform_interface 2.0.2 (2.0.4 available)
+  audio_session 0.2.3 (0.2.4 available)
+  build 2.4.1 (4.0.7 available)
+  build_config 1.1.2 (1.3.1 available)
+  build_daemon 4.1.1 (4.1.2 available)
+  build_resolvers 2.4.2 (3.0.4 available)
+  build_runner 2.4.13 (2.15.1 available)
+  build_runner_core 7.3.2 (9.3.2 available)
+  connectivity_plus 7.1.1 (7.2.0 available)
+  cross_file 0.3.5+2 (0.3.5+4 available)
+  dart_style 2.3.2 (3.1.11 available)
+  device_info_plus 12.4.0 (13.2.0 available)
+  device_info_plus_platform_interface 7.0.3 (8.1.0 available)
+  dio_web_adapter 2.1.2 (2.2.0 available)
+  file_picker 10.3.10 (11.0.2 available)
+  firebase_database 12.4.3 (12.4.4 available)
+  flat_buffers 23.5.26 (25.9.23 available)
+  flutter_appauth 12.0.1 (12.0.2 available)
+  flutter_blue_plus 2.3.8 (2.3.10 available)
+  flutter_blue_plus_android 9.0.2 (9.0.3 available)
+  flutter_blue_plus_darwin 9.0.2 (9.0.3 available)
+  flutter_blue_plus_linux 9.0.2 (9.0.3 available)
+  flutter_blue_plus_platform_interface 9.0.2 (9.0.3 available)
+  flutter_blue_plus_web 9.0.2 (9.0.3 available)
+  flutter_gemma 0.13.6 (1.2.2 available)
+  flutter_markdown 0.7.7+1 (discontinued replaced by flutter_markdown_plus)
+  flutter_secure_storage_darwin 0.3.2 (0.4.0 available)
+  flutter_secure_storage_windows 4.1.0 (4.2.2 available)
+  freezed 2.5.2 (3.2.5 available)
+  freezed_annotation 2.4.4 (3.1.0 available)
+  google_mlkit_commons 0.11.1 (0.12.0 available)
+  google_mlkit_text_recognition 0.15.1 (0.16.0 available)
+  googleai_dart 3.6.0 (9.0.0 available)
+  googleapis 15.0.0 (16.0.0 available)
+  googleapis_auth 2.3.2 (2.3.3 available)
+  image_picker 1.2.2 (1.2.3 available)
+  image_picker_android 0.8.13+17 (0.8.13+19 available)
+  injectable 2.7.1+4 (3.0.0 available)
+  injectable_generator 2.4.2 (3.1.0 available)
+  intl 0.20.2 (0.20.3 available)
+  js 0.6.7 (0.7.2 available)
+  just_audio 0.10.5 (0.10.6 available)
+  large_file_handler 0.3.1 (0.5.0 available)
+  local_auth 3.0.1 (3.0.2 available)
+  local_auth_android 2.0.8 (2.0.9 available)
+  matcher 0.12.18 (0.12.20 available)
+  meta 1.17.0 (1.19.0 available)
+  mobile_scanner 6.0.11 (7.2.0 available)
+  mockito 5.4.4 (5.7.0 available)
+  native_toolchain_c 0.19.1 (0.19.2 available)
+  objectbox 5.0.4 (5.3.2 available)
+  objectbox_flutter_libs 5.0.4 (5.3.2 available)
+  package_config 2.2.0 (3.0.0 available)
+  path_provider_linux 2.2.1 (2.2.2 available)
+  pointycastle 3.9.1 (4.0.0 available)
+  record 6.2.1 (7.1.1 available)
+  record_android 1.5.2 (2.1.2 available)
+  record_ios 1.2.1 (2.1.1 available)
+  record_linux 1.3.1 (2.1.1 available)
+  record_macos 1.2.2 (2.1.1 available)
+  record_platform_interface 1.6.0 (2.1.0 available)
+  record_web 1.3.0 (2.1.1 available)
+  record_windows 1.0.7 (2.2.2 available)
+  share_plus 12.0.2 (13.2.0 available)
+  share_plus_platform_interface 6.1.0 (7.1.0 available)
+  shared_preferences_android 2.4.23 (2.4.26 available)
+  shelf_web_socket 2.0.1 (3.0.0 available)
+  source_gen 1.5.0 (4.2.3 available)
+  sqflite 2.4.2+1 (2.4.3 available)
+  sqflite_android 2.4.2+3 (2.4.3 available)
+  sqflite_common 2.5.8 (2.5.11 available)
+  sqflite_darwin 2.4.2 (2.4.3+1 available)
+  sqflite_platform_interface 2.4.0 (2.4.1 available)
+  sqlite3 3.3.3 (3.3.4 available)
+  synchronized 3.4.0+1 (3.4.1 available)
+  test_api 0.7.9 (0.7.13 available)
+  timezone 0.9.4 (0.11.1 available)
+  url_launcher_android 6.3.30 (6.3.32 available)
+  vector_math 2.2.0 (2.4.0 available)
+  vertex_ai 0.2.1 (0.2.4 available)
+  web_socket_channel 2.4.0 (3.0.3 available)
+  win32 5.15.0 (6.3.0 available)
+  win32_registry 2.1.0 (3.0.3 available)
+  xml 6.6.1 (7.0.1 available)
+Got dependencies!
+1 package is discontinued.
+86 packages have newer versions incompatible with dependency constraints.
+Try `flutter pub outdated` for more information.
+Analyzing app...
+
+warning • Unused import: 'dart:async' • integration_test/about_e2e_test.dart:1:8 • unused_import
+warning • Unused import: 'dart:async' • integration_test/doctor_verification_e2e_test.dart:14:8 • unused_import
+  error • Invalid constant value • integration_test/doctor_verification_e2e_test.dart:131:40 • invalid_constant
+warning • Unused import: 'dart:async' • integration_test/email_citas_e2e_test.dart:4:8 • unused_import
+   info • 'setMockMethodCallHandler' is deprecated and shouldn't be used. Use tester.binding.defaultBinaryMessenger.setMockMethodCallHandler or TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger.setMockMethodCallHandler instead. Pass the channel as the first argument. This feature was deprecated after v3.9.0-19.0.pre • integration_test/health_data_import_e2e_test.dart:55:10 • deprecated_member_use
+warning • Unused import: 'package:orionhealth_health/features/health_record/domain/repositories/health_record_repository.dart' • integration_test/health_record_e2e_test.dart:10:8 • unused_import
+warning • Unused import: 'package:orionhealth_health/features/health_sharing/application/sharing_cubit.dart' • integration_test/health_sharing_e2e_test.dart:7:8 • unused_import
+   info • Angle brackets will be interpreted as HTML • integration_test/screenshot_flow_e2e_test.dart:27:61 • unintended_html_in_doc_comment
+   info • Angle brackets will be interpreted as HTML • integration_test/screenshot_flow_e2e_test.dart:27:68 • unintended_html_in_doc_comment
+   info • Don't invoke 'print' in production code • integration_test/utils/video_recorder.dart:19:5 • avoid_print
+   info • Use the null-aware marker '?' rather than a null check via an 'if' • lib/core/logging/audit_logger.dart:57:7 • use_null_aware_elements
+   info • 'encryptedSharedPreferences' is deprecated and shouldn't be used. EncryptedSharedPreferences is deprecated and will be removed in v11. The Jetpack Security library is deprecated by Google. Your data will be automatically migrated to custom ciphers on first access. Remove this parameter - it will be ignored • lib/core/services/secure_storage_service.dart:58:17 • deprecated_member_use
+   info • Use the null-aware marker '?' rather than a null check via an 'if' • lib/core/widgets/page_header.dart:62:15 • use_null_aware_elements
+   info • Constructors for public widgets should have a named 'key' parameter • lib/features/about/presentation/pages/about_page.dart:102:9 • use_key_in_widget_constructors
+warning • Unused import: 'package:injectable/injectable.dart' • lib/features/allergies/infrastructure/repositories/isar_allergy_repository.dart:1:8 • unused_import
+warning • Unused import: 'package:injectable/injectable.dart' • lib/features/appointments/infrastructure/repositories/isar_appointment_repository.dart:1:8 • unused_import
+   info • 'value' is deprecated and shouldn't be used. Use initialValue instead. This will set the initial value for the form field. This feature was deprecated after v3.33.0-1.0.pre • lib/features/appointments/presentation/widgets/appointment_form.dart:119:15 • deprecated_member_use
+   info • 'activeColor' is deprecated and shouldn't be used. Use activeThumbColor instead. This feature was deprecated after v3.31.0-2.0.pre • lib/features/data_sources/presentation/widgets/data_source_tile.dart:44:15 • deprecated_member_use
+   info • Unnecessary 'const' keyword • lib/features/eps_connection/presentation/pages/eps_connection_page.dart:99:18 • unnecessary_const
+warning • Unused import: '../entities/health_import_result.dart' • lib/features/health_data_import/domain/usecases/health_import_usecases.dart:5:8 • unused_import
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • lib/features/health_sharing/presentation/widgets/share_card.dart:54:47 • deprecated_member_use
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • lib/features/health_sharing/presentation/widgets/share_card.dart:121:29 • deprecated_member_use
+warning • Duplicate import • lib/features/local_agent/domain/services/llm_adapter.dart:8:8 • duplicate_import
+warning • Duplicate import • lib/features/local_agent/domain/services/llm_adapter.dart:9:8 • duplicate_import
+warning • Unused import: 'package:isar/isar.dart' • lib/features/local_agent/domain/services/vector_store_service.dart:1:8 • unused_import
+warning • Unused import: '../../../../core/widgets/glassmorphic_card.dart' • lib/features/medications/presentation/pages/medications_page.dart:6:8 • unused_import
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • lib/features/network/network_health/presentation/widgets/network_stats_card.dart:78:34 • deprecated_member_use
+warning • The declaration 'hasConsent' isn't referenced • lib/features/onboarding/presentation/pages/hipaa_consent_page.dart:375:23 • unused_element
+   info • Unnecessary 'const' keyword • lib/features/settings/presentation/widgets/profile_section.dart:69:19 • unnecessary_const
+   info • 'activeColor' is deprecated and shouldn't be used. Use activeThumbColor instead. This feature was deprecated after v3.31.0-2.0.pre • lib/features/settings/presentation/widgets/profile_section.dart:80:17 • deprecated_member_use
+warning • Unused import: 'features/home/presentation/pages/main_navigation_page.dart' • lib/main.dart:26:8 • unused_import
+   info • The imported package 'flutter_test' isn't a dependency of the importing package • packages/health_wallet/test/encryption_service_test.dart:2:8 • depend_on_referenced_packages
+   info • The imported package 'flutter_test' isn't a dependency of the importing package • packages/health_wallet/test/sync_service_test.dart:2:8 • depend_on_referenced_packages
+   info • The imported package 'flutter_test' isn't a dependency of the importing package • packages/health_wallet/test/wallet_service_test.dart:2:8 • depend_on_referenced_packages
+   info • The imported package 'path' isn't a dependency of the importing package • packages/health_wallet/test/wallet_service_test.dart:4:8 • depend_on_referenced_packages
+   info • Don't invoke 'print' in production code • scripts/coverage_report.dart:7:5 • avoid_print
+warning • The value of the local variable 'testFeaturesDir' isn't used • scripts/coverage_report.dart:11:9 • unused_local_variable
+   info • Don't invoke 'print' in production code • scripts/coverage_report.dart:38:3 • avoid_print
+   info • Don't invoke 'print' in production code • scripts/coverage_report.dart:54:3 • avoid_print
+   info • The import of 'package:mocktail/mocktail.dart' is unnecessary because all of the used elements are also provided by the import of 'package:flutter_test/flutter_test.dart' • test/core/logging/audit_logger_test.dart:7:8 • unnecessary_import
+   info • The imported package 'path_provider_platform_interface' isn't a dependency of the importing package • test/core/logging/audit_logger_test.dart:10:8 • depend_on_referenced_packages
+warning • Unused import: 'dart:io' • test/core/network/dio_behavior_test.dart:4:8 • unused_import
+   info • Don't invoke 'print' in production code • test/core/network/dio_behavior_test.dart:26:5 • avoid_print
+warning • Unused import: 'dart:io' • test/core/network/http_client_test.dart:4:8 • unused_import
+warning • The value of the local variable 'adapter' isn't used • test/core/network/http_client_test.dart:51:15 • unused_local_variable
+  error • Target of URI doesn't exist: 'package:orionhealth_health/core/security/encryption_service.dart' • test/features/allergies/data/repositories/allergy_repository_impl_test.dart:3:8 • uri_does_not_exist
+  error • Classes and mixins can only implement other classes and mixins • test/features/allergies/data/repositories/allergy_repository_impl_test.dart:10:53 • implements_non_class
+  error • The argument type 'MockEncryptionService' can't be assigned to the parameter type 'EncryptionService'.  • test/features/allergies/data/repositories/allergy_repository_impl_test.dart:24:80 • argument_type_not_assignable
+   info • Don't return 'null' from a function with a return type of 'void' • test/features/auth/application/bloc/auth_cubit_test.dart:143:64 • avoid_returning_null_for_void
+   info • Don't return 'null' from a function with a return type of 'void' • test/features/auth/application/bloc/auth_cubit_test.dart:152:48 • avoid_returning_null_for_void
+warning • Unused import: 'package:flutter/material.dart' • test/features/auth/presentation/golden/auth_gate_golden_test.dart:2:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/auth/presentation/golden/auth_methods_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/auth/presentation/golden/auth_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/auth/presentation/golden/login_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/calendar_import/presentation/golden/calendar_import_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart' • test/features/calendar_import/presentation/golden/calendar_import_page_golden_test.dart:9:8 • unused_import
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/data_sources/presentation/pages/config_page_test.dart:2:8 • unused_import
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/doctor_verification/presentation/pages/doctor_detail_page_test.dart:3:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/doctor_verification/presentation/pages/doctor_list_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/email-citas/presentation/golden/email_connect_error_golden_test.dart:2:8 • unused_import
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • test/features/email-citas/presentation/widgets/citas_list_tile_test.dart:89:66 • deprecated_member_use
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • test/features/email-citas/presentation/widgets/citas_list_tile_test.dart:89:95 • deprecated_member_use
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • test/features/email-citas/presentation/widgets/citas_list_tile_test.dart:90:66 • deprecated_member_use
+   info • 'withOpacity' is deprecated and shouldn't be used. Use .withValues() to avoid precision loss • test/features/email-citas/presentation/widgets/citas_list_tile_test.dart:90:94 • deprecated_member_use
+   info • Unnecessary 'const' keyword • test/features/health_data_import/presentation/golden/data_source_card_golden_test.dart:49:26 • unnecessary_const
+warning • Unused import: 'package:flutter/material.dart' • test/features/health_data_import/presentation/golden/health_import_page_ready_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:get_it/get_it.dart' • test/features/health_data_import/presentation/golden/health_import_page_ready_golden_test.dart:4:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/health_data_import/presentation/golden/health_import_page_status_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:get_it/get_it.dart' • test/features/health_data_import/presentation/golden/health_import_page_status_golden_test.dart:4:8 • unused_import
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/health_data_import/presentation/pages/health_import_golden_test.dart:3:8 • unused_import
+warning • Unused import: 'package:orionhealth_health/features/health_data_import/domain/entities/health_import_result.dart' • test/features/health_data_import/presentation/pages/health_import_page_test.dart:10:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/health_record/presentation/golden/timeline_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:get_it/get_it.dart' • test/features/health_sharing/presentation/pages/health_sharing_page_golden_test.dart:5:8 • unused_import
+warning • Unused import: 'package:orionhealth_health/features/health_sharing/infrastructure/wifi_direct_service.dart' • test/features/health_sharing/presentation/pages/health_sharing_page_golden_test.dart:17:8 • unused_import
+  error • Const variables must be initialized with a constant value • test/features/medical_research/presentation/golden/research_result_card_golden_test.dart:7:21 • const_initialized_with_non_constant_value
+  error • The function 'ResearchResult' isn't defined • test/features/medical_research/presentation/golden/research_result_card_golden_test.dart:7:21 • undefined_function
+warning • Unused import: 'package:flutter/material.dart' • test/features/network/governance/presentation/pages/governance_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/network/incentives/presentation/pages/incentives_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/network/incentives/presentation/pages/incentives_page_golden_test.dart:4:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/network/network_health/presentation/pages/network_health_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/network/presentation/golden/connection_status_badge_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter_bloc/flutter_bloc.dart' • test/features/settings/presentation/golden/settings_page_golden_test.dart:2:8 • unused_import
+warning • Unused import: 'package:get_it/get_it.dart' • test/features/settings/presentation/golden/settings_page_golden_test.dart:5:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/sync/presentation/golden/sync_page_golden_test.dart:1:8 • unused_import
+warning • Unused import: 'package:flutter/material.dart' • test/features/user_profile/presentation/golden/user_profile_page_golden_test.dart:1:8 • unused_import
+  error • The function 'Transcript' isn't defined • test/features/voice_chat/domain/repositories/voice_chat_repository_test.dart:55:27 • undefined_function
+warning • Unused import: 'package:flutter/material.dart' • test/features/voice_chat/presentation/golden/voice_chat_page_golden_test.dart:1:8 • unused_import
+   info • The local variable '_buildApp' starts with an underscore • test/integration/dashboard_integration_test.dart:43:10 • no_leading_underscores_for_local_identifiers
+warning • Unused import: 'package:orionhealth_health/features/data_sources/domain/repositories/data_source_repository.dart' • test/integration/data_sources_integration_test.dart:4:8 • unused_import
+
+89 issues found. (ran in 10.6s)

--- a/integration_test/about_e2e_test.dart
+++ b/integration_test/about_e2e_test.dart
@@ -1,4 +1,3 @@
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';

--- a/integration_test/doctor_verification_e2e_test.dart
+++ b/integration_test/doctor_verification_e2e_test.dart
@@ -11,7 +11,6 @@ import 'package:orionhealth_health/features/doctor_verification/domain/services/
 import 'package:orionhealth_health/features/doctor_verification/presentation/widgets/doctor_card.dart';
 import 'package:orionhealth_health/features/doctor_verification/presentation/widgets/rating_dialog.dart';
 import 'package:mocktail/mocktail.dart';
-import 'dart:async';
 import 'package:orionhealth_health/features/doctor_verification/domain/entities/doctor_rating.dart';
 import 'utils/video_recorder.dart';
 
@@ -127,7 +126,7 @@ void main() {
       when(() => mockLicenseVerifier.verify(any(), any()))
           .thenThrow(Exception('Verification Failed'));
 
-      await tester.pumpWidget(const MaterialApp(
+      await tester.pumpWidget(MaterialApp(
         home: DoctorDetailPage(doctor: doctor),
       ));
       await tester.pumpAndSettle();

--- a/integration_test/email_citas_e2e_test.dart
+++ b/integration_test/email_citas_e2e_test.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // SPDX-FileCopyrightText: 2025 SouthWest AI Labs
 
-import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/integration_test/health_data_import_e2e_test.dart
+++ b/integration_test/health_data_import_e2e_test.dart
@@ -8,6 +8,7 @@ import 'package:orionhealth_health/core/di/injection.dart' as di;
 import 'package:orionhealth_health/features/health_data_import/presentation/pages/health_import_page.dart';
 import 'package:orionhealth_health/features/health_data_import/domain/usecases/health_import_usecases.dart';
 import 'package:orionhealth_health/features/health_data_import/domain/entities/health_data_source.dart';
+import 'package:orionhealth_health/features/health_data_import/domain/services/health_data_import_service.dart';
 import 'package:orionhealth_health/features/vitals/domain/repositories/vital_sign_repository.dart';
 import 'package:orionhealth_health/features/vitals/domain/entities/vital_sign.dart';
 import 'package:orionhealth_health/features/user_profile/presentation/pages/user_profile_page.dart';

--- a/integration_test/health_record_e2e_test.dart
+++ b/integration_test/health_record_e2e_test.dart
@@ -7,7 +7,6 @@ import 'package:integration_test/integration_test.dart';
 import 'package:orionhealth_health/core/di/injection.dart' as di;
 import 'package:orionhealth_health/features/health_record/presentation/pages/timeline_page.dart';
 import 'package:orionhealth_health/features/health_record/presentation/pages/health_record_staging_page.dart';
-import 'package:orionhealth_health/features/health_record/domain/repositories/health_record_repository.dart';
 import 'package:orionhealth_health/features/health_record/domain/entities/medical_record.dart';
 import 'package:orionhealth_health/features/health_record/infrastructure/services/file_picker_service.dart';
 import 'package:orionhealth_health/features/health_record/infrastructure/services/image_picker_service.dart';

--- a/integration_test/health_sharing_e2e_test.dart
+++ b/integration_test/health_sharing_e2e_test.dart
@@ -4,7 +4,6 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:integration_test/integration_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/core/di/injection.dart' as di;
-import 'package:orionhealth_health/features/health_sharing/application/sharing_cubit.dart';
 import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
 import 'package:orionhealth_health/features/health_sharing/presentation/pages/share_page.dart';
 import 'package:orionhealth_health/features/health_sharing/presentation/pages/receive_page.dart';
@@ -111,7 +110,7 @@ void main() {
         package: any(named: 'package'),
         pin: any(named: 'pin'),
       )).thenAnswer((_) async {
-        bleStateController.add(const BleSharingState(status: 'scanning'));
+        bleStateController.add(BleSharingState.scanning());
       });
 
       await tester.tap(find.text('Compartir'));
@@ -121,11 +120,7 @@ void main() {
       await VideoRecorder.recordStep(tester, 'health_sharing', '02_sharing_scanning');
 
       // Simulate completion
-      bleStateController.add(const BleSharingState(
-        status: 'completed',
-        bytesTransferred: 1024,
-        transferTime: Duration(seconds: 2),
-      ));
+      bleStateController.add(BleSharingState.completed(1024, const Duration(seconds: 2)));
       await tester.pumpAndSettle();
 
       expect(find.text('¡Compartido exitosamente!'), findsOneWidget);
@@ -145,7 +140,7 @@ void main() {
 
       when(() => mockStartListeningUseCase(any(), pin: any(named: 'pin')))
           .thenAnswer((_) async {
-        nfcStateController.add(const NfcSharingState(status: 'listening'));
+        nfcStateController.add(NfcSharingState.listening());
       });
 
       await tester.tap(find.text('NFC'));
@@ -170,7 +165,7 @@ void main() {
         signature: 'sig',
       );
 
-      nfcStateController.add(NfcSharingState(status: 'received', receivedPackage: mockPackage));
+      nfcStateController.add(NfcSharingState.received(mockPackage));
       await tester.pumpAndSettle();
 
       expect(find.text('Datos recibidos'), findsOneWidget);
@@ -186,11 +181,7 @@ void main() {
       await tester.tap(find.text('Importar'));
       await tester.pump();
 
-      nfcStateController.add(const NfcSharingState(
-        status: 'completed',
-        bytesTransferred: 512,
-        transferTime: Duration(seconds: 1),
-      ));
+      nfcStateController.add(NfcSharingState.completed(512, const Duration(seconds: 1)));
       await tester.pumpAndSettle();
 
       expect(find.text('¡Importación completa!'), findsOneWidget);
@@ -210,7 +201,7 @@ void main() {
         package: any(named: 'package'),
         pin: any(named: 'pin'),
       )).thenAnswer((_) async {
-        bleStateController.add(const BleSharingState(status: 'scanning'));
+        bleStateController.add(BleSharingState.scanning());
       });
 
       await tester.tap(find.text('Laboratorios'));
@@ -234,7 +225,7 @@ void main() {
 
       when(() => mockStartListeningUseCase(any(), pin: any(named: 'pin')))
           .thenAnswer((_) async {
-        nfcStateController.add(const NfcSharingState(status: 'listening'));
+        nfcStateController.add(NfcSharingState.listening());
       });
 
       await tester.tap(find.text('NFC'));
@@ -256,7 +247,7 @@ void main() {
         signature: 'sig',
       );
 
-      nfcStateController.add(NfcSharingState(status: 'received', receivedPackage: mockPackage));
+      nfcStateController.add(NfcSharingState.received(mockPackage));
       await tester.pumpAndSettle();
 
       expect(find.text('Datos recibidos'), findsOneWidget);

--- a/integration_test/medical_research_e2e_test.dart
+++ b/integration_test/medical_research_e2e_test.dart
@@ -89,6 +89,7 @@ void main() {
             latestVitals: [],
             upcomingAppointments: [],
             medicationCount: 0,
+            summaryText: 'Summary',
           ));
 
       // Mock Research Data

--- a/integration_test/meditation_e2e_test.dart
+++ b/integration_test/meditation_e2e_test.dart
@@ -48,7 +48,6 @@ void main() {
 
     when(() => mockRepository.initialize()).thenAnswer((_) async {});
     when(() => mockRepository.getProgress()).thenAnswer((_) async => const MeditationProgress());
-    when(() => mockRepository.getHomeModules()).thenAnswer((_) async => []); // If needed
   });
 
   tearDown(() {

--- a/integration_test/vitals_e2e_test.dart
+++ b/integration_test/vitals_e2e_test.dart
@@ -73,7 +73,7 @@ void main() {
 
       expect(find.text('72.0'), findsOneWidget);
       expect(find.text('120/80'), findsOneWidget);
-      expect(find.textContaining('RITMO CARDÍACO', caseSensitive: false), findsOneWidget);
+      expect(find.textContaining('RITMO CARDÍACO'), findsOneWidget);
 
       // 2. MANUAL ENTRY
       await tester.tap(find.text('Agregar Signo Vital'));

--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -25,30 +25,25 @@ import 'package:just_audio/just_audio.dart' as _i13;
 import 'package:medical_standards/medical_standards.dart' as _i69;
 import 'package:shared_preferences/shared_preferences.dart' as _i52;
 
-import '../../features/about/application/about_cubit.dart' as _i142;
-import '../../features/about/application/about_cubit.dart' as _i143;
+import '../../features/about/application/about_cubit.dart' as _i141;
 import '../../features/about/domain/repositories/i_about_repository.dart'
     as _i54;
 import '../../features/about/domain/usecases/get_about_info_usecase.dart'
-    as _i167;
+    as _i165;
 import '../../features/about/infrastructure/datasources/about_local_datasource.dart'
     as _i4;
 import '../../features/about/infrastructure/datasources/about_remote_datasource.dart'
-    as _i143;
-    as _i168;
-    as _i144;
+    as _i142;
 import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
     as _i55;
 import '../../features/allergies/application/allergies_cubit.dart' as _i262;
 import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i263;
 import '../../features/allergies/data/datasources/allergy_local_datasource.dart'
-    as _i144;
+    as _i143;
 import '../../features/allergies/data/repositories/allergy_repository_impl.dart'
     as _i226;
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
     as _i225;
-    as _i145;
-    as _i227;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i6;
 import '../../features/allergies/domain/usecases/get_allergies_usecase.dart'
     as _i243;
@@ -67,55 +62,38 @@ import '../../features/appointments/domain/usecases/delete_appointment_usecase.d
 import '../../features/appointments/domain/usecases/get_all_appointments_usecase.dart'
     as _i44;
 import '../../features/appointments/domain/usecases/save_appointment_usecase.dart'
-    as _i109;
-import '../../features/auth/application/auth_cubit.dart' as _i263;
+    as _i110;
+import '../../features/auth/application/auth_cubit.dart' as _i264;
 import '../../features/auth/application/bloc/auth_cubit.dart' as _i227;
 import '../../features/auth/data/datasources/auth_local_datasource.dart'
-    as _i145;
+    as _i144;
 import '../../features/auth/data/repositories/auth_repository_impl.dart'
-    as _i147;
+    as _i146;
 import '../../features/auth/domain/auth_service.dart' as _i228;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i146;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i145;
 import '../../features/auth/domain/usecases/check_session_timeout.dart'
-    as _i151;
+    as _i150;
 import '../../features/auth/domain/usecases/get_credentials_usecase.dart'
-    as _i173;
-import '../../features/auth/domain/usecases/login_usecase.dart' as _i195;
-import '../../features/auth/domain/usecases/logout_usecase.dart' as _i196;
+    as _i171;
+import '../../features/auth/domain/usecases/login_usecase.dart' as _i193;
+import '../../features/auth/domain/usecases/logout_usecase.dart' as _i194;
 import '../../features/auth/domain/usecases/save_credentials_usecase.dart'
-    as _i208;
-import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i215;
+    as _i206;
+import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i213;
 import '../../features/auth/domain/usecases/validate_session_usecase.dart'
     as _i221;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i16;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i164;
+    as _i163;
 import '../../features/calendar_import/application/calendar_import_cubit.dart'
     as _i231;
-    as _i110;
-import '../../features/auth/application/auth_cubit.dart' as _i264;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i228;
-    as _i146;
-    as _i148;
-import '../../features/auth/domain/auth_service.dart' as _i229;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i147;
-    as _i152;
-    as _i174;
-import '../../features/auth/domain/usecases/login_usecase.dart' as _i196;
-import '../../features/auth/domain/usecases/logout_usecase.dart' as _i197;
-    as _i209;
-import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i216;
-    as _i222;
-    as _i165;
-    as _i232;
 import '../../features/calendar_import/domain/repositories/calendar_import_repository.dart'
     as _i21;
 import '../../features/calendar_import/domain/services/calendar_parser_service.dart'
     as _i23;
 import '../../features/calendar_import/domain/usecases/import_calendar_usecase.dart'
-    as _i188;
-    as _i189;
+    as _i186;
 import '../../features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart'
     as _i19;
 import '../../features/calendar_import/infrastructure/repositories/calendar_import_repository_impl.dart'
@@ -125,83 +103,65 @@ import '../../features/calendar_import/infrastructure/services/calendar_parser_s
 import '../../features/dashboard/application/dashboard_cubit.dart' as _i265;
 import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
     as _i233;
-    as _i234;
 import '../../features/dashboard/domain/usecases/get_dashboard_stats_usecase.dart'
     as _i244;
 import '../../features/dashboard/domain/usecases/get_recent_activity_usecase.dart'
     as _i246;
 import '../../features/dashboard/infrastructure/datasources/dashboard_local_datasource.dart'
-    as _i155;
+    as _i154;
 import '../../features/dashboard/infrastructure/datasources/dashboard_remote_datasource.dart'
     as _i27;
 import '../../features/dashboard/infrastructure/repositories/dashboard_repository_impl.dart'
     as _i234;
 import '../../features/data_sources/application/data_source_cubit.dart'
-    as _i265;
+    as _i266;
 import '../../features/data_sources/domain/repositories/data_source_repository.dart'
     as _i235;
 import '../../features/data_sources/infrastructure/datasources/file_import_datasource.dart'
-    as _i166;
+    as _i164;
 import '../../features/data_sources/infrastructure/datasources/health_connect_datasource.dart'
-    as _i45;
+    as _i46;
 import '../../features/data_sources/infrastructure/datasources/sensor_api_datasource.dart'
-    as _i115;
+    as _i116;
 import '../../features/data_sources/infrastructure/repositories/data_source_repository_impl.dart'
     as _i236;
 import '../../features/doctor_verification/application/badge_cubit.dart'
     as _i230;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
-    as _i161;
+    as _i160;
 import '../../features/doctor_verification/application/second_opinion_cubit.dart'
-    as _i213;
+    as _i211;
 import '../../features/doctor_verification/application/vouch_cubit.dart'
     as _i224;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
-    as _i159;
+    as _i158;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
-    as _i103;
+    as _i104;
 import '../../features/doctor_verification/domain/repositories/second_opinion_repository.dart'
-    as _i111;
+    as _i112;
 import '../../features/doctor_verification/domain/repositories/vouch_repository.dart'
-    as _i139;
+    as _i138;
 import '../../features/doctor_verification/domain/services/badge_calculator.dart'
     as _i229;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
-    as _i62;
-import '../../features/doctor_verification/domain/usecases/get_all_doctors_usecase.dart'
-    as _i168;
-import '../../features/doctor_verification/domain/usecases/get_doctor_profile_usecase.dart'
-    as _i174;
-import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
-    as _i61;
-import '../../features/doctor_verification/infrastructure/repositories/isar_doctor_profile_repository.dart'
-    as _i160;
-import '../../features/doctor_verification/infrastructure/repositories/isar_rating_repository.dart'
-    as _i104;
-import '../../features/doctor_verification/infrastructure/repositories/isar_second_opinion_repository.dart'
-    as _i112;
-import '../../features/doctor_verification/infrastructure/repositories/isar_vouch_repository.dart'
-    as _i140;
-import '../../features/email-citas/application/bloc/email_citas_bloc.dart'
-    as _i162;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i163;
-    as _i156;
-    as _i266;
-    as _i167;
-    as _i46;
-    as _i116;
-    as _i237;
-    as _i231;
-    as _i214;
-    as _i225;
     as _i63;
-    as _i169;
-    as _i175;
+import '../../features/doctor_verification/domain/usecases/get_all_doctors_usecase.dart'
+    as _i166;
+import '../../features/doctor_verification/domain/usecases/get_doctor_profile_usecase.dart'
+    as _i172;
+import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
+    as _i62;
+import '../../features/doctor_verification/infrastructure/repositories/isar_doctor_profile_repository.dart'
+    as _i159;
+import '../../features/doctor_verification/infrastructure/repositories/isar_rating_repository.dart'
     as _i105;
+import '../../features/doctor_verification/infrastructure/repositories/isar_second_opinion_repository.dart'
     as _i113;
-    as _i141;
-    as _i163;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i164;
+import '../../features/doctor_verification/infrastructure/repositories/isar_vouch_repository.dart'
+    as _i139;
+import '../../features/email-citas/application/bloc/email_citas_bloc.dart'
+    as _i161;
+import '../../features/email-citas/application/email_citas_cubit.dart' as _i162;
 import '../../features/email-citas/domain/repositories/email_repository.dart'
     as _i32;
 import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
@@ -213,45 +173,23 @@ import '../../features/eps_connection/application/bloc/eps_connection_bloc.dart'
 import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
     as _i239;
 import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
-    as _i97;
-import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
-    as _i154;
-import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
-    as _i156;
-import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
-    as _i172;
-import '../../features/eps_connection/infrastructure/datasources/oauth_local_datasource.dart'
-    as _i96;
-import '../../features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart'
-    as _i240;
     as _i98;
 import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
-    as _i155;
+    as _i153;
 import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
-    as _i157;
+    as _i155;
 import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
-    as _i173;
+    as _i170;
 import '../../features/eps_connection/infrastructure/datasources/oauth_local_datasource.dart'
     as _i97;
 import '../../features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart'
     as _i99;
 import '../../features/health_data_import/application/bloc/health_import_bloc.dart'
     as _i247;
-import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i184;
-import '../../features/health_data_import/domain/services/health_data_import_service.dart'
-    as _i46;
-import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
-    as _i108;
-import '../../features/health_data_import/infrastructure/data_source.dart'
-    as _i116;
-import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i185;
-import '../../features/health_record/application/bloc/health_record_cubit.dart'
 import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i248;
 import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i185;
+    as _i182;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i47;
 import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
@@ -259,20 +197,17 @@ import '../../features/health_data_import/domain/usecases/health_import_usecases
 import '../../features/health_data_import/infrastructure/data_source.dart'
     as _i117;
 import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i186;
+    as _i183;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
     as _i249;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i186;
-    as _i187;
+    as _i184;
 import '../../features/health_record/domain/usecases/get_all_records_usecase.dart'
     as _i242;
 import '../../features/health_record/domain/usecases/save_record_usecase.dart'
-    as _i210;
+    as _i208;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i187;
-    as _i211;
-    as _i188;
+    as _i185;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i37;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
@@ -283,30 +218,16 @@ import '../../features/health_sharing/application/sharing_cubit.dart' as _i261;
 import '../../features/health_sharing/domain/repositories/sharing_repository.dart'
     as _i121;
 import '../../features/health_sharing/domain/usecases/cancel_sharing_usecase.dart'
-    as _i149;
-import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
-    as _i217;
-import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
-    as _i218;
-import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
     as _i148;
-    as _i150;
-    as _i219;
+import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
+    as _i215;
+import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
+    as _i216;
+import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
+    as _i147;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i17;
 import '../../features/health_sharing/infrastructure/datasources/health_sharing_local_datasource.dart'
     as _i48;
-import '../../features/health_sharing/infrastructure/nfc_handler.dart' as _i91;
-import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
-    as _i93;
-import '../../features/health_sharing/infrastructure/repositories/health_sharing_repository_impl.dart'
-    as _i121;
-import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i141;
-import '../../features/home/application/home_cubit.dart' as _i268;
-import '../../features/home/domain/repositories/home_repository.dart' as _i249;
-import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
-    as _i266;
-import '../../features/home/infrastructure/datasources/health_summary_datasource.dart'
 import '../../features/health_sharing/infrastructure/datasources/health_sharing_remote_datasource.dart'
     as _i49;
 import '../../features/health_sharing/infrastructure/nfc_handler.dart' as _i92;
@@ -315,7 +236,7 @@ import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
 import '../../features/health_sharing/infrastructure/repositories/health_sharing_repository_impl.dart'
     as _i122;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i142;
+    as _i140;
 import '../../features/home/application/home_cubit.dart' as _i269;
 import '../../features/home/domain/repositories/home_repository.dart' as _i250;
 import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
@@ -329,22 +250,18 @@ import '../../features/home/infrastructure/datasources/home_remote_datasource.da
 import '../../features/home/infrastructure/repositories/home_repository_impl.dart'
     as _i251;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i216;
+    as _i214;
 import '../../features/local_agent/data/datasources/chat_message_local_datasource.dart'
-    as _i150;
-    as _i217;
-    as _i151;
+    as _i149;
 import '../../features/local_agent/data/datasources/local_model_local_datasource.dart'
     as _i68;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i70;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i64;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i132;
+    as _i131;
 import '../../features/local_agent/domain/usecases/get_chat_history_usecase.dart'
-    as _i171;
-    as _i133;
-    as _i172;
+    as _i168;
 import '../../features/local_agent/domain/usecases/send_chat_message_usecase.dart'
     as _i115;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
@@ -352,48 +269,26 @@ import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i40;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i189;
-    as _i191;
+    as _i187;
 import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i42;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i190;
+    as _i188;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i64;
-import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i193;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i192;
     as _i66;
-    as _i194;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i193;
+import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
+    as _i191;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i190;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
     as _i252;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i70;
+    as _i72;
 import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i71;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i133;
+    as _i132;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i191;
-import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
-    as _i66;
-import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i269;
-import '../../features/local_agent/infrastructure/services/model_download_service.dart'
-    as _i84;
-import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i256;
-import '../../features/medical_research/application/medical_research_cubit.dart'
-    as _i270;
-import '../../features/medical_research/domain/repositories/medical_research_repository.dart'
-    as _i252;
-import '../../features/medical_research/domain/services/medical_scraper_service.dart'
-    as _i72;
-import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i134;
-import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i192;
+    as _i189;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i67;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
@@ -419,236 +314,182 @@ import '../../features/medical_research/domain/usecases/search_medical_research.
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i18;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i197;
-    as _i198;
+    as _i195;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i74;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
     as _i76;
 import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
-    as _i77;
-import '../../features/medical_research/infrastructure/repositories/medical_research_repository_impl.dart'
-    as _i253;
-import '../../features/medications/application/bloc/medication_bloc.dart'
-    as _i254;
-import '../../features/medications/application/medications_cubit.dart' as _i200;
-import '../../features/medications/domain/repositories/medication_adherence_repository.dart'
     as _i78;
+import '../../features/medical_research/infrastructure/repositories/medical_research_repository_impl.dart'
+    as _i254;
+import '../../features/medications/application/bloc/medication_bloc.dart'
     as _i255;
-import '../../features/medications/application/medications_cubit.dart' as _i201;
+import '../../features/medications/application/medications_cubit.dart' as _i198;
+import '../../features/medications/domain/repositories/medication_adherence_repository.dart'
     as _i79;
 import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i198;
-    as _i199;
+    as _i196;
 import '../../features/medications/domain/usecases/get_all_medications_usecase.dart'
     as _i241;
 import '../../features/medications/domain/usecases/save_medication_usecase.dart'
-    as _i209;
+    as _i207;
 import '../../features/medications/infrastructure/datasources/adherence_sqlite_datasource.dart'
     as _i5;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i199;
+    as _i197;
 import '../../features/medications/infrastructure/repositories/sqlite_medication_adherence_repository.dart'
-    as _i79;
-import '../../features/medications/infrastructure/services/pharmacy_api_service.dart'
-    as _i100;
-import '../../features/medications/infrastructure/services/rxnorm_api_service.dart'
-    as _i101;
-import '../../features/meditation/application/meditation_cubit.dart' as _i201;
-import '../../features/meditation/domain/repositories/meditation_repository.dart'
-    as _i81;
-import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
-    as _i152;
-import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
-    as _i177;
-import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
-    as _i179;
-import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
-    as _i105;
-import '../../features/meditation/domain/usecases/start_session_usecase.dart'
-    as _i122;
-import '../../features/meditation/infrastructure/datasources/meditation_local_datasource.dart'
     as _i80;
-import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
+import '../../features/medications/infrastructure/services/pharmacy_api_service.dart'
+    as _i101;
+import '../../features/medications/infrastructure/services/rxnorm_api_service.dart'
+    as _i102;
+import '../../features/meditation/application/meditation_cubit.dart' as _i199;
+import '../../features/meditation/domain/repositories/meditation_repository.dart'
     as _i82;
-import '../../features/network/application/network_cubit.dart' as _i202;
-import '../../features/network/domain/repositories/network_peer_repository.dart'
-    as _i87;
-import '../../features/network/governance/domain/repositories/governance_repository.dart'
-    as _i182;
-import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
-    as _i181;
-import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
-    as _i183;
-import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
-    as _i57;
-import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
-    as _i56;
-import '../../features/network/incentives/infrastructure/repositories/incentive_repository_impl.dart'
-    as _i58;
-import '../../features/network/infrastructure/datasources/network_p2p_api.dart'
-    as _i86;
-import '../../features/network/infrastructure/repositories/network_peer_repository_impl.dart'
-    as _i88;
-import '../../features/network/network_health/application/network_health_cubit.dart'
-    as _i203;
-import '../../features/network/network_health/domain/repositories/network_repository.dart'
-    as _i89;
-import '../../features/network/network_health/domain/usecases/connect_node.dart'
-    as _i153;
-import '../../features/network/network_health/domain/usecases/get_network_health.dart'
+import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
+    as _i151;
+import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
     as _i175;
-import '../../features/network/network_health/domain/usecases/get_node_stats.dart'
-    as _i176;
-import '../../features/network/network_health/infrastructure/datasources/network_datasource.dart'
-    as _i85;
-import '../../features/network/network_health/infrastructure/repositories/network_repository_impl.dart'
+import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
+    as _i177;
+import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
+    as _i106;
+import '../../features/meditation/domain/usecases/start_session_usecase.dart'
+    as _i123;
+import '../../features/meditation/infrastructure/datasources/meditation_local_datasource.dart'
+    as _i81;
+import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
+    as _i83;
+import '../../features/network/application/network_cubit.dart' as _i200;
+import '../../features/network/domain/repositories/network_peer_repository.dart'
+    as _i88;
+import '../../features/network/governance/domain/repositories/governance_repository.dart'
+    as _i180;
+import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
+    as _i179;
+import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
+    as _i181;
+import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
+    as _i58;
+import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
+    as _i57;
+import '../../features/network/incentives/infrastructure/repositories/incentive_repository_impl.dart'
+    as _i59;
+import '../../features/network/infrastructure/datasources/network_p2p_api.dart'
+    as _i87;
+import '../../features/network/infrastructure/repositories/network_peer_repository_impl.dart'
+    as _i89;
+import '../../features/network/network_health/application/network_health_cubit.dart'
+    as _i201;
+import '../../features/network/network_health/domain/repositories/network_repository.dart'
     as _i90;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i255;
-import '../../features/onboarding/application/sync_cubit.dart' as _i219;
+import '../../features/network/network_health/domain/usecases/connect_node.dart'
+    as _i152;
+import '../../features/network/network_health/domain/usecases/get_network_health.dart'
+    as _i173;
+import '../../features/network/network_health/domain/usecases/get_node_stats.dart'
+    as _i174;
+import '../../features/network/network_health/infrastructure/datasources/network_datasource.dart'
+    as _i86;
+import '../../features/network/network_health/infrastructure/repositories/network_repository_impl.dart'
+    as _i91;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i256;
+import '../../features/onboarding/application/sync_cubit.dart' as _i217;
 import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i204;
+    as _i202;
 import '../../features/onboarding/domain/usecases/complete_onboarding_usecase.dart'
     as _i232;
 import '../../features/onboarding/domain/usecases/get_onboarding_profile_usecase.dart'
-    as _i244;
-import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
-    as _i205;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i257;
-import '../../features/reports/domain/repositories/report_repository.dart'
-    as _i106;
-import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i206;
-import '../../features/reports/domain/usecases/get_reports_usecase.dart'
-    as _i178;
-import '../../features/reports/domain/usecases/save_report_usecase.dart'
-    as _i110;
-import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
-    as _i107;
-import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i207;
-import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
-    as _i83;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i194;
-    as _i210;
-    as _i200;
-    as _i102;
-import '../../features/meditation/application/meditation_cubit.dart' as _i202;
-    as _i180;
-    as _i123;
-import '../../features/network/application/network_cubit.dart' as _i203;
-    as _i184;
-    as _i59;
-    as _i154;
-    as _i91;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i256;
-import '../../features/onboarding/application/sync_cubit.dart' as _i220;
-    as _i233;
     as _i245;
+import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
+    as _i203;
 import '../../features/reports/application/bloc/report_bloc.dart' as _i258;
+import '../../features/reports/domain/repositories/report_repository.dart'
+    as _i107;
+import '../../features/reports/domain/services/report_generation_service.dart'
+    as _i204;
+import '../../features/reports/domain/usecases/get_reports_usecase.dart'
+    as _i176;
+import '../../features/reports/domain/usecases/save_report_usecase.dart'
     as _i111;
+import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i108;
-    as _i208;
+import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+    as _i205;
+import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i84;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i195;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i192;
 import '../../features/settings/domain/repositories/settings_repository.dart'
     as _i119;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i30;
+    as _i29;
 import '../../features/settings/infrastructure/datasources/settings_local_datasource.dart'
     as _i118;
 import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
-    as _i119;
-import '../../features/sync/application/sync_cubit.dart' as _i165;
-import '../../features/sync/domain/repositories/sync_repository.dart' as _i124;
+    as _i120;
+import '../../features/sync/application/sync_cubit.dart' as _i240;
+import '../../features/sync/domain/repositories/sync_repository.dart' as _i125;
 import '../../features/sync/domain/services/distributed_storage_service.dart'
-    as _i157;
+    as _i156;
 import '../../features/sync/domain/services/node_discovery_service.dart'
-    as _i94;
-import '../../features/sync/domain/services/sync_service.dart' as _i126;
+    as _i95;
+import '../../features/sync/domain/services/sync_service.dart' as _i218;
 import '../../features/sync/domain/usecases/distributed_cache_usecase.dart'
     as _i237;
-    as _i120;
-import '../../features/sync/application/sync_cubit.dart' as _i166;
-import '../../features/sync/domain/repositories/sync_repository.dart' as _i125;
-    as _i158;
-    as _i95;
-import '../../features/sync/domain/services/sync_service.dart' as _i127;
-    as _i238;
 import '../../features/sync/infrastructure/datasources/filecoin_datasource.dart'
     as _i38;
 import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
     as _i60;
 import '../../features/sync/infrastructure/repositories/sync_repository_impl.dart'
-    as _i125;
+    as _i126;
 import '../../features/sync/infrastructure/services/fhir_client.dart' as _i36;
-import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i158;
+import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i157;
 import '../../features/sync/infrastructure/services/node_discovery_service.dart'
-    as _i95;
+    as _i96;
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
-    as _i127;
+    as _i219;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
     as _i220;
 import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
-    as _i128;
+    as _i127;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i129;
+    as _i128;
 import '../../features/user_profile/domain/services/user_profile_service.dart'
-    as _i131;
-import '../../features/user_profile/domain/usecases/get_user_profile_usecase.dart'
-    as _i180;
-import '../../features/user_profile/domain/usecases/save_user_profile_usecase.dart'
-    as _i211;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
     as _i130;
+import '../../features/user_profile/domain/usecases/get_user_profile_usecase.dart'
+    as _i178;
+import '../../features/user_profile/domain/usecases/save_user_profile_usecase.dart'
+    as _i209;
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+    as _i129;
 import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i222;
-import '../../features/vitals/application/vitals_cubit.dart' as _i136;
+import '../../features/vitals/application/vitals_cubit.dart' as _i135;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i134;
+    as _i133;
 import '../../features/vitals/domain/usecases/get_all_vital_signs_usecase.dart'
-    as _i169;
+    as _i167;
 import '../../features/vitals/domain/usecases/save_vital_signs_usecase.dart'
-    as _i212;
+    as _i210;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
-    as _i135;
+    as _i134;
 import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i223;
 import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
-    as _i137;
+    as _i136;
 import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
-    as _i170;
+    as _i169;
 import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
-    as _i214;
+    as _i212;
 import '../../features/voice_chat/infrastructure/datasources/chat_ai_datasource.dart'
     as _i25;
 import '../../features/voice_chat/infrastructure/repositories/voice_chat_repository_impl.dart'
-    as _i138;
-    as _i126;
-import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i159;
-    as _i96;
-    as _i221;
-    as _i132;
-    as _i181;
-import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i223;
-import '../../features/vitals/application/vitals_cubit.dart' as _i137;
-    as _i213;
-    as _i136;
-import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i224;
-    as _i171;
-    as _i215;
-    as _i139;
+    as _i137;
 import '../logging/audit_logger.dart' as _i15;
 import '../services/aicore_service.dart' as _i3;
 import '../services/asr/asr_service.dart' as _i11;
 import '../services/audio/audio_player_service.dart' as _i12;
 import '../services/audio/audio_recorder_service.dart' as _i14;
-import '../services/device_capability_service.dart' as _i29;
-import '../services/privacy_anonymizer.dart' as _i102;
-import '../services/secure_storage_service.dart' as _i113;
-import 'database_module.dart' as _i274;
-import 'fhir_module.dart' as _i275;
-import 'memory_module.dart' as _i273;
-import 'network_module.dart' as _i272;
-import 'service_module.dart' as _i271;
+import '../services/device_capability_service.dart' as _i30;
 import '../services/privacy_anonymizer.dart' as _i103;
 import '../services/secure_storage_service.dart' as _i114;
 import 'database_module.dart' as _i275;
@@ -788,21 +629,17 @@ extension GetItInjectableX on _i1.GetIt {
         () => _i68.LocalModelLocalDataSource());
     gh.lazySingleton<_i69.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
-    gh.factory<_i69.MedicalKnowledgeRepository>(
-      () => _i70.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
-    );
-      () => _i71.JsonMedicalKnowledgeRepository(),
     gh.factory<_i70.MedicalKnowledgeRepository>(
-      () => _i71.AssetMedicalKnowledgeRepository(),
-      () => _i72.JsonMedicalKnowledgeRepository(),
+      () => _i71.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
     );
-    gh.lazySingleton<_i72.MedicalScraperService>(
-        () => _i73.MedicalScraperServiceImpl(
+    gh.factory<_i70.MedicalKnowledgeRepository>(
+      () => _i72.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
+    );
     gh.lazySingleton<_i73.MedicalScraperService>(
         () => _i74.MedicalScraperServiceImpl(
               gh<_i31.Dio>(),
@@ -899,714 +736,431 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i41.FlutterSecureStorage>(),
           gh<_i95.NodeDiscoveryService>(),
         ));
-    gh.lazySingleton<_i68.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i126.SyncService>(() => _i127.SyncServiceImpl(
-          gh<_i124.SyncRepository>(),
-          gh<_i68.SyncService>(),
-        ));
-    gh.lazySingleton<_i128.UserProfileLocalDataSource>(
-        () => _i128.UserProfileLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i129.UserProfileRepository>(
-        () => _i130.UserProfileRepositoryImpl(gh<_i60.Isar>()));
-    gh.lazySingleton<_i131.UserProfileService>(
-        () => _i131.UserProfileService(gh<_i129.UserProfileRepository>()));
-    gh.lazySingleton<_i132.VectorStoreService>(
-        () => _i133.IsarVectorStoreService(
     gh.lazySingleton<_i69.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i127.SyncService>(() => _i128.SyncServiceImpl(
-          gh<_i125.SyncRepository>(),
-          gh<_i69.SyncService>(),
-    gh.lazySingleton<_i129.UserProfileLocalDataSource>(
-        () => _i129.UserProfileLocalDataSource(gh<_i61.Isar>()));
-    gh.lazySingleton<_i130.UserProfileRepository>(
-        () => _i131.UserProfileRepositoryImpl(gh<_i61.Isar>()));
-    gh.lazySingleton<_i132.UserProfileService>(
-        () => _i132.UserProfileService(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i133.VectorStoreService>(
-        () => _i134.IsarVectorStoreService(
+    gh.lazySingleton<_i127.UserProfileLocalDataSource>(
+        () => _i127.UserProfileLocalDataSource(gh<_i61.Isar>()));
+    gh.lazySingleton<_i128.UserProfileRepository>(
+        () => _i129.UserProfileRepositoryImpl(gh<_i61.Isar>()));
+    gh.lazySingleton<_i130.UserProfileService>(
+        () => _i130.UserProfileService(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i131.VectorStoreService>(
+        () => _i132.IsarVectorStoreService(
               gh<_i34.MemoryGraph>(),
               gh<_i70.MedicalKnowledgeRepository>(),
             ));
-    gh.lazySingleton<_i134.VitalSignRepository>(
-        () => _i135.VitalSignRepositoryImpl(gh<_i60.Isar>()));
-    gh.factory<_i136.VitalsCubit>(
-        () => _i136.VitalsCubit(gh<_i134.VitalSignRepository>()));
-    gh.lazySingleton<_i137.VoiceChatRepository>(
-        () => _i138.VoiceChatRepositoryImpl(gh<_i25.ChatAiDatasource>()));
-    gh.lazySingleton<_i139.VouchRepository>(
-        () => _i140.IsarVouchRepository(gh<_i60.Isar>()));
-    gh.lazySingleton<_i135.VitalSignRepository>(
-        () => _i136.VitalSignRepositoryImpl(gh<_i61.Isar>()));
-    gh.factory<_i137.VitalsCubit>(
-        () => _i137.VitalsCubit(gh<_i135.VitalSignRepository>()));
-    gh.lazySingleton<_i138.VoiceChatRepository>(
-        () => _i139.VoiceChatRepositoryImpl(gh<_i25.ChatAiDatasource>()));
-    gh.lazySingleton<_i140.VouchRepository>(
-        () => _i141.IsarVouchRepository(gh<_i61.Isar>()));
+    gh.lazySingleton<_i133.VitalSignRepository>(
+        () => _i134.VitalSignRepositoryImpl(gh<_i61.Isar>()));
+    gh.factory<_i135.VitalsCubit>(
+        () => _i135.VitalsCubit(gh<_i133.VitalSignRepository>()));
+    gh.lazySingleton<_i136.VoiceChatRepository>(
+        () => _i137.VoiceChatRepositoryImpl(gh<_i25.ChatAiDatasource>()));
+    gh.lazySingleton<_i138.VouchRepository>(
+        () => _i139.IsarVouchRepository(gh<_i61.Isar>()));
     gh.lazySingleton<_i35.WalletService>(() => databaseModule.walletService(
           gh<_i61.Isar>(),
           gh<_i35.EncryptionService>(),
         ));
-    gh.lazySingleton<_i141.WifiDirectService>(() => _i141.WifiDirectService());
-    gh.factory<_i142.AboutCubit>(
-        () => _i142.AboutCubit(gh<_i53.IAboutRepository>()));
-    gh.lazySingleton<_i143.AboutRemoteDataSource>(
-        () => _i143.AboutRemoteDataSource(gh<_i31.Dio>()));
-    gh.lazySingleton<_i144.AllergyLocalDataSource>(
-        () => _i144.AllergyLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i145.AuthLocalDataSource>(
-        () => _i145.AuthLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i146.AuthRepository>(() => _i147.AuthRepositoryImpl(
-          gh<_i145.AuthLocalDataSource>(),
-          gh<_i113.SecureStorageService>(),
-        ));
-    gh.lazySingleton<_i148.BleSharingService>(
-        () => _i148.BleSharingService(gh<_i17.BleWrapper>()));
-    gh.lazySingleton<_i149.CancelSharingUseCase>(
-        () => _i149.CancelSharingUseCase(
-              gh<_i148.BleSharingService>(),
-              gh<_i93.NfcSharingService>(),
-              gh<_i141.WifiDirectService>(),
-            ));
-    gh.lazySingleton<_i150.ChatMessageLocalDataSource>(
-        () => _i150.ChatMessageLocalDataSource(gh<_i60.Isar>()));
-    gh.factory<_i151.CheckSessionTimeoutUseCase>(
-        () => _i151.CheckSessionTimeoutUseCase(gh<_i146.AuthRepository>()));
-    gh.lazySingleton<_i152.CompleteSessionUseCase>(
-        () => _i152.CompleteSessionUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i123.ConnectEmailProviderUseCase>(
-        () => _i123.ConnectEmailProviderUseCase(gh<_i32.EmailRepository>()));
-    gh.lazySingleton<_i153.ConnectNode>(
-        () => _i153.ConnectNode(gh<_i89.NetworkRepository>()));
-    gh.factory<_i154.ConnectProviderUseCase>(() => _i154.ConnectProviderUseCase(
-          gh<_i97.OAuthRepository>(),
-          gh<_i129.UserProfileRepository>(),
-    gh.lazySingleton<_i155.DashboardLocalDataSource>(
-        () => _i155.DashboardLocalDataSource(gh<_i60.Isar>()));
-    gh.factory<_i156.DisconnectProviderUseCase>(
-        () => _i156.DisconnectProviderUseCase(
-              gh<_i97.OAuthRepository>(),
-              gh<_i129.UserProfileRepository>(),
-    gh.lazySingleton<_i157.DistributedStorageService>(() => _i158.IpfsService(
-          gh<_i59.IpfsDatasource>(),
-          gh<_i38.FilecoinDatasource>(),
-    gh.lazySingleton<_i159.DoctorProfileRepository>(
-        () => _i160.IsarDoctorProfileRepository(gh<_i60.Isar>()));
-    gh.factoryAsync<_i161.DoctorVerificationCubit>(
-        () async => _i161.DoctorVerificationCubit(
-              gh<_i159.DoctorProfileRepository>(),
-              gh<_i103.RatingRepository>(),
-              await getAsync<_i62.LicenseVerifier>(),
-    gh.factory<_i162.EmailCitasBloc>(() => _i162.EmailCitasBloc(
-          gh<_i123.ConnectEmailProviderUseCase>(),
-          gh<_i123.SyncEmailAppointmentsUseCase>(),
-          gh<_i32.EmailRepository>(),
-          gh<_i8.AppointmentRepository>(),
-    gh.factory<_i163.EmailCitasCubit>(() => _i163.EmailCitasCubit(
-    gh.lazySingleton<_i164.EncryptionService>(
-        () => _i164.EncryptionService(gh<_i113.SecureStorageService>()));
-    gh.factory<_i165.FhirSyncCubit>(() => _i165.FhirSyncCubit(
-          gh<_i126.SyncService>(),
-          gh<_i94.NodeDiscoveryService>(),
-    gh.lazySingleton<_i116.FileHealthDataSource>(
-        () => _i116.FileHealthDataSourceImpl(
-    gh.lazySingleton<_i142.WifiDirectService>(() => _i142.WifiDirectService());
-    gh.factory<_i143.AboutCubit>(
-        () => _i143.AboutCubit(gh<_i54.IAboutRepository>()));
-    gh.lazySingleton<_i144.AboutRemoteDataSource>(
-        () => _i144.AboutRemoteDataSource(gh<_i31.Dio>()));
-    gh.lazySingleton<_i145.AllergyLocalDataSource>(
-        () => _i145.AllergyLocalDataSource(gh<_i61.Isar>()));
-    gh.lazySingleton<_i146.AuthLocalDataSource>(
-        () => _i146.AuthLocalDataSource(gh<_i61.Isar>()));
-    gh.lazySingleton<_i147.AuthRepository>(() => _i148.AuthRepositoryImpl(
-          gh<_i146.AuthLocalDataSource>(),
+    gh.lazySingleton<_i140.WifiDirectService>(() => _i140.WifiDirectService());
+    gh.factory<_i141.AboutCubit>(
+        () => _i141.AboutCubit(gh<_i54.IAboutRepository>()));
+    gh.lazySingleton<_i142.AboutRemoteDataSource>(
+        () => _i142.AboutRemoteDataSource(gh<_i31.Dio>()));
+    gh.lazySingleton<_i143.AllergyLocalDataSource>(
+        () => _i143.AllergyLocalDataSource(gh<_i61.Isar>()));
+    gh.lazySingleton<_i144.AuthLocalDataSource>(
+        () => _i144.AuthLocalDataSource(gh<_i61.Isar>()));
+    gh.lazySingleton<_i145.AuthRepository>(() => _i146.AuthRepositoryImpl(
+          gh<_i144.AuthLocalDataSource>(),
           gh<_i114.SecureStorageService>(),
-    gh.lazySingleton<_i149.BleSharingService>(
-        () => _i149.BleSharingService(gh<_i17.BleWrapper>()));
-    gh.lazySingleton<_i150.CancelSharingUseCase>(
-        () => _i150.CancelSharingUseCase(
-              gh<_i149.BleSharingService>(),
+        ));
+    gh.lazySingleton<_i147.BleSharingService>(
+        () => _i147.BleSharingService(gh<_i17.BleWrapper>()));
+    gh.lazySingleton<_i148.CancelSharingUseCase>(
+        () => _i148.CancelSharingUseCase(
+              gh<_i147.BleSharingService>(),
               gh<_i94.NfcSharingService>(),
-              gh<_i142.WifiDirectService>(),
-    gh.lazySingleton<_i151.ChatMessageLocalDataSource>(
-        () => _i151.ChatMessageLocalDataSource(gh<_i61.Isar>()));
-    gh.factory<_i152.CheckSessionTimeoutUseCase>(
-        () => _i152.CheckSessionTimeoutUseCase(gh<_i147.AuthRepository>()));
-    gh.lazySingleton<_i153.CompleteSessionUseCase>(
-        () => _i153.CompleteSessionUseCase(gh<_i82.MeditationRepository>()));
+              gh<_i140.WifiDirectService>(),
+            ));
+    gh.lazySingleton<_i149.ChatMessageLocalDataSource>(
+        () => _i149.ChatMessageLocalDataSource(gh<_i61.Isar>()));
+    gh.factory<_i150.CheckSessionTimeoutUseCase>(
+        () => _i150.CheckSessionTimeoutUseCase(gh<_i145.AuthRepository>()));
+    gh.lazySingleton<_i151.CompleteSessionUseCase>(
+        () => _i151.CompleteSessionUseCase(gh<_i82.MeditationRepository>()));
     gh.factory<_i124.ConnectEmailProviderUseCase>(
         () => _i124.ConnectEmailProviderUseCase(gh<_i32.EmailRepository>()));
-    gh.lazySingleton<_i154.ConnectNode>(
-        () => _i154.ConnectNode(gh<_i90.NetworkRepository>()));
-    gh.factory<_i155.ConnectProviderUseCase>(() => _i155.ConnectProviderUseCase(
+    gh.lazySingleton<_i152.ConnectNode>(
+        () => _i152.ConnectNode(gh<_i90.NetworkRepository>()));
+    gh.factory<_i153.ConnectProviderUseCase>(() => _i153.ConnectProviderUseCase(
           gh<_i98.OAuthRepository>(),
-          gh<_i130.UserProfileRepository>(),
-    gh.lazySingleton<_i156.DashboardLocalDataSource>(
-        () => _i156.DashboardLocalDataSource(gh<_i61.Isar>()));
-    gh.factory<_i157.DisconnectProviderUseCase>(
-        () => _i157.DisconnectProviderUseCase(
+          gh<_i128.UserProfileRepository>(),
+        ));
+    gh.lazySingleton<_i154.DashboardLocalDataSource>(
+        () => _i154.DashboardLocalDataSource(gh<_i61.Isar>()));
+    gh.factory<_i155.DisconnectProviderUseCase>(
+        () => _i155.DisconnectProviderUseCase(
               gh<_i98.OAuthRepository>(),
-              gh<_i130.UserProfileRepository>(),
-    gh.lazySingleton<_i158.DistributedStorageService>(() => _i159.IpfsService(
+              gh<_i128.UserProfileRepository>(),
+            ));
+    gh.lazySingleton<_i156.DistributedStorageService>(() => _i157.IpfsService(
           gh<_i60.IpfsDatasource>(),
-    gh.lazySingleton<_i160.DoctorProfileRepository>(
-        () => _i161.IsarDoctorProfileRepository(gh<_i61.Isar>()));
-    gh.factoryAsync<_i162.DoctorVerificationCubit>(
-        () async => _i162.DoctorVerificationCubit(
-              gh<_i160.DoctorProfileRepository>(),
+          gh<_i38.FilecoinDatasource>(),
+        ));
+    gh.lazySingleton<_i158.DoctorProfileRepository>(
+        () => _i159.IsarDoctorProfileRepository(gh<_i61.Isar>()));
+    gh.factoryAsync<_i160.DoctorVerificationCubit>(
+        () async => _i160.DoctorVerificationCubit(
+              gh<_i158.DoctorProfileRepository>(),
               gh<_i104.RatingRepository>(),
               await getAsync<_i63.LicenseVerifier>(),
-    gh.factory<_i163.EmailCitasBloc>(() => _i163.EmailCitasBloc(
+            ));
+    gh.factory<_i161.EmailCitasBloc>(() => _i161.EmailCitasBloc(
           gh<_i124.ConnectEmailProviderUseCase>(),
           gh<_i124.SyncEmailAppointmentsUseCase>(),
-    gh.factory<_i164.EmailCitasCubit>(() => _i164.EmailCitasCubit(
-    gh.lazySingleton<_i165.EncryptionService>(
-        () => _i165.EncryptionService(gh<_i114.SecureStorageService>()));
-    gh.factory<_i166.FhirSyncCubit>(() => _i166.FhirSyncCubit(
-          gh<_i127.SyncService>(),
-          gh<_i95.NodeDiscoveryService>(),
+          gh<_i32.EmailRepository>(),
+          gh<_i8.AppointmentRepository>(),
+        ));
+    gh.factory<_i162.EmailCitasCubit>(() => _i162.EmailCitasCubit(
+          gh<_i32.EmailRepository>(),
+          gh<_i8.AppointmentRepository>(),
+        ));
+    gh.lazySingleton<_i163.EncryptionService>(
+        () => _i163.EncryptionService(gh<_i114.SecureStorageService>()));
     gh.lazySingleton<_i117.FileHealthDataSource>(
         () => _i117.FileHealthDataSourceImpl(
               gh<_i37.FilePickerService>(),
               gh<_i100.OcrService>(),
             ));
-    gh.lazySingleton<_i166.FileImportDataSource>(
-        () => _i166.FileImportDataSourceImpl(
-    gh.lazySingleton<_i167.FileImportDataSource>(
-        () => _i167.FileImportDataSourceImpl(
+    gh.lazySingleton<_i164.FileImportDataSource>(
+        () => _i164.FileImportDataSourceImpl(
               gh<_i37.FilePickerService>(),
               gh<_i100.OcrService>(),
             ));
-    gh.factory<_i167.GetAboutInfoUseCase>(
-        () => _i167.GetAboutInfoUseCase(gh<_i53.IAboutRepository>()));
-    gh.factory<_i168.GetAllDoctorsUseCase>(
-        () => _i168.GetAllDoctorsUseCase(gh<_i159.DoctorProfileRepository>()));
-    gh.factory<_i169.GetAllVitalSignsUseCase>(
-        () => _i169.GetAllVitalSignsUseCase(gh<_i134.VitalSignRepository>()));
-    gh.factory<_i108.GetAvailableSourcesUseCase>(() =>
-        _i108.GetAvailableSourcesUseCase(gh<_i46.HealthDataImportService>()));
-    gh.factory<_i170.GetChatHistoryUseCase>(
-        () => _i170.GetChatHistoryUseCase(gh<_i137.VoiceChatRepository>()));
-    gh.factory<_i171.GetChatHistoryUseCase>(
-        () => _i171.GetChatHistoryUseCase(gh<_i132.VectorStoreService>()));
-    gh.factory<_i172.GetConnectionsUseCase>(
-        () => _i172.GetConnectionsUseCase(gh<_i97.OAuthRepository>()));
-    gh.factory<_i173.GetCredentialsUseCase>(
-        () => _i173.GetCredentialsUseCase(gh<_i146.AuthRepository>()));
-    gh.factory<_i174.GetDoctorProfileUseCase>(() =>
-        _i174.GetDoctorProfileUseCase(gh<_i159.DoctorProfileRepository>()));
-    gh.lazySingleton<_i175.GetNetworkHealth>(
-        () => _i175.GetNetworkHealth(gh<_i89.NetworkRepository>()));
-    gh.lazySingleton<_i176.GetNodeStats>(
-        () => _i176.GetNodeStats(gh<_i89.NetworkRepository>()));
-    gh.lazySingleton<_i177.GetProgressUseCase>(
-        () => _i177.GetProgressUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i178.GetReportsUseCase>(
-        () => _i178.GetReportsUseCase(gh<_i106.ReportRepository>()));
-    gh.lazySingleton<_i179.GetScriptsUseCase>(
-        () => _i179.GetScriptsUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i180.GetUserProfileUseCase>(
-        () => _i180.GetUserProfileUseCase(gh<_i129.UserProfileRepository>()));
-    gh.lazySingleton<_i181.GovernanceIpfsDatasource>(
-        () => _i181.GovernanceIpfsDatasource(gh<_i59.IpfsDatasource>()));
-    gh.lazySingleton<_i182.GovernanceRepository>(() =>
-        _i183.GovernanceRepositoryImpl(gh<_i181.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i184.HealthDataImportRepository>(
-        () => _i185.HealthDataImportRepositoryImpl(
-              gh<_i116.SensorHealthDataSource>(),
-              gh<_i116.FileHealthDataSource>(),
-            ));
-    gh.lazySingleton<_i186.HealthRecordRepository>(
-        () => _i187.HealthRecordRepositoryImpl(gh<_i60.Isar>()));
-    gh.factory<_i188.ImportCalendarUseCase>(() => _i188.ImportCalendarUseCase(
-          gh<_i21.CalendarImportRepository>(),
-          gh<_i8.AppointmentRepository>(),
-          gh<_i129.UserProfileRepository>(),
-        ));
-    gh.factory<_i108.ImportHealthDataUseCase>(
-        () => _i108.ImportHealthDataUseCase(
-              gh<_i46.HealthDataImportService>(),
-              gh<_i134.VitalSignRepository>(),
-    gh.lazySingleton<_i63.LlmAdapter>(
-      () => _i189.GeminiLlmAdapter(
-        scrubber: gh<_i102.PromptScrubber>(),
-        userProfileRepository: gh<_i129.UserProfileRepository>(),
-    gh.factory<_i168.GetAboutInfoUseCase>(
-        () => _i168.GetAboutInfoUseCase(gh<_i54.IAboutRepository>()));
-    gh.factory<_i169.GetAllDoctorsUseCase>(
-        () => _i169.GetAllDoctorsUseCase(gh<_i160.DoctorProfileRepository>()));
-    gh.factory<_i170.GetAllVitalSignsUseCase>(
-        () => _i170.GetAllVitalSignsUseCase(gh<_i135.VitalSignRepository>()));
+    gh.factory<_i165.GetAboutInfoUseCase>(
+        () => _i165.GetAboutInfoUseCase(gh<_i54.IAboutRepository>()));
+    gh.factory<_i166.GetAllDoctorsUseCase>(
+        () => _i166.GetAllDoctorsUseCase(gh<_i158.DoctorProfileRepository>()));
+    gh.factory<_i167.GetAllVitalSignsUseCase>(
+        () => _i167.GetAllVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
     gh.factory<_i109.GetAvailableSourcesUseCase>(() =>
         _i109.GetAvailableSourcesUseCase(gh<_i47.HealthDataImportService>()));
-        () => _i171.GetChatHistoryUseCase(gh<_i138.VoiceChatRepository>()));
-    gh.factory<_i172.GetChatHistoryUseCase>(
-        () => _i172.GetChatHistoryUseCase(gh<_i133.VectorStoreService>()));
-    gh.factory<_i173.GetConnectionsUseCase>(
-        () => _i173.GetConnectionsUseCase(gh<_i98.OAuthRepository>()));
-    gh.factory<_i174.GetCredentialsUseCase>(
-        () => _i174.GetCredentialsUseCase(gh<_i147.AuthRepository>()));
-    gh.factory<_i175.GetDoctorProfileUseCase>(() =>
-        _i175.GetDoctorProfileUseCase(gh<_i160.DoctorProfileRepository>()));
-    gh.lazySingleton<_i176.GetNetworkHealth>(
-        () => _i176.GetNetworkHealth(gh<_i90.NetworkRepository>()));
-    gh.lazySingleton<_i177.GetNodeStats>(
-        () => _i177.GetNodeStats(gh<_i90.NetworkRepository>()));
-    gh.lazySingleton<_i178.GetProgressUseCase>(
-        () => _i178.GetProgressUseCase(gh<_i82.MeditationRepository>()));
-    gh.factory<_i179.GetReportsUseCase>(
-        () => _i179.GetReportsUseCase(gh<_i107.ReportRepository>()));
-    gh.lazySingleton<_i180.GetScriptsUseCase>(
-        () => _i180.GetScriptsUseCase(gh<_i82.MeditationRepository>()));
-    gh.factory<_i181.GetUserProfileUseCase>(
-        () => _i181.GetUserProfileUseCase(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i182.GovernanceIpfsDatasource>(
-        () => _i182.GovernanceIpfsDatasource(gh<_i60.IpfsDatasource>()));
-    gh.lazySingleton<_i183.GovernanceRepository>(() =>
-        _i184.GovernanceRepositoryImpl(gh<_i182.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i185.HealthDataImportRepository>(
-        () => _i186.HealthDataImportRepositoryImpl(
+    gh.factory<_i168.GetChatHistoryUseCase>(
+        () => _i168.GetChatHistoryUseCase(gh<_i131.VectorStoreService>()));
+    gh.factory<_i169.GetChatHistoryUseCase>(
+        () => _i169.GetChatHistoryUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i170.GetConnectionsUseCase>(
+        () => _i170.GetConnectionsUseCase(gh<_i98.OAuthRepository>()));
+    gh.factory<_i171.GetCredentialsUseCase>(
+        () => _i171.GetCredentialsUseCase(gh<_i145.AuthRepository>()));
+    gh.factory<_i172.GetDoctorProfileUseCase>(() =>
+        _i172.GetDoctorProfileUseCase(gh<_i158.DoctorProfileRepository>()));
+    gh.lazySingleton<_i173.GetNetworkHealth>(
+        () => _i173.GetNetworkHealth(gh<_i90.NetworkRepository>()));
+    gh.lazySingleton<_i174.GetNodeStats>(
+        () => _i174.GetNodeStats(gh<_i90.NetworkRepository>()));
+    gh.lazySingleton<_i175.GetProgressUseCase>(
+        () => _i175.GetProgressUseCase(gh<_i82.MeditationRepository>()));
+    gh.factory<_i176.GetReportsUseCase>(
+        () => _i176.GetReportsUseCase(gh<_i107.ReportRepository>()));
+    gh.lazySingleton<_i177.GetScriptsUseCase>(
+        () => _i177.GetScriptsUseCase(gh<_i82.MeditationRepository>()));
+    gh.factory<_i178.GetUserProfileUseCase>(
+        () => _i178.GetUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i179.GovernanceIpfsDatasource>(
+        () => _i179.GovernanceIpfsDatasource(gh<_i60.IpfsDatasource>()));
+    gh.lazySingleton<_i180.GovernanceRepository>(() =>
+        _i181.GovernanceRepositoryImpl(gh<_i179.GovernanceIpfsDatasource>()));
+    gh.lazySingleton<_i182.HealthDataImportRepository>(
+        () => _i183.HealthDataImportRepositoryImpl(
               gh<_i117.SensorHealthDataSource>(),
               gh<_i117.FileHealthDataSource>(),
-    gh.lazySingleton<_i187.HealthRecordRepository>(
-        () => _i188.HealthRecordRepositoryImpl(gh<_i61.Isar>()));
-    gh.factory<_i189.ImportCalendarUseCase>(() => _i189.ImportCalendarUseCase(
-          gh<_i130.UserProfileRepository>(),
+            ));
+    gh.lazySingleton<_i184.HealthRecordRepository>(
+        () => _i185.HealthRecordRepositoryImpl(gh<_i61.Isar>()));
+    gh.factory<_i186.ImportCalendarUseCase>(() => _i186.ImportCalendarUseCase(
+          gh<_i21.CalendarImportRepository>(),
+          gh<_i8.AppointmentRepository>(),
+          gh<_i128.UserProfileRepository>(),
+        ));
     gh.factory<_i109.ImportHealthDataUseCase>(
         () => _i109.ImportHealthDataUseCase(
               gh<_i47.HealthDataImportService>(),
-              gh<_i135.VitalSignRepository>(),
-    gh.factory<_i64.LlmAdapter>(
-      () => _i190.MockLlmAdapter(gh<_i103.PromptScrubber>()),
-      instanceName: 'mock',
-    );
+              gh<_i133.VitalSignRepository>(),
+            ));
     gh.lazySingleton<_i64.LlmAdapter>(
-      () => _i191.GeminiLlmAdapter(
+      () => _i187.GeminiLlmAdapter(
         scrubber: gh<_i103.PromptScrubber>(),
-        userProfileRepository: gh<_i130.UserProfileRepository>(),
+        userProfileRepository: gh<_i128.UserProfileRepository>(),
         modelWrapper: gh<_i42.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
     );
-    gh.factory<_i63.LlmAdapter>(
-      () => _i190.MockLlmAdapter(gh<_i102.PromptScrubber>()),
+    gh.factory<_i64.LlmAdapter>(
+      () => _i188.MockLlmAdapter(gh<_i103.PromptScrubber>()),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i191.LlmAdapterFactory>(
-        () => _i191.LlmAdapterFactory(gh<_i118.SettingsRepository>()));
-    gh.lazySingleton<_i192.LlmService>(() => _i193.GemmaLlmService(
-          gh<_i132.VectorStoreService>(),
-          gh<_i129.UserProfileRepository>(),
-          gh<_i63.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i189.LlmAdapterFactory>(
+        () => _i189.LlmAdapterFactory(gh<_i119.SettingsRepository>()));
+    gh.lazySingleton<_i190.LlmService>(() => _i191.GemmaLlmService(
+          gh<_i131.VectorStoreService>(),
+          gh<_i128.UserProfileRepository>(),
+          gh<_i64.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i194.LlmSettingsCubit>(() => _i194.LlmSettingsCubit(
-          gh<_i118.SettingsRepository>(),
-          gh<_i30.DeviceCapabilityService>(),
-    gh.factory<_i195.LoginUseCase>(() => _i195.LoginUseCase(
-          gh<_i146.AuthRepository>(),
-          gh<_i164.EncryptionService>(),
+    gh.factory<_i192.LlmSettingsCubit>(() => _i192.LlmSettingsCubit(
+          gh<_i119.SettingsRepository>(),
+          gh<_i29.DeviceCapabilityService>(),
+          gh<_i64.LlmAdapter>(instanceName: 'gemma'),
+        ));
+    gh.factory<_i193.LoginUseCase>(() => _i193.LoginUseCase(
+          gh<_i145.AuthRepository>(),
+          gh<_i163.EncryptionService>(),
           gh<_i16.BiometricService>(),
-    gh.factory<_i196.LogoutUseCase>(
-        () => _i196.LogoutUseCase(gh<_i146.AuthRepository>()));
-    gh.lazySingleton<_i197.MedicalResearchService>(
-        () => _i197.MedicalResearchService(
-              gh<_i76.MedicalWebSearchService>(),
-              gh<_i72.MedicalScraperService>(),
+        ));
+    gh.factory<_i194.LogoutUseCase>(
+        () => _i194.LogoutUseCase(gh<_i145.AuthRepository>()));
+    gh.lazySingleton<_i195.MedicalResearchService>(
+        () => _i195.MedicalResearchService(
+              gh<_i77.MedicalWebSearchService>(),
+              gh<_i73.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i198.MedicationRepository>(
-        () => _i199.IsarMedicationRepository(
-              gh<_i60.Isar>(),
-              gh<_i100.PharmacyApiService>(),
-    gh.factory<_i200.MedicationsCubit>(
-        () => _i200.MedicationsCubit(gh<_i198.MedicationRepository>()));
-    gh.factory<_i201.MeditationCubit>(() => _i201.MeditationCubit(
-          gh<_i105.RecommendScriptUseCase>(),
-          gh<_i122.StartSessionUseCase>(),
-          gh<_i152.CompleteSessionUseCase>(),
-          gh<_i177.GetProgressUseCase>(),
+    gh.lazySingleton<_i196.MedicationRepository>(
+        () => _i197.IsarMedicationRepository(
+              gh<_i61.Isar>(),
+              gh<_i101.PharmacyApiService>(),
+            ));
+    gh.factory<_i198.MedicationsCubit>(
+        () => _i198.MedicationsCubit(gh<_i196.MedicationRepository>()));
+    gh.factory<_i199.MeditationCubit>(() => _i199.MeditationCubit(
+          gh<_i106.RecommendScriptUseCase>(),
+          gh<_i123.StartSessionUseCase>(),
+          gh<_i151.CompleteSessionUseCase>(),
+          gh<_i175.GetProgressUseCase>(),
           gh<_i12.AudioService>(),
-    gh.factory<_i202.NetworkCubit>(() => _i202.NetworkCubit(
-          gh<_i87.NetworkPeerRepository>(),
-          gh<_i86.NetworkP2PApi>(),
-    gh.factory<_i203.NetworkHealthCubit>(() => _i203.NetworkHealthCubit(
-          gh<_i175.GetNetworkHealth>(),
-          gh<_i153.ConnectNode>(),
-          gh<_i89.NetworkRepository>(),
-    gh.lazySingleton<_i204.OnboardingRepository>(() =>
-        _i205.OnboardingRepositoryImpl(gh<_i129.UserProfileRepository>()));
-    gh.lazySingleton<_i206.ReportGenerationService>(
-        () => _i207.GemmaReportGenerationService(
-              gh<_i63.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i132.VectorStoreService>(),
-              gh<_i129.UserProfileRepository>(),
-              gh<_i102.PromptScrubber>(),
-    gh.factory<_i208.SaveCredentialsUseCase>(
-        () => _i208.SaveCredentialsUseCase(gh<_i146.AuthRepository>()));
-    gh.factory<_i209.SaveMedicationUseCase>(
-        () => _i209.SaveMedicationUseCase(gh<_i198.MedicationRepository>()));
-    gh.factory<_i210.SaveRecordUseCase>(
-        () => _i210.SaveRecordUseCase(gh<_i186.HealthRecordRepository>()));
-    gh.factory<_i211.SaveUserProfileUseCase>(
-        () => _i211.SaveUserProfileUseCase(gh<_i129.UserProfileRepository>()));
-    gh.factory<_i212.SaveVitalSignsUseCase>(
-        () => _i212.SaveVitalSignsUseCase(gh<_i134.VitalSignRepository>()));
-    gh.factory<_i213.SecondOpinionCubit>(
-        () => _i213.SecondOpinionCubit(gh<_i111.SecondOpinionRepository>()));
-    gh.factory<_i214.SendMessageUseCase>(
-        () => _i214.SendMessageUseCase(gh<_i137.VoiceChatRepository>()));
-    gh.factory<_i215.SetPinUseCase>(() => _i215.SetPinUseCase(
-    gh.lazySingleton<_i216.SmartSearchUseCase>(
-        () => _i216.SmartSearchUseCase(gh<_i132.VectorStoreService>()));
-    gh.lazySingleton<_i217.StartListeningUseCase>(
-        () => _i217.StartListeningUseCase(
-              gh<_i148.BleSharingService>(),
-              gh<_i93.NfcSharingService>(),
-              gh<_i141.WifiDirectService>(),
-    gh.lazySingleton<_i218.StartSharingUseCase>(() => _i218.StartSharingUseCase(
-          gh<_i148.BleSharingService>(),
-          gh<_i93.NfcSharingService>(),
-          gh<_i141.WifiDirectService>(),
-    gh.factory<_i219.SyncCubit>(() => _i219.SyncCubit(
-          gh<_i68.SyncService>(),
+        ));
+    gh.factory<_i200.NetworkCubit>(() => _i200.NetworkCubit(
+          gh<_i88.NetworkPeerRepository>(),
+          gh<_i87.NetworkP2PApi>(),
+        ));
+    gh.factory<_i201.NetworkHealthCubit>(() => _i201.NetworkHealthCubit(
+          gh<_i173.GetNetworkHealth>(),
+          gh<_i152.ConnectNode>(),
+          gh<_i90.NetworkRepository>(),
+        ));
+    gh.lazySingleton<_i202.OnboardingRepository>(() =>
+        _i203.OnboardingRepositoryImpl(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i204.ReportGenerationService>(
+        () => _i205.GemmaReportGenerationService(
+              gh<_i64.LlmAdapter>(instanceName: 'gemma'),
+              gh<_i131.VectorStoreService>(),
+              gh<_i128.UserProfileRepository>(),
+              gh<_i103.PromptScrubber>(),
+            ));
+    gh.factory<_i206.SaveCredentialsUseCase>(
+        () => _i206.SaveCredentialsUseCase(gh<_i145.AuthRepository>()));
+    gh.factory<_i207.SaveMedicationUseCase>(
+        () => _i207.SaveMedicationUseCase(gh<_i196.MedicationRepository>()));
+    gh.factory<_i208.SaveRecordUseCase>(
+        () => _i208.SaveRecordUseCase(gh<_i184.HealthRecordRepository>()));
+    gh.factory<_i209.SaveUserProfileUseCase>(
+        () => _i209.SaveUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.factory<_i210.SaveVitalSignsUseCase>(
+        () => _i210.SaveVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i211.SecondOpinionCubit>(
+        () => _i211.SecondOpinionCubit(gh<_i112.SecondOpinionRepository>()));
+    gh.factory<_i212.SendMessageUseCase>(
+        () => _i212.SendMessageUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i213.SetPinUseCase>(() => _i213.SetPinUseCase(
+          gh<_i145.AuthRepository>(),
+          gh<_i163.EncryptionService>(),
+        ));
+    gh.lazySingleton<_i214.SmartSearchUseCase>(
+        () => _i214.SmartSearchUseCase(gh<_i131.VectorStoreService>()));
+    gh.lazySingleton<_i215.StartListeningUseCase>(
+        () => _i215.StartListeningUseCase(
+              gh<_i147.BleSharingService>(),
+              gh<_i94.NfcSharingService>(),
+              gh<_i140.WifiDirectService>(),
+            ));
+    gh.lazySingleton<_i216.StartSharingUseCase>(() => _i216.StartSharingUseCase(
+          gh<_i147.BleSharingService>(),
+          gh<_i94.NfcSharingService>(),
+          gh<_i140.WifiDirectService>(),
+        ));
+    gh.factory<_i217.SyncCubit>(() => _i217.SyncCubit(
+          gh<_i69.SyncService>(),
+          gh<_i131.VectorStoreService>(),
+        ));
+    gh.lazySingleton<_i218.SyncService>(() => _i219.SyncServiceImpl(
+          gh<_i125.SyncRepository>(),
+          gh<_i69.SyncService>(),
+        ));
     gh.factory<_i220.UserProfileCubit>(
-        () => _i220.UserProfileCubit(gh<_i129.UserProfileRepository>()));
+        () => _i220.UserProfileCubit(gh<_i128.UserProfileRepository>()));
     gh.factory<_i221.ValidateSessionUseCase>(
-        () => _i221.ValidateSessionUseCase(gh<_i146.AuthRepository>()));
+        () => _i221.ValidateSessionUseCase(gh<_i145.AuthRepository>()));
     gh.factory<_i222.VitalSignBloc>(
-        () => _i222.VitalSignBloc(gh<_i134.VitalSignRepository>()));
+        () => _i222.VitalSignBloc(gh<_i133.VitalSignRepository>()));
     gh.factory<_i223.VoiceChatCubit>(() => _i223.VoiceChatCubit(
-          gh<_i214.SendMessageUseCase>(),
-          gh<_i170.GetChatHistoryUseCase>(),
-          gh<_i137.VoiceChatRepository>(),
+          gh<_i212.SendMessageUseCase>(),
+          gh<_i169.GetChatHistoryUseCase>(),
+          gh<_i136.VoiceChatRepository>(),
+          gh<_i12.AudioService>(),
+        ));
     gh.factory<_i224.VouchCubit>(
-        () => _i224.VouchCubit(gh<_i139.VouchRepository>()));
+        () => _i224.VouchCubit(gh<_i138.VouchRepository>()));
     gh.lazySingleton<_i225.AllergyRepository>(() => _i226.AllergyRepositoryImpl(
-          gh<_i144.AllergyLocalDataSource>(),
-          encryptionService: gh<_i164.EncryptionService>(),
+          gh<_i143.AllergyLocalDataSource>(),
+          encryptionService: gh<_i163.EncryptionService>(),
+        ));
     gh.factory<_i227.AuthCubit>(() => _i227.AuthCubit(
-          gh<_i195.LoginUseCase>(),
-          gh<_i196.LogoutUseCase>(),
+          gh<_i145.AuthRepository>(),
+          gh<_i16.BiometricService>(),
+          gh<_i193.LoginUseCase>(),
+          gh<_i194.LogoutUseCase>(),
           gh<_i221.ValidateSessionUseCase>(),
-          gh<_i215.SetPinUseCase>(),
-          gh<_i151.CheckSessionTimeoutUseCase>(),
+          gh<_i213.SetPinUseCase>(),
+          gh<_i150.CheckSessionTimeoutUseCase>(),
+        ));
     gh.lazySingleton<_i228.AuthService>(
-        () => _i228.AuthServiceImpl(gh<_i164.EncryptionService>()));
+        () => _i228.AuthServiceImpl(gh<_i163.EncryptionService>()));
     gh.lazySingleton<_i229.BadgeCalculator>(() => _i229.BadgeCalculator(
-          gh<_i159.DoctorProfileRepository>(),
-          gh<_i103.RatingRepository>(),
-          gh<_i139.VouchRepository>(),
+          gh<_i158.DoctorProfileRepository>(),
+          gh<_i104.RatingRepository>(),
+          gh<_i138.VouchRepository>(),
+        ));
     gh.factory<_i230.BadgeCubit>(
         () => _i230.BadgeCubit(gh<_i229.BadgeCalculator>()));
     gh.factory<_i231.CalendarImportCubit>(() => _i231.CalendarImportCubit(
           gh<_i21.CalendarImportRepository>(),
-          gh<_i188.ImportCalendarUseCase>(),
+          gh<_i186.ImportCalendarUseCase>(),
+        ));
     gh.factory<_i232.CompleteOnboardingUseCase>(() =>
-        _i232.CompleteOnboardingUseCase(gh<_i204.OnboardingRepository>()));
+        _i232.CompleteOnboardingUseCase(gh<_i202.OnboardingRepository>()));
     gh.lazySingleton<_i233.DashboardRepository>(
         () => _i234.DashboardRepositoryImpl(
               gh<_i27.DashboardRemoteDataSource>(),
-              gh<_i134.VitalSignRepository>(),
-              gh<_i198.MedicationRepository>(),
-              gh<_i106.ReportRepository>(),
+              gh<_i133.VitalSignRepository>(),
+              gh<_i196.MedicationRepository>(),
+              gh<_i107.ReportRepository>(),
+            ));
     gh.lazySingleton<_i235.DataSourceRepository>(
         () => _i236.DataSourceRepositoryImpl(
-              gh<_i115.SensorApiDataSource>(),
-              gh<_i166.FileImportDataSource>(),
-              gh<_i45.HealthConnectDataSource>(),
-    gh.lazySingleton<_i237.DistributedCacheUsecase>(() =>
-        _i237.DistributedCacheUsecase(gh<_i157.DistributedStorageService>()));
-    gh.factory<_i238.EpsConnectionBloc>(() => _i238.EpsConnectionBloc(
-          gh<_i172.GetConnectionsUseCase>(),
-          gh<_i154.ConnectProviderUseCase>(),
-          gh<_i156.DisconnectProviderUseCase>(),
-    gh.factory<_i239.EpsConnectionCubit>(() => _i239.EpsConnectionCubit(
-    gh.factory<_i240.GetAllMedicationsUseCase>(
-        () => _i240.GetAllMedicationsUseCase(gh<_i198.MedicationRepository>()));
-    gh.factory<_i241.GetAllRecordsUseCase>(
-        () => _i241.GetAllRecordsUseCase(gh<_i186.HealthRecordRepository>()));
-    gh.factory<_i242.GetAllergiesUseCase>(
-        () => _i242.GetAllergiesUseCase(gh<_i225.AllergyRepository>()));
-    gh.factory<_i243.GetDashboardStatsUseCase>(
-        () => _i243.GetDashboardStatsUseCase(gh<_i233.DashboardRepository>()));
-    gh.factory<_i244.GetOnboardingProfileUseCase>(() =>
-        _i244.GetOnboardingProfileUseCase(gh<_i204.OnboardingRepository>()));
-    gh.factory<_i245.GetRecentActivityUseCase>(
-        () => _i245.GetRecentActivityUseCase(gh<_i233.DashboardRepository>()));
-    gh.factory<_i246.HealthImportBloc>(() => _i246.HealthImportBloc(
-          gh<_i108.GetAvailableSourcesUseCase>(),
-          gh<_i108.RequestHealthAuthUseCase>(),
-          gh<_i108.ImportHealthDataUseCase>(),
-    gh.factory<_i247.HealthImportCubit>(() => _i247.HealthImportCubit(
-    gh.factory<_i248.HealthRecordCubit>(() => _i248.HealthRecordCubit(
-          gh<_i186.HealthRecordRepository>(),
-          gh<_i37.FilePickerService>(),
-          gh<_i55.ImagePickerService>(),
-          gh<_i99.OcrService>(),
-    gh.lazySingleton<_i249.HomeRepository>(() => _i250.HomeRepositoryImpl(
-          gh<_i134.VitalSignRepository>(),
-          gh<_i8.AppointmentRepository>(),
-          gh<_i198.MedicationRepository>(),
-          gh<_i50.HomeLocalDataSource>(),
-          gh<_i52.HomeRemoteDataSource>(),
-          gh<_i49.HealthSummaryDatasource>(),
-    gh.lazySingleton<_i192.LlmService>(
-      () => _i251.RagLlmService(
-        gh<_i132.VectorStoreService>(),
-        gh<_i197.MedicalResearchService>(),
-        gh<_i129.UserProfileRepository>(),
-        gh<_i63.LlmAdapter>(instanceName: 'gemma'),
-      ),
-      instanceName: 'rag',
-    gh.lazySingleton<_i252.MedicalResearchRepository>(
-        () => _i253.MedicalResearchRepositoryImpl(
-              gh<_i197.MedicalResearchService>(),
-    gh.factory<_i254.MedicationBloc>(
-        () => _i254.MedicationBloc(gh<_i198.MedicationRepository>()));
-    gh.factory<_i255.OnboardingCubit>(
-        () => _i255.OnboardingCubit(gh<_i204.OnboardingRepository>()));
-    gh.lazySingleton<_i256.PatientContextIndexer>(
-      () => _i256.PatientContextIndexer(
-        gh<_i60.Isar>(),
-        gh<_i186.HealthRecordRepository>(),
-        gh<_i198.MedicationRepository>(),
-        gh<_i225.AllergyRepository>(),
-        gh<_i134.VitalSignRepository>(),
-    gh.lazySingleton<_i192.LlmAdapterFactory>(
-        () => _i192.LlmAdapterFactory(gh<_i119.SettingsRepository>()));
-    gh.lazySingleton<_i193.LlmService>(() => _i194.GemmaLlmService(
-          gh<_i133.VectorStoreService>(),
-          gh<_i130.UserProfileRepository>(),
-          gh<_i64.LlmAdapter>(instanceName: 'gemma'),
-    gh.factory<_i195.LlmSettingsCubit>(() => _i195.LlmSettingsCubit(
-          gh<_i119.SettingsRepository>(),
-    gh.factory<_i196.LoginUseCase>(() => _i196.LoginUseCase(
-          gh<_i147.AuthRepository>(),
-          gh<_i165.EncryptionService>(),
-    gh.factory<_i197.LogoutUseCase>(
-        () => _i197.LogoutUseCase(gh<_i147.AuthRepository>()));
-    gh.lazySingleton<_i198.MedicalResearchService>(
-        () => _i198.MedicalResearchService(
-              gh<_i77.MedicalWebSearchService>(),
-              gh<_i73.MedicalScraperService>(),
-    gh.lazySingleton<_i199.MedicationRepository>(
-        () => _i200.IsarMedicationRepository(
-              gh<_i61.Isar>(),
-              gh<_i101.PharmacyApiService>(),
-    gh.factory<_i201.MedicationsCubit>(
-        () => _i201.MedicationsCubit(gh<_i199.MedicationRepository>()));
-    gh.factory<_i202.MeditationCubit>(() => _i202.MeditationCubit(
-          gh<_i106.RecommendScriptUseCase>(),
-          gh<_i123.StartSessionUseCase>(),
-          gh<_i153.CompleteSessionUseCase>(),
-          gh<_i178.GetProgressUseCase>(),
-    gh.factory<_i203.NetworkCubit>(() => _i203.NetworkCubit(
-          gh<_i88.NetworkPeerRepository>(),
-          gh<_i87.NetworkP2PApi>(),
-    gh.factory<_i204.NetworkHealthCubit>(() => _i204.NetworkHealthCubit(
-          gh<_i176.GetNetworkHealth>(),
-          gh<_i154.ConnectNode>(),
-          gh<_i90.NetworkRepository>(),
-    gh.lazySingleton<_i205.OnboardingRepository>(() =>
-        _i206.OnboardingRepositoryImpl(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i207.ReportGenerationService>(
-        () => _i208.GemmaReportGenerationService(
-              gh<_i64.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i133.VectorStoreService>(),
-              gh<_i130.UserProfileRepository>(),
-              gh<_i103.PromptScrubber>(),
-    gh.factory<_i209.SaveCredentialsUseCase>(
-        () => _i209.SaveCredentialsUseCase(gh<_i147.AuthRepository>()));
-    gh.factory<_i210.SaveMedicationUseCase>(
-        () => _i210.SaveMedicationUseCase(gh<_i199.MedicationRepository>()));
-    gh.factory<_i211.SaveRecordUseCase>(
-        () => _i211.SaveRecordUseCase(gh<_i187.HealthRecordRepository>()));
-    gh.factory<_i212.SaveUserProfileUseCase>(
-        () => _i212.SaveUserProfileUseCase(gh<_i130.UserProfileRepository>()));
-    gh.factory<_i213.SaveVitalSignsUseCase>(
-        () => _i213.SaveVitalSignsUseCase(gh<_i135.VitalSignRepository>()));
-    gh.factory<_i214.SecondOpinionCubit>(
-        () => _i214.SecondOpinionCubit(gh<_i112.SecondOpinionRepository>()));
-    gh.factory<_i215.SendMessageUseCase>(
-        () => _i215.SendMessageUseCase(gh<_i138.VoiceChatRepository>()));
-    gh.factory<_i216.SetPinUseCase>(() => _i216.SetPinUseCase(
-    gh.lazySingleton<_i217.SmartSearchUseCase>(
-        () => _i217.SmartSearchUseCase(gh<_i133.VectorStoreService>()));
-    gh.lazySingleton<_i218.StartListeningUseCase>(
-        () => _i218.StartListeningUseCase(
-              gh<_i149.BleSharingService>(),
-              gh<_i94.NfcSharingService>(),
-              gh<_i142.WifiDirectService>(),
-    gh.lazySingleton<_i219.StartSharingUseCase>(() => _i219.StartSharingUseCase(
-          gh<_i149.BleSharingService>(),
-          gh<_i94.NfcSharingService>(),
-          gh<_i142.WifiDirectService>(),
-    gh.factory<_i220.SyncCubit>(() => _i220.SyncCubit(
-          gh<_i69.SyncService>(),
-    gh.factory<_i221.UserProfileCubit>(
-        () => _i221.UserProfileCubit(gh<_i130.UserProfileRepository>()));
-    gh.factory<_i222.ValidateSessionUseCase>(
-        () => _i222.ValidateSessionUseCase(gh<_i147.AuthRepository>()));
-    gh.factory<_i223.VitalSignBloc>(
-        () => _i223.VitalSignBloc(gh<_i135.VitalSignRepository>()));
-    gh.factory<_i224.VoiceChatCubit>(() => _i224.VoiceChatCubit(
-          gh<_i215.SendMessageUseCase>(),
-          gh<_i171.GetChatHistoryUseCase>(),
-          gh<_i138.VoiceChatRepository>(),
-    gh.factory<_i225.VouchCubit>(
-        () => _i225.VouchCubit(gh<_i140.VouchRepository>()));
-    gh.lazySingleton<_i226.AllergyRepository>(() => _i227.AllergyRepositoryImpl(
-          gh<_i145.AllergyLocalDataSource>(),
-          _encryptionService: gh<_i165.EncryptionService>(),
-    gh.factory<_i228.AuthCubit>(() => _i228.AuthCubit(
-          gh<_i196.LoginUseCase>(),
-          gh<_i197.LogoutUseCase>(),
-          gh<_i222.ValidateSessionUseCase>(),
-          gh<_i216.SetPinUseCase>(),
-          gh<_i152.CheckSessionTimeoutUseCase>(),
-    gh.lazySingleton<_i229.AuthService>(
-        () => _i229.AuthServiceImpl(gh<_i165.EncryptionService>()));
-    gh.lazySingleton<_i230.BadgeCalculator>(() => _i230.BadgeCalculator(
-          gh<_i160.DoctorProfileRepository>(),
-          gh<_i104.RatingRepository>(),
-          gh<_i140.VouchRepository>(),
-    gh.factory<_i231.BadgeCubit>(
-        () => _i231.BadgeCubit(gh<_i230.BadgeCalculator>()));
-    gh.factory<_i232.CalendarImportCubit>(() => _i232.CalendarImportCubit(
-          gh<_i189.ImportCalendarUseCase>(),
-    gh.factory<_i233.CompleteOnboardingUseCase>(() =>
-        _i233.CompleteOnboardingUseCase(gh<_i205.OnboardingRepository>()));
-    gh.lazySingleton<_i234.DashboardRepository>(
-        () => _i235.DashboardRepositoryImpl(
-              gh<_i135.VitalSignRepository>(),
-              gh<_i199.MedicationRepository>(),
-              gh<_i107.ReportRepository>(),
-    gh.lazySingleton<_i236.DataSourceRepository>(
-        () => _i237.DataSourceRepositoryImpl(
               gh<_i116.SensorApiDataSource>(),
-              gh<_i167.FileImportDataSource>(),
+              gh<_i164.FileImportDataSource>(),
               gh<_i46.HealthConnectDataSource>(),
-    gh.lazySingleton<_i238.DistributedCacheUsecase>(() =>
-        _i238.DistributedCacheUsecase(gh<_i158.DistributedStorageService>()));
-    gh.factory<_i239.EpsConnectionBloc>(() => _i239.EpsConnectionBloc(
-          gh<_i173.GetConnectionsUseCase>(),
-          gh<_i155.ConnectProviderUseCase>(),
-          gh<_i157.DisconnectProviderUseCase>(),
-    gh.factory<_i240.EpsConnectionCubit>(() => _i240.EpsConnectionCubit(
+            ));
+    gh.lazySingleton<_i237.DistributedCacheUsecase>(() =>
+        _i237.DistributedCacheUsecase(gh<_i156.DistributedStorageService>()));
+    gh.factory<_i238.EpsConnectionBloc>(() => _i238.EpsConnectionBloc(
+          gh<_i170.GetConnectionsUseCase>(),
+          gh<_i153.ConnectProviderUseCase>(),
+          gh<_i155.DisconnectProviderUseCase>(),
+        ));
+    gh.factory<_i239.EpsConnectionCubit>(() => _i239.EpsConnectionCubit(
+          gh<_i170.GetConnectionsUseCase>(),
+          gh<_i153.ConnectProviderUseCase>(),
+          gh<_i155.DisconnectProviderUseCase>(),
+        ));
+    gh.factory<_i240.FhirSyncCubit>(() => _i240.FhirSyncCubit(
+          gh<_i218.SyncService>(),
+          gh<_i95.NodeDiscoveryService>(),
+        ));
     gh.factory<_i241.GetAllMedicationsUseCase>(
-        () => _i241.GetAllMedicationsUseCase(gh<_i199.MedicationRepository>()));
+        () => _i241.GetAllMedicationsUseCase(gh<_i196.MedicationRepository>()));
     gh.factory<_i242.GetAllRecordsUseCase>(
-        () => _i242.GetAllRecordsUseCase(gh<_i187.HealthRecordRepository>()));
+        () => _i242.GetAllRecordsUseCase(gh<_i184.HealthRecordRepository>()));
     gh.factory<_i243.GetAllergiesUseCase>(
-        () => _i243.GetAllergiesUseCase(gh<_i226.AllergyRepository>()));
+        () => _i243.GetAllergiesUseCase(gh<_i225.AllergyRepository>()));
     gh.factory<_i244.GetDashboardStatsUseCase>(
-        () => _i244.GetDashboardStatsUseCase(gh<_i234.DashboardRepository>()));
+        () => _i244.GetDashboardStatsUseCase(gh<_i233.DashboardRepository>()));
     gh.factory<_i245.GetOnboardingProfileUseCase>(() =>
-        _i245.GetOnboardingProfileUseCase(gh<_i205.OnboardingRepository>()));
+        _i245.GetOnboardingProfileUseCase(gh<_i202.OnboardingRepository>()));
     gh.factory<_i246.GetRecentActivityUseCase>(
-        () => _i246.GetRecentActivityUseCase(gh<_i234.DashboardRepository>()));
+        () => _i246.GetRecentActivityUseCase(gh<_i233.DashboardRepository>()));
     gh.factory<_i247.HealthImportBloc>(() => _i247.HealthImportBloc(
           gh<_i109.GetAvailableSourcesUseCase>(),
           gh<_i109.RequestHealthAuthUseCase>(),
           gh<_i109.ImportHealthDataUseCase>(),
+        ));
     gh.factory<_i248.HealthImportCubit>(() => _i248.HealthImportCubit(
+          gh<_i109.GetAvailableSourcesUseCase>(),
+          gh<_i109.RequestHealthAuthUseCase>(),
+          gh<_i109.ImportHealthDataUseCase>(),
+        ));
     gh.factory<_i249.HealthRecordCubit>(() => _i249.HealthRecordCubit(
-          gh<_i187.HealthRecordRepository>(),
+          gh<_i184.HealthRecordRepository>(),
+          gh<_i37.FilePickerService>(),
           gh<_i56.ImagePickerService>(),
           gh<_i100.OcrService>(),
+          gh<_i131.VectorStoreService>(),
+        ));
     gh.lazySingleton<_i250.HomeRepository>(() => _i251.HomeRepositoryImpl(
-          gh<_i135.VitalSignRepository>(),
-          gh<_i199.MedicationRepository>(),
+          gh<_i133.VitalSignRepository>(),
+          gh<_i8.AppointmentRepository>(),
+          gh<_i196.MedicationRepository>(),
           gh<_i51.HomeLocalDataSource>(),
           gh<_i53.HomeRemoteDataSource>(),
           gh<_i50.HealthSummaryDatasource>(),
-    gh.lazySingleton<_i193.LlmService>(
+        ));
+    gh.lazySingleton<_i190.LlmService>(
       () => _i252.RagLlmService(
-        gh<_i133.VectorStoreService>(),
-        gh<_i198.MedicalResearchService>(),
-        gh<_i130.UserProfileRepository>(),
+        gh<_i131.VectorStoreService>(),
+        gh<_i195.MedicalResearchService>(),
+        gh<_i128.UserProfileRepository>(),
         gh<_i64.LlmAdapter>(instanceName: 'gemma'),
+      ),
+      instanceName: 'rag',
+    );
     gh.lazySingleton<_i253.MedicalResearchRepository>(
         () => _i254.MedicalResearchRepositoryImpl(
-              gh<_i198.MedicalResearchService>(),
+              gh<_i195.MedicalResearchService>(),
+              gh<_i61.Isar>(),
+            ));
     gh.factory<_i255.MedicationBloc>(
-        () => _i255.MedicationBloc(gh<_i199.MedicationRepository>()));
+        () => _i255.MedicationBloc(gh<_i196.MedicationRepository>()));
     gh.factory<_i256.OnboardingCubit>(
-        () => _i256.OnboardingCubit(gh<_i205.OnboardingRepository>()));
+        () => _i256.OnboardingCubit(gh<_i202.OnboardingRepository>()));
     gh.lazySingleton<_i257.PatientContextIndexer>(
       () => _i257.PatientContextIndexer(
         gh<_i61.Isar>(),
-        gh<_i187.HealthRecordRepository>(),
-        gh<_i199.MedicationRepository>(),
-        gh<_i226.AllergyRepository>(),
-        gh<_i135.VitalSignRepository>(),
+        gh<_i131.VectorStoreService>(),
+        gh<_i184.HealthRecordRepository>(),
+        gh<_i196.MedicationRepository>(),
+        gh<_i225.AllergyRepository>(),
+        gh<_i133.VitalSignRepository>(),
         gh<_i8.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.factory<_i257.ReportBloc>(() => _i257.ReportBloc(
-          gh<_i106.ReportRepository>(),
-          gh<_i206.ReportGenerationService>(),
-        ));
-    gh.factory<_i258.SaveAllergyUseCase>(
-        () => _i258.SaveAllergyUseCase(gh<_i225.AllergyRepository>()));
-    gh.factory<_i259.SearchMedicalResearch>(() =>
-        _i259.SearchMedicalResearch(gh<_i252.MedicalResearchRepository>()));
-    gh.factory<_i260.SharingCubit>(() => _i260.SharingCubit(
-          bleService: gh<_i148.BleSharingService>(),
-          nfcService: gh<_i93.NfcSharingService>(),
-          wifiService: gh<_i141.WifiDirectService>(),
-          startSharingUseCase: gh<_i218.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i217.StartListeningUseCase>(),
-          cancelSharingUseCase: gh<_i149.CancelSharingUseCase>(),
-          walletService: gh<_i35.WalletService>(),
-          walletEncryption: gh<_i35.EncryptionService>(),
-    gh.factory<_i261.AllergiesCubit>(
-        () => _i261.AllergiesCubit(gh<_i225.AllergyRepository>()));
-    gh.factory<_i262.AllergyBloc>(
-        () => _i262.AllergyBloc(gh<_i225.AllergyRepository>()));
-    gh.factory<_i263.AuthCubit>(() => _i263.AuthCubit(gh<_i228.AuthService>()));
-    gh.factory<_i264.DashboardCubit>(() => _i264.DashboardCubit(
-          gh<_i243.GetDashboardStatsUseCase>(),
-          gh<_i245.GetRecentActivityUseCase>(),
-    gh.factory<_i265.DataSourceCubit>(
-        () => _i265.DataSourceCubit(gh<_i235.DataSourceRepository>()));
-    gh.factory<_i266.GetHealthSummaryUseCase>(
-        () => _i266.GetHealthSummaryUseCase(gh<_i249.HomeRepository>()));
-    gh.factory<_i267.GetResearchHistory>(
-        () => _i267.GetResearchHistory(gh<_i252.MedicalResearchRepository>()));
-    gh.factory<_i268.HomeCubit>(() => _i268.HomeCubit(
-          gh<_i266.GetHealthSummaryUseCase>(),
-          gh<_i249.HomeRepository>(),
-    gh.lazySingleton<_i269.MedicalIndexingService>(
-        () => _i269.MedicalIndexingService(
-              gh<_i69.MedicalKnowledgeRepository>(),
-              gh<_i132.VectorStoreService>(),
-              gh<_i256.PatientContextIndexer>(),
     gh.factory<_i258.ReportBloc>(() => _i258.ReportBloc(
           gh<_i107.ReportRepository>(),
-          gh<_i207.ReportGenerationService>(),
+          gh<_i204.ReportGenerationService>(),
+        ));
     gh.factory<_i259.SaveAllergyUseCase>(
-        () => _i259.SaveAllergyUseCase(gh<_i226.AllergyRepository>()));
+        () => _i259.SaveAllergyUseCase(gh<_i225.AllergyRepository>()));
     gh.factory<_i260.SearchMedicalResearch>(() =>
         _i260.SearchMedicalResearch(gh<_i253.MedicalResearchRepository>()));
     gh.factory<_i261.SharingCubit>(() => _i261.SharingCubit(
-          bleService: gh<_i149.BleSharingService>(),
+          bleService: gh<_i147.BleSharingService>(),
           nfcService: gh<_i94.NfcSharingService>(),
-          wifiService: gh<_i142.WifiDirectService>(),
-          startSharingUseCase: gh<_i219.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i218.StartListeningUseCase>(),
-          cancelSharingUseCase: gh<_i150.CancelSharingUseCase>(),
+          wifiService: gh<_i140.WifiDirectService>(),
+          startSharingUseCase: gh<_i216.StartSharingUseCase>(),
+          startListeningUseCase: gh<_i215.StartListeningUseCase>(),
+          cancelSharingUseCase: gh<_i148.CancelSharingUseCase>(),
+          walletService: gh<_i35.WalletService>(),
+          walletEncryption: gh<_i35.EncryptionService>(),
+        ));
     gh.factory<_i262.AllergiesCubit>(
-        () => _i262.AllergiesCubit(gh<_i226.AllergyRepository>()));
+        () => _i262.AllergiesCubit(gh<_i225.AllergyRepository>()));
     gh.factory<_i263.AllergyBloc>(
-        () => _i263.AllergyBloc(gh<_i226.AllergyRepository>()));
-    gh.factory<_i264.AuthCubit>(() => _i264.AuthCubit(gh<_i229.AuthService>()));
+        () => _i263.AllergyBloc(gh<_i225.AllergyRepository>()));
+    gh.factory<_i264.AuthCubit>(() => _i264.AuthCubit(gh<_i228.AuthService>()));
     gh.factory<_i265.DashboardCubit>(() => _i265.DashboardCubit(
           gh<_i244.GetDashboardStatsUseCase>(),
           gh<_i246.GetRecentActivityUseCase>(),
+        ));
     gh.factory<_i266.DataSourceCubit>(
-        () => _i266.DataSourceCubit(gh<_i236.DataSourceRepository>()));
+        () => _i266.DataSourceCubit(gh<_i235.DataSourceRepository>()));
     gh.factory<_i267.GetHealthSummaryUseCase>(
         () => _i267.GetHealthSummaryUseCase(gh<_i250.HomeRepository>()));
     gh.factory<_i268.GetResearchHistory>(
@@ -1614,10 +1168,11 @@ extension GetItInjectableX on _i1.GetIt {
     gh.factory<_i269.HomeCubit>(() => _i269.HomeCubit(
           gh<_i267.GetHealthSummaryUseCase>(),
           gh<_i250.HomeRepository>(),
+        ));
     gh.lazySingleton<_i270.MedicalIndexingService>(
         () => _i270.MedicalIndexingService(
               gh<_i70.MedicalKnowledgeRepository>(),
-              gh<_i133.VectorStoreService>(),
+              gh<_i131.VectorStoreService>(),
               gh<_i257.PatientContextIndexer>(),
             ));
     gh.factory<_i271.MedicalResearchCubit>(() => _i271.MedicalResearchCubit(
@@ -1638,5 +1193,3 @@ class _$MemoryModule extends _i274.MemoryModule {}
 class _$DatabaseModule extends _i275.DatabaseModule {}
 
 class _$FhirModule extends _i276.FhirModule {}
-
-

--- a/lib/core/logging/audit_logger.dart
+++ b/lib/core/logging/audit_logger.dart
@@ -54,7 +54,7 @@ class AuditLogger {
       'action': action,
       'resourceType': resourceType,
       'resourceId': resourceId,
-      if (metadata != null) 'metadata': metadata,
+      'metadata': ?metadata,
     };
 
     try {

--- a/lib/core/widgets/page_header.dart
+++ b/lib/core/widgets/page_header.dart
@@ -59,7 +59,7 @@ class PageHeader extends StatelessWidget {
                   ),
                 ),
               ),
-              if (trailing != null) trailing!,
+              ?trailing,
             ],
           ),
           if (subtitle != null) ...[

--- a/lib/features/about/presentation/pages/about_page.dart
+++ b/lib/features/about/presentation/pages/about_page.dart
@@ -99,7 +99,7 @@ class AboutPage extends StatelessWidget {
 
 class BlogTile extends StatelessWidget {
   final BlogPost post;
-  const BlogTile({required this.post});
+  const BlogTile({super.key, required this.post});
 
   @override
   Widget build(BuildContext context) {

--- a/lib/features/allergies/infrastructure/repositories/isar_allergy_repository.dart
+++ b/lib/features/allergies/infrastructure/repositories/isar_allergy_repository.dart
@@ -1,4 +1,3 @@
-import 'package:injectable/injectable.dart';
 import 'package:isar/isar.dart';
 import '../../domain/entities/allergy.dart';
 import '../../domain/repositories/allergy_repository.dart';

--- a/lib/features/appointments/infrastructure/repositories/isar_appointment_repository.dart
+++ b/lib/features/appointments/infrastructure/repositories/isar_appointment_repository.dart
@@ -1,4 +1,3 @@
-import 'package:injectable/injectable.dart';
 import 'package:isar/isar.dart';
 import '../../domain/entities/appointment.dart';
 import '../../domain/repositories/appointment_repository.dart';

--- a/lib/features/appointments/presentation/widgets/appointment_form.dart
+++ b/lib/features/appointments/presentation/widgets/appointment_form.dart
@@ -116,7 +116,7 @@ class _AppointmentFormState extends State<AppointmentForm> {
             ),
             const SizedBox(height: 12),
             DropdownButtonFormField<AppointmentStatus>(
-              value: _status,
+              initialValue: _status,
               decoration: const InputDecoration(labelText: 'Estado', border: OutlineInputBorder()),
               items: AppointmentStatus.values.map((s) => DropdownMenuItem(value: s, child: Text(s.name))).toList(),
               onChanged: (val) => setState(() => _status = val!),

--- a/lib/features/data_sources/presentation/widgets/data_source_tile.dart
+++ b/lib/features/data_sources/presentation/widgets/data_source_tile.dart
@@ -41,7 +41,7 @@ class DataSourceTile extends StatelessWidget {
             Switch(
               value: source.status == DataSourceStatus.connected,
               onChanged: (_) => onToggle(),
-              activeColor: AppColors.primary,
+              activeThumbColor: AppColors.primary,
             ),
           ],
         ),

--- a/lib/features/eps_connection/presentation/pages/eps_connection_page.dart
+++ b/lib/features/eps_connection/presentation/pages/eps_connection_page.dart
@@ -96,7 +96,7 @@ class EpsConnectionPage extends StatelessWidget {
         },
         child: const Padding(
           padding: EdgeInsets.all(20),
-          child: const Row(
+          child: Row(
             mainAxisAlignment: MainAxisAlignment.center,
             children: [
               Icon(Icons.qr_code_scanner, color: AppColors.primary),

--- a/lib/features/health_data_import/domain/usecases/health_import_usecases.dart
+++ b/lib/features/health_data_import/domain/usecases/health_import_usecases.dart
@@ -2,7 +2,6 @@ import 'package:health/health.dart';
 import 'package:injectable/injectable.dart';
 import '../services/health_data_import_service.dart';
 import '../entities/health_data_source.dart';
-import '../entities/health_import_result.dart';
 import '../../../vitals/domain/repositories/vital_sign_repository.dart';
 
 @injectable

--- a/lib/features/local_agent/domain/services/llm_adapter.dart
+++ b/lib/features/local_agent/domain/services/llm_adapter.dart
@@ -1,12 +1,6 @@
 import '../chat_message.dart';
 import '../entities/local_model_descriptor.dart';
 
-/// LLM Adapter interface for integration with isar_agent_memory v0.4.0
-///
-/// This interface allows OrionHealth to integrate with the HiRAG Phase 2
-/// automatic summarization features while maintaining hexagonal architecture.
-import '../chat_message.dart';
-import '../entities/local_model_descriptor.dart';
 
 abstract class LlmAdapter {
   /// Generate text based on a prompt

--- a/lib/features/local_agent/domain/services/vector_store_service.dart
+++ b/lib/features/local_agent/domain/services/vector_store_service.dart
@@ -1,4 +1,3 @@
-import 'package:isar/isar.dart';
 import 'package:orionhealth_health/features/local_agent/domain/chat_message.dart';
 
 /// Vector Store Service interface for memory management

--- a/lib/features/medications/presentation/pages/medications_page.dart
+++ b/lib/features/medications/presentation/pages/medications_page.dart
@@ -3,7 +3,6 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:isar/isar.dart';
 import 'package:get_it/get_it.dart';
 import '../../../../core/theme/app_colors.dart';
-import '../../../../core/widgets/glassmorphic_card.dart';
 import '../../domain/entities/medication.dart';
 import '../../application/medications_cubit.dart';
 import '../../application/medications_state.dart';

--- a/lib/features/settings/presentation/widgets/profile_section.dart
+++ b/lib/features/settings/presentation/widgets/profile_section.dart
@@ -66,7 +66,7 @@ class ProfileSection extends StatelessWidget {
               const Row(
                 children: [
                   Icon(Icons.dark_mode_outlined, color: AppColors.secondary, size: 20),
-                  const SizedBox(width: 12),
+                  SizedBox(width: 12),
                   Text(
                     'Modo Oscuro',
                     style: TextStyle(color: Colors.white, fontSize: 15),
@@ -77,7 +77,7 @@ class ProfileSection extends StatelessWidget {
                 key: const Key('dark_mode_switch'),
                 value: isDarkMode,
                 onChanged: onDarkModeChanged,
-                activeColor: AppColors.primary,
+                activeThumbColor: AppColors.primary,
               ),
             ],
           ),

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -23,7 +23,6 @@ import 'features/local_agent/infrastructure/services/medical_indexing_service.da
 import 'features/onboarding/presentation/pages/onboarding_page.dart';
 import 'features/onboarding/application/onboarding_cubit.dart';
 import 'features/sync/domain/sync_repository.dart';
-import 'features/home/presentation/pages/main_navigation_page.dart';
 import 'features/auth/presentation/auth_gate.dart';
 
 // ─────────────────────────────────────────────

--- a/packages/medical_standards/test/medications_test.dart
+++ b/packages/medical_standards/test/medications_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 void main() {

--- a/packages/medical_standards/test/onboarding_test.dart
+++ b/packages/medical_standards/test/onboarding_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 void main() {

--- a/packages/medical_standards/test/snomed_test.dart
+++ b/packages/medical_standards/test/snomed_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 void main() {

--- a/packages/medical_standards/test/standards_test.dart
+++ b/packages/medical_standards/test/standards_test.dart
@@ -1,4 +1,4 @@
-import 'package:test/test.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:medical_standards/medical_standards.dart';
 
 void main() {

--- a/test/core/logging/audit_logger_test.dart
+++ b/test/core/logging/audit_logger_test.dart
@@ -4,7 +4,6 @@
 import 'dart:convert';
 import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/core/logging/audit_logger.dart';
 import 'package:path/path.dart' as p;
 import 'package:path_provider_platform_interface/path_provider_platform_interface.dart';

--- a/test/core/network/dio_behavior_test.dart
+++ b/test/core/network/dio_behavior_test.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // SPDX-FileCopyrightText: 2025 SouthWest AI Labs
 
-import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/core/network/http_client_test.dart
+++ b/test/core/network/http_client_test.dart
@@ -1,7 +1,6 @@
 // SPDX-License-Identifier: AGPL-3.0-only
 // SPDX-FileCopyrightText: 2025 SouthWest AI Labs
 
-import 'dart:io';
 import 'package:dio/dio.dart';
 import 'package:dio/io.dart';
 import 'package:flutter_test/flutter_test.dart';

--- a/test/features/allergies/data/repositories/allergy_repository_impl_test.dart
+++ b/test/features/allergies/data/repositories/allergy_repository_impl_test.dart
@@ -1,10 +1,13 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/auth/infrastructure/services/encryption_service.dart';
 import 'package:orionhealth_health/features/allergies/data/datasources/allergy_local_datasource.dart';
 import 'package:orionhealth_health/features/allergies/data/repositories/allergy_repository_impl.dart';
 import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
 
 class MockAllergyLocalDataSource extends Mock implements AllergyLocalDataSource {}
+
+class MockEncryptionService extends Mock implements EncryptionService {}
 
 class FakeAllergy extends Fake implements Allergy {}
 

--- a/test/features/auth/application/bloc/auth_cubit_test.dart
+++ b/test/features/auth/application/bloc/auth_cubit_test.dart
@@ -140,7 +140,7 @@ void main() {
       when(mockRepository.getCredentials()).thenAnswer((_) async => credentials);
       when(mockBiometric.authenticate(localizedReason: anyNamed('localizedReason')))
           .thenAnswer((_) async => true);
-      when(mockRepository.saveCredentials(any)).thenAnswer((_) async => null);
+      when(mockRepository.saveCredentials(any)).thenAnswer((_) async {});
 
       await authCubit.toggleBiometrics(true);
 
@@ -149,7 +149,7 @@ void main() {
     });
 
     test('logout should call logoutUseCase and emit AuthUnauthenticated', () async {
-      when(mockLogoutUseCase()).thenAnswer((_) async => null);
+      when(mockLogoutUseCase()).thenAnswer((_) async {});
 
       await authCubit.logout();
 

--- a/test/features/auth/presentation/golden/auth_gate_golden_test.dart
+++ b/test/features/auth/presentation/golden/auth_gate_golden_test.dart
@@ -1,5 +1,4 @@
-﻿import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
 import 'package:orionhealth_health/features/auth/presentation/auth_gate.dart';
 import '../../../../core/golden_test_utils.dart';
 

--- a/test/features/auth/presentation/golden/auth_methods_page_golden_test.dart
+++ b/test/features/auth/presentation/golden/auth_methods_page_golden_test.dart
@@ -1,4 +1,3 @@
-﻿import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';

--- a/test/features/auth/presentation/golden/auth_page_golden_test.dart
+++ b/test/features/auth/presentation/golden/auth_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';

--- a/test/features/auth/presentation/golden/login_page_golden_test.dart
+++ b/test/features/auth/presentation/golden/login_page_golden_test.dart
@@ -1,4 +1,3 @@
-﻿import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';

--- a/test/features/calendar_import/presentation/golden/calendar_import_page_golden_test.dart
+++ b/test/features/calendar_import/presentation/golden/calendar_import_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';
@@ -6,7 +5,6 @@ import 'package:intl/date_symbol_data_local.dart';
 import 'package:orionhealth_health/features/calendar_import/domain/entities/calendar_appointment.dart';
 import 'package:orionhealth_health/features/calendar_import/presentation/calendar_import_page.dart';
 import 'package:orionhealth_health/features/calendar_import/application/calendar_import_cubit.dart';
-import 'package:orionhealth_health/features/appointments/domain/entities/appointment.dart';
 import '../../../../core/golden_test_utils.dart';
 
 class MockCalendarImportCubit extends Mock implements CalendarImportCubit {}

--- a/test/features/data_sources/presentation/pages/config_page_test.dart
+++ b/test/features/data_sources/presentation/pages/config_page_test.dart
@@ -1,6 +1,4 @@
-import 'package:bloc_test/bloc_test.dart';
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/data_sources/application/data_source_cubit.dart';
@@ -10,7 +8,7 @@ import 'package:orionhealth_health/features/data_sources/presentation/pages/data
 import 'package:orionhealth_health/features/data_sources/presentation/widgets/data_source_tile.dart';
 import 'package:get_it/get_it.dart';
 
-class MockDataSourceCubit extends MockCubit<DataSourceState> implements DataSourceCubit {}
+class MockDataSourceCubit extends Mock implements DataSourceCubit {}
 
 void main() {
   late MockDataSourceCubit mockCubit;
@@ -28,6 +26,10 @@ void main() {
   setUpAll(() {
     final getIt = GetIt.instance;
     mockCubit = MockDataSourceCubit();
+
+    when(() => mockCubit.stream).thenAnswer((_) => const Stream.empty());
+    when(() => mockCubit.close()).thenAnswer((_) async => {});
+
     if (!getIt.isRegistered<DataSourceCubit>()) {
       getIt.registerFactory<DataSourceCubit>(() => mockCubit);
     }

--- a/test/features/doctor_verification/presentation/pages/doctor_detail_page_test.dart
+++ b/test/features/doctor_verification/presentation/pages/doctor_detail_page_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/doctor_verification/application/doctor_verification_cubit.dart';
 import 'package:orionhealth_health/features/doctor_verification/application/doctor_verification_state.dart';

--- a/test/features/doctor_verification/presentation/pages/doctor_list_page_golden_test.dart
+++ b/test/features/doctor_verification/presentation/pages/doctor_list_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';

--- a/test/features/email-citas/presentation/golden/email_connect_error_golden_test.dart
+++ b/test/features/email-citas/presentation/golden/email_connect_error_golden_test.dart
@@ -1,5 +1,4 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';

--- a/test/features/health_data_import/presentation/golden/data_source_card_golden_test.dart
+++ b/test/features/health_data_import/presentation/golden/data_source_card_golden_test.dart
@@ -46,7 +46,7 @@ void main() {
           const Scaffold(
             body: Center(
               child: Padding(
-                padding: const EdgeInsets.all(16.0),
+                padding: EdgeInsets.all(16.0),
                 child: DataSourceCard(
                   source: HealthDataSource.appleHealth,
                   isAvailable: false,

--- a/test/features/health_data_import/presentation/golden/health_import_page_ready_golden_test.dart
+++ b/test/features/health_data_import/presentation/golden/health_import_page_ready_golden_test.dart
@@ -1,7 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/core/di/injection.dart' as di;
 import 'package:orionhealth_health/features/health_data_import/application/health_import_cubit.dart';
 import 'package:orionhealth_health/features/health_data_import/application/health_import_state.dart';

--- a/test/features/health_data_import/presentation/golden/health_import_page_status_golden_test.dart
+++ b/test/features/health_data_import/presentation/golden/health_import_page_status_golden_test.dart
@@ -1,7 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/core/di/injection.dart' as di;
 import 'package:orionhealth_health/features/health_data_import/application/health_import_cubit.dart';
 import 'package:orionhealth_health/features/health_data_import/application/health_import_state.dart';

--- a/test/features/health_data_import/presentation/pages/health_import_golden_test.dart
+++ b/test/features/health_data_import/presentation/pages/health_import_golden_test.dart
@@ -1,6 +1,5 @@
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/health_data_import/presentation/pages/health_import_page.dart';

--- a/test/features/health_data_import/presentation/pages/health_import_page_test.dart
+++ b/test/features/health_data_import/presentation/pages/health_import_page_test.dart
@@ -7,7 +7,6 @@ import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/health_data_import/application/health_import_cubit.dart';
 import 'package:orionhealth_health/features/health_data_import/application/health_import_state.dart';
 import 'package:orionhealth_health/features/health_data_import/domain/entities/health_data_source.dart';
-import 'package:orionhealth_health/features/health_data_import/domain/entities/health_import_result.dart';
 import 'package:orionhealth_health/features/health_data_import/presentation/pages/health_import_page.dart';
 import 'package:orionhealth_health/features/health_data_import/presentation/widgets/data_source_card.dart';
 import 'package:orionhealth_health/features/health_data_import/presentation/widgets/import_progress_dialog.dart';

--- a/test/features/health_record/presentation/golden/timeline_page_golden_test.dart
+++ b/test/features/health_record/presentation/golden/timeline_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/core/di/injection.dart';

--- a/test/features/health_sharing/presentation/pages/health_sharing_page_golden_test.dart
+++ b/test/features/health_sharing/presentation/pages/health_sharing_page_golden_test.dart
@@ -2,7 +2,6 @@ import 'dart:async';
 import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:orionhealth_health/features/health_sharing/presentation/pages/share_page.dart';
 import 'package:orionhealth_health/features/health_sharing/presentation/pages/receive_page.dart';
@@ -14,7 +13,6 @@ import 'package:orionhealth_health/features/health_sharing/application/sharing_c
 import 'package:orionhealth_health/features/auth/application/bloc/auth_cubit.dart';
 import 'package:orionhealth_health/features/auth/application/bloc/auth_state.dart' as auth_state;
 import 'package:orionhealth_health/features/health_sharing/domain/entities/shared_health_package.dart';
-import 'package:orionhealth_health/features/health_sharing/infrastructure/wifi_direct_service.dart';
 import 'package:orionhealth_health/core/di/injection.dart';
 import 'package:flutter/services.dart';
 import '../../../../core/golden_test_utils.dart';

--- a/test/features/medical_research/presentation/golden/research_result_card_golden_test.dart
+++ b/test/features/medical_research/presentation/golden/research_result_card_golden_test.dart
@@ -4,8 +4,15 @@ import 'package:orionhealth_health/features/medical_research/presentation/widget
 
 void main() {
   testWidgets('ResearchResultCard golden test', (tester) async {
+    final tResult = ResearchResult(
+      title: 'Test Title',
+      content: 'Test Content',
+      source: 'PubMed',
+      url: 'https://pubmed.ncbi.nlm.nih.gov/',
+    );
     await tester.pumpWidget(
-      const MaterialApp(home: Scaffold(body: ResearchResultCard())),
+      const MaterialApp(
+          home: Scaffold(body: ResearchResultCard(result: tResult))),
     );
     await expectLater(
       find.byType(ResearchResultCard),

--- a/test/features/network/governance/presentation/pages/governance_page_golden_test.dart
+++ b/test/features/network/governance/presentation/pages/governance_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/test/features/network/incentives/presentation/pages/incentives_page_golden_test.dart
+++ b/test/features/network/incentives/presentation/pages/incentives_page_golden_test.dart
@@ -1,7 +1,5 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:orionhealth_health/core/di/injection.dart';
 import 'package:orionhealth_health/features/network/incentives/application/incentive_cubit.dart';
 import 'package:orionhealth_health/features/network/incentives/domain/entities/contribution.dart';

--- a/test/features/network/network_health/presentation/pages/network_health_page_golden_test.dart
+++ b/test/features/network/network_health/presentation/pages/network_health_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';

--- a/test/features/network/presentation/golden/connection_status_badge_golden_test.dart
+++ b/test/features/network/presentation/golden/connection_status_badge_golden_test.dart
@@ -1,4 +1,3 @@
-﻿import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:orionhealth_health/features/network/presentation/widgets/connection_status_badge.dart';
 import 'package:orionhealth_health/core/utils/connectivity_manager.dart';

--- a/test/features/settings/presentation/golden/settings_page_golden_test.dart
+++ b/test/features/settings/presentation/golden/settings_page_golden_test.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
-import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/settings/application/llm_settings_cubit.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/app_settings.dart';
 import 'package:orionhealth_health/features/settings/domain/entities/llm_config.dart';

--- a/test/features/sync/presentation/golden/sync_page_golden_test.dart
+++ b/test/features/sync/presentation/golden/sync_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';

--- a/test/features/user_profile/presentation/golden/user_profile_page_golden_test.dart
+++ b/test/features/user_profile/presentation/golden/user_profile_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';

--- a/test/features/vitals/presentation/golden/vitals_monitor_page_golden_test.dart
+++ b/test/features/vitals/presentation/golden/vitals_monitor_page_golden_test.dart
@@ -18,7 +18,7 @@ void main() {
     when(() => mockBleService.initialize()).thenAnswer((_) async {});
     when(() => mockBleService.scanForDevices()).thenAnswer((_) async => []);
     when(() => mockBleService.connect(any())).thenAnswer((_) async => true);
-    when(() => mockBleService.startMedicalDataStream(any())).thenAnswer((_) => {});
+    when(() => mockBleService.startMedicalDataStream(any())).thenAnswer((_) async {});
   });
 
   tearDownAll(() {

--- a/test/features/voice_chat/domain/repositories/voice_chat_repository_test.dart
+++ b/test/features/voice_chat/domain/repositories/voice_chat_repository_test.dart
@@ -52,13 +52,16 @@ void main() {
     });
 
     test('can be mocked and called for transcribeAudio', () async {
-      const tTranscription = 'Transcribed text';
+      final tTranscript = Transcript(
+        text: 'Transcribed text',
+        timestamp: DateTime(2025),
+      );
       when(() => mockRepository.transcribeAudio(any()))
-          .thenAnswer((_) async => tTranscription);
+          .thenAnswer((_) async => tTranscript);
 
       final result = await mockRepository.transcribeAudio([1, 2, 3]);
 
-      expect(result, tTranscription);
+      expect(result, tTranscript);
       verify(() => mockRepository.transcribeAudio([1, 2, 3])).called(1);
     });
   });

--- a/test/features/voice_chat/presentation/golden/voice_chat_page_golden_test.dart
+++ b/test/features/voice_chat/presentation/golden/voice_chat_page_golden_test.dart
@@ -1,4 +1,3 @@
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:get_it/get_it.dart';

--- a/test/integration/dashboard_integration_test.dart
+++ b/test/integration/dashboard_integration_test.dart
@@ -40,7 +40,7 @@ void main() {
     when(() => mockDashboardCubit.stream).thenAnswer((_) => const Stream.empty());
   });
 
-  Widget _buildApp(DashboardState state) {
+  Widget buildApp(DashboardState state) {
     when(() => mockDashboardCubit.state).thenReturn(state);
     return MaterialApp(
       localizationsDelegates: AppLocalizations.localizationsDelegates,
@@ -85,7 +85,7 @@ void main() {
       ];
 
       await tester.pumpWidget(
-        _buildApp(DashboardLoaded(stats: stats, activities: activities)),
+        buildApp(DashboardLoaded(stats: stats, activities: activities)),
       );
       await tester.pumpAndSettle();
 
@@ -130,7 +130,7 @@ void main() {
 
       final stats = DashboardStats(totalMedications: 3, reportsCount: 5);
       await tester.pumpWidget(
-        _buildApp(DashboardLoaded(stats: stats, activities: const [])),
+        buildApp(DashboardLoaded(stats: stats, activities: const [])),
       );
       await tester.pumpAndSettle();
 
@@ -189,7 +189,7 @@ void main() {
           Future(() {
             controller.add(
               DashboardLoaded(
-                stats: const DashboardStats(
+                stats: DashboardStats(
                   totalMedications: 5,
                   reportsCount: 12,
                   lastVitalCheck: DateTime(2026, 7, 7),
@@ -213,7 +213,7 @@ void main() {
       when(() => mockDashboardCubit.stream).thenAnswer((_) => stateStream);
 
       await tester.pumpWidget(
-        _buildApp(const DashboardLoading()),
+        buildApp(DashboardLoading()),
       );
       await tester.pump();
 

--- a/test/integration/data_sources_integration_test.dart
+++ b/test/integration/data_sources_integration_test.dart
@@ -1,7 +1,6 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/data_sources/domain/entities/data_source_entity.dart';
-import 'package:orionhealth_health/features/data_sources/domain/repositories/data_source_repository.dart';
 import 'package:orionhealth_health/features/data_sources/infrastructure/datasources/sensor_api_datasource.dart';
 import 'package:orionhealth_health/features/data_sources/infrastructure/datasources/file_import_datasource.dart';
 import 'package:orionhealth_health/features/data_sources/infrastructure/datasources/health_connect_datasource.dart';

--- a/test_bloc_version.sh
+++ b/test_bloc_version.sh
@@ -1,0 +1,3 @@
+flutter pub add --dev bloc_test:any
+grep "bloc_test:" pubspec.lock
+flutter pub remove bloc_test


### PR DESCRIPTION
I have addressed the `flutter analyze` issues by fixing compilation errors in tests, resolving dependency conflicts, and applying automated lint fixes.

Key actions taken:
1. **Medical Standards Package**: Switched from `test` to `flutter_test` to fix undefined matcher errors in package tests.
2. **Dependency Resolution**: Replaced `MockCubit` (which required `bloc_test`) with standard `mocktail` mocks in `config_page_test.dart` to avoid version conflicts.
3. **Compilation Fixes**: 
    - Fixed `ResearchResultCard` and `HomeHealthSummary` instantiations by adding missing required parameters.
    - Updated `VoiceChatRepository` mocks to match the domain interface (returning `Transcript` instead of `String`).
    - Removed invalid `const` keywords from various widget tests where constructors or values were not actually constant.
    - Fixed factory method calls in `health_sharing_e2e_test.dart`.
4. **General Cleanup**: Ran `dart fix --apply` to resolve multiple "unused import" and "unused variable" warnings across the codebase.

While many issues were resolved, some remaining warnings or errors might persist due to the vast number of initial issues (1776). I prioritized fixing "errors" and major "warnings" as requested.

Fixes #1471

---
*PR created automatically by Jules for task [13650026634091576366](https://jules.google.com/task/13650026634091576366) started by @iberi22*