### PR TITLE
Refactor SyncStatus to SyncPageStatus in sync feature

### DIFF
--- a/lib/features/sync/application/sync_cubit.dart
+++ b/lib/features/sync/application/sync_cubit.dart
@@ -35,17 +35,17 @@ class FhirSyncCubit extends Cubit<SyncState> {
   }
 
   Future<void> performSync() async {
-    emit(state.copyWith(status: SyncStatus.loading));
+    emit(state.copyWith(status: SyncPageStatus.loading));
     try {
       await _syncService.performFullSync();
       final lastSync = await _syncService.getLastSyncTime();
       emit(state.copyWith(
-        status: SyncStatus.success,
+        status: SyncPageStatus.success,
         lastSyncTime: lastSync,
       ));
     } catch (e) {
       emit(state.copyWith(
-        status: SyncStatus.failure,
+        status: SyncPageStatus.failure,
         errorMessage: e.toString(),
       ));
     }

--- a/lib/features/sync/application/sync_state.dart
+++ b/lib/features/sync/application/sync_state.dart
@@ -1,23 +1,23 @@
 import 'package:equatable/equatable.dart';
 import '../domain/entities/sync_node.dart';
 
-enum SyncStatus { initial, loading, success, failure }
+enum SyncPageStatus { initial, loading, success, failure }
 
 class SyncState extends Equatable {
-  final SyncStatus status;
+  final SyncPageStatus status;
   final DateTime? lastSyncTime;
   final String? errorMessage;
   final List<SyncNode> discoveredNodes;
 
   const SyncState({
-    this.status = SyncStatus.initial,
+    this.status = SyncPageStatus.initial,
     this.lastSyncTime,
     this.errorMessage,
     this.discoveredNodes = const [],
   });
 
   SyncState copyWith({
-    SyncStatus? status,
+    SyncPageStatus? status,
     DateTime? lastSyncTime,
     String? errorMessage,
     List<SyncNode>? discoveredNodes,

--- a/lib/features/sync/presentation/pages/sync_page.dart
+++ b/lib/features/sync/presentation/pages/sync_page.dart
@@ -29,11 +29,11 @@ class SyncPage extends StatelessWidget {
               Expanded(
                 child: BlocConsumer<FhirSyncCubit, SyncState>(
                   listener: (context, state) {
-                    if (state.status == SyncStatus.success) {
+                    if (state.status == SyncPageStatus.success) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         const SnackBar(content: Text('Sincronización completada con éxito')),
                       );
-                    } else if (state.status == SyncStatus.failure) {
+                    } else if (state.status == SyncPageStatus.failure) {
                       ScaffoldMessenger.of(context).showSnackBar(
                         SnackBar(content: Text('Error: ${state.errorMessage}')),
                       );
@@ -92,7 +92,7 @@ class SyncPage extends StatelessWidget {
                   overflow: TextOverflow.ellipsis,
                 ),
               ),
-              if (state.status == SyncStatus.loading)
+              if (state.status == SyncPageStatus.loading)
                 const Padding(
                   padding: EdgeInsets.only(left: 8.0),
                   child: SizedBox(
@@ -135,7 +135,7 @@ class SyncPage extends StatelessWidget {
           SizedBox(
             width: double.infinity,
             child: ElevatedButton.icon(
-              onPressed: state.status == SyncStatus.loading
+              onPressed: state.status == SyncPageStatus.loading
                   ? null
                   : () => context.read<FhirSyncCubit>().performSync(),
               icon: const Icon(Icons.sync),

--- a/test/features/sync/application/fhir_sync_cubit_test.dart
+++ b/test/features/sync/application/fhir_sync_cubit_test.dart
@@ -66,7 +66,7 @@ void main() {
 
     await cubit.performSync();
 
-    expect(cubit.state.status, SyncStatus.success);
+    expect(cubit.state.status, SyncPageStatus.success);
     expect(cubit.state.lastSyncTime, lastSync);
   });
 
@@ -75,7 +75,7 @@ void main() {
 
     await cubit.performSync();
 
-    expect(cubit.state.status, SyncStatus.failure);
+    expect(cubit.state.status, SyncPageStatus.failure);
     expect(cubit.state.errorMessage, 'Exception: Sync failed');
   });
 }

--- a/test/features/sync/application/sync_cubit_test.dart
+++ b/test/features/sync/application/sync_cubit_test.dart
@@ -32,7 +32,7 @@ void main() {
 
   group('FhirSyncCubit', () {
     test('initial state has initial status', () {
-      expect(cubit.state.status, SyncStatus.initial);
+      expect(cubit.state.status, SyncPageStatus.initial);
     });
 
     group('performSync', () {
@@ -44,8 +44,8 @@ void main() {
         ).thenAnswer((_) async => tLastSync);
 
         final expected = [
-          SyncState(status: SyncStatus.loading, lastSyncTime: null),
-          SyncState(status: SyncStatus.success, lastSyncTime: tLastSync),
+          SyncState(status: SyncPageStatus.loading, lastSyncTime: null),
+          SyncState(status: SyncPageStatus.success, lastSyncTime: tLastSync),
         ];
 
         expectLater(cubit.stream, emitsInOrder(expected));
@@ -59,9 +59,9 @@ void main() {
         when(() => service.getLastSyncTime()).thenAnswer((_) async => null);
 
         final expected = [
-          SyncState(status: SyncStatus.loading, lastSyncTime: null),
+          SyncState(status: SyncPageStatus.loading, lastSyncTime: null),
           SyncState(
-            status: SyncStatus.failure,
+            status: SyncPageStatus.failure,
             errorMessage: 'Exception: sync failed',
           ),
         ];
@@ -74,19 +74,19 @@ void main() {
     group('SyncState', () {
       test('supports value equality', () {
         expect(
-          const SyncState(status: SyncStatus.initial),
-          const SyncState(status: SyncStatus.initial),
+          const SyncState(status: SyncPageStatus.initial),
+          const SyncState(status: SyncPageStatus.initial),
         );
         expect(
-          SyncState(status: SyncStatus.success, lastSyncTime: DateTime(2024)),
-          SyncState(status: SyncStatus.success, lastSyncTime: DateTime(2024)),
+          SyncState(status: SyncPageStatus.success, lastSyncTime: DateTime(2024)),
+          SyncState(status: SyncPageStatus.success, lastSyncTime: DateTime(2024)),
         );
       });
 
       test('copyWith preserves unchanged fields', () {
-        const state = SyncState(status: SyncStatus.loading);
+        const state = SyncState(status: SyncPageStatus.loading);
         final copied = state.copyWith();
-        expect(copied.status, SyncStatus.loading);
+        expect(copied.status, SyncPageStatus.loading);
       });
     });
   });

--- a/test/features/sync/application/sync_state_test.dart
+++ b/test/features/sync/application/sync_state_test.dart
@@ -12,13 +12,13 @@ void main() {
 
       expect(
         SyncState(
-          status: SyncStatus.initial,
+          status: SyncPageStatus.initial,
           lastSyncTime: lastSync,
           errorMessage: 'error',
           discoveredNodes: nodes,
         ),
         SyncState(
-          status: SyncStatus.initial,
+          status: SyncPageStatus.initial,
           lastSyncTime: lastSync,
           errorMessage: 'error',
           discoveredNodes: nodes,
@@ -37,26 +37,26 @@ void main() {
       ];
 
       final state = SyncState(
-        status: SyncStatus.initial,
+        status: SyncPageStatus.initial,
         lastSyncTime: lastSync,
         errorMessage: 'error',
         discoveredNodes: nodes,
       );
 
       final updatedState = state.copyWith(
-        status: SyncStatus.success,
+        status: SyncPageStatus.success,
         lastSyncTime: newSync,
         errorMessage: 'no error',
         discoveredNodes: newNodes,
       );
 
-      expect(updatedState.status, SyncStatus.success);
+      expect(updatedState.status, SyncPageStatus.success);
       expect(updatedState.lastSyncTime, newSync);
       expect(updatedState.errorMessage, 'no error');
       expect(updatedState.discoveredNodes, newNodes);
 
-      final partiallyUpdated = state.copyWith(status: SyncStatus.loading);
-      expect(partiallyUpdated.status, SyncStatus.loading);
+      final partiallyUpdated = state.copyWith(status: SyncPageStatus.loading);
+      expect(partiallyUpdated.status, SyncPageStatus.loading);
       expect(partiallyUpdated.lastSyncTime, lastSync);
       expect(partiallyUpdated.errorMessage, 'error');
       expect(partiallyUpdated.discoveredNodes, nodes);

--- a/test/features/sync/presentation/golden/sync_page_golden_test.dart
+++ b/test/features/sync/presentation/golden/sync_page_golden_test.dart
@@ -35,7 +35,7 @@ void main() {
       setupGoldenTest(tester);
 
       final state = SyncState(
-        status: SyncStatus.initial,
+        status: SyncPageStatus.initial,
         lastSyncTime: DateTime(2026, 6, 14, 15, 30),
         discoveredNodes: const [
           SyncNode(id: '1', name: 'Nodo Sala Principal', host: '192.168.1.15', port: 8080),
@@ -60,7 +60,7 @@ void main() {
       setupGoldenTest(tester);
 
       final state = SyncState(
-        status: SyncStatus.loading,
+        status: SyncPageStatus.loading,
         lastSyncTime: DateTime(2026, 6, 14, 15, 30),
       );
 

--- a/test/features/sync/presentation/pages/sync_page_test.dart
+++ b/test/features/sync/presentation/pages/sync_page_test.dart
@@ -72,7 +72,7 @@ void main() {
       setupGoldenTest(tester);
 
       final syncingState = SyncState(
-        status: SyncStatus.loading,
+        status: SyncPageStatus.loading,
         lastSyncTime: DateTime(2025, 1, 1, 10, 0),
       );
       when(() => mockCubit.state).thenReturn(syncingState);

--- a/test/features/sync/presentation/sync_page_golden_test.dart
+++ b/test/features/sync/presentation/sync_page_golden_test.dart
@@ -72,7 +72,7 @@ void main() {
       setupGoldenTest(tester);
 
       final syncingState = SyncState(
-        status: SyncStatus.loading,
+        status: SyncPageStatus.loading,
         lastSyncTime: DateTime(2025, 1, 1, 10, 0),
       );
       when(() => mockCubit.state).thenReturn(syncingState);


### PR DESCRIPTION
Renamed SyncStatus to SyncPageStatus in lib/features/sync to avoid naming conflicts with external dependencies (like isar_agent_memory) and other packages (health_wallet). Updated application logic, UI components, and corresponding tests.

Fixes #1484

---
*PR created automatically by Jules for task [10478081555423177006](https://jules.google.com/task/10478081555423177006) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved sync status handling across the sync workflow.
  * The sync screen now consistently displays loading, success, and failure states.
  * The synchronization button is disabled while a sync is in progress.
  * Successful syncs continue to show the latest synchronization time, while failures display an error message.

* **Tests**
  * Updated sync workflow and screen tests to verify the revised status behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->