### PR TITLE
Fix Health() constructor crash on devices without Health Connect

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -36,19 +36,19 @@ import '../../features/about/infrastructure/datasources/about_remote_datasource.
     as _i142;
 import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
     as _i55;
-import '../../features/allergies/application/allergies_cubit.dart' as _i262;
-import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i263;
+import '../../features/allergies/application/allergies_cubit.dart' as _i263;
+import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i264;
 import '../../features/allergies/data/datasources/allergy_local_datasource.dart'
     as _i143;
 import '../../features/allergies/data/repositories/allergy_repository_impl.dart'
-    as _i226;
+    as _i227;
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
-    as _i225;
+    as _i226;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i6;
 import '../../features/allergies/domain/usecases/get_allergies_usecase.dart'
-    as _i243;
+    as _i244;
 import '../../features/allergies/domain/usecases/save_allergy_usecase.dart'
-    as _i259;
+    as _i260;
 import '../../features/appointments/application/appointments_cubit.dart'
     as _i10;
 import '../../features/appointments/application/bloc/appointment_bloc.dart'
@@ -63,76 +63,76 @@ import '../../features/appointments/domain/usecases/get_all_appointments_usecase
     as _i44;
 import '../../features/appointments/domain/usecases/save_appointment_usecase.dart'
     as _i110;
-import '../../features/auth/application/auth_cubit.dart' as _i264;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i227;
+import '../../features/auth/application/auth_cubit.dart' as _i265;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i228;
 import '../../features/auth/data/datasources/auth_local_datasource.dart'
     as _i144;
 import '../../features/auth/data/repositories/auth_repository_impl.dart'
     as _i146;
-import '../../features/auth/domain/auth_service.dart' as _i228;
+import '../../features/auth/domain/auth_service.dart' as _i229;
 import '../../features/auth/domain/repositories/auth_repository.dart' as _i145;
 import '../../features/auth/domain/usecases/check_session_timeout.dart'
     as _i150;
 import '../../features/auth/domain/usecases/get_credentials_usecase.dart'
     as _i171;
-import '../../features/auth/domain/usecases/login_usecase.dart' as _i193;
-import '../../features/auth/domain/usecases/logout_usecase.dart' as _i194;
+import '../../features/auth/domain/usecases/login_usecase.dart' as _i194;
+import '../../features/auth/domain/usecases/logout_usecase.dart' as _i195;
 import '../../features/auth/domain/usecases/save_credentials_usecase.dart'
-    as _i206;
-import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i213;
+    as _i207;
+import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i214;
 import '../../features/auth/domain/usecases/validate_session_usecase.dart'
-    as _i221;
+    as _i222;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i16;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
     as _i163;
 import '../../features/calendar_import/application/calendar_import_cubit.dart'
-    as _i231;
+    as _i232;
 import '../../features/calendar_import/domain/repositories/calendar_import_repository.dart'
     as _i21;
 import '../../features/calendar_import/domain/services/calendar_parser_service.dart'
     as _i23;
 import '../../features/calendar_import/domain/usecases/import_calendar_usecase.dart'
-    as _i186;
+    as _i187;
 import '../../features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart'
     as _i19;
 import '../../features/calendar_import/infrastructure/repositories/calendar_import_repository_impl.dart'
     as _i22;
 import '../../features/calendar_import/infrastructure/services/calendar_parser_service_impl.dart'
     as _i24;
-import '../../features/dashboard/application/dashboard_cubit.dart' as _i265;
+import '../../features/dashboard/application/dashboard_cubit.dart' as _i266;
 import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
-    as _i233;
+    as _i234;
 import '../../features/dashboard/domain/usecases/get_dashboard_stats_usecase.dart'
-    as _i244;
+    as _i245;
 import '../../features/dashboard/domain/usecases/get_recent_activity_usecase.dart'
-    as _i246;
+    as _i247;
 import '../../features/dashboard/infrastructure/datasources/dashboard_local_datasource.dart'
     as _i154;
 import '../../features/dashboard/infrastructure/datasources/dashboard_remote_datasource.dart'
     as _i27;
 import '../../features/dashboard/infrastructure/repositories/dashboard_repository_impl.dart'
-    as _i234;
-import '../../features/data_sources/application/data_source_cubit.dart'
-    as _i266;
-import '../../features/data_sources/domain/repositories/data_source_repository.dart'
     as _i235;
+import '../../features/data_sources/application/data_source_cubit.dart'
+    as _i267;
+import '../../features/data_sources/domain/repositories/data_source_repository.dart'
+    as _i236;
 import '../../features/data_sources/infrastructure/datasources/file_import_datasource.dart'
     as _i164;
 import '../../features/data_sources/infrastructure/datasources/health_connect_datasource.dart'
-    as _i46;
+    as _i182;
 import '../../features/data_sources/infrastructure/datasources/sensor_api_datasource.dart'
     as _i116;
 import '../../features/data_sources/infrastructure/repositories/data_source_repository_impl.dart'
-    as _i236;
+    as _i237;
 import '../../features/doctor_verification/application/badge_cubit.dart'
-    as _i230;
+    as _i231;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
     as _i160;
 import '../../features/doctor_verification/application/second_opinion_cubit.dart'
-    as _i211;
+    as _i212;
 import '../../features/doctor_verification/application/vouch_cubit.dart'
-    as _i224;
+    as _i225;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
     as _i158;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
@@ -142,7 +142,7 @@ import '../../features/doctor_verification/domain/repositories/second_opinion_re
 import '../../features/doctor_verification/domain/repositories/vouch_repository.dart'
     as _i138;
 import '../../features/doctor_verification/domain/services/badge_calculator.dart'
-    as _i229;
+    as _i230;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
     as _i63;
 import '../../features/doctor_verification/domain/usecases/get_all_doctors_usecase.dart'
@@ -169,9 +169,9 @@ import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
 import '../../features/email-citas/infrastructure/repositories/email_repository_impl.dart'
     as _i33;
 import '../../features/eps_connection/application/bloc/eps_connection_bloc.dart'
-    as _i238;
-import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
     as _i239;
+import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
+    as _i240;
 import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
     as _i98;
 import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
@@ -185,51 +185,51 @@ import '../../features/eps_connection/infrastructure/datasources/oauth_local_dat
 import '../../features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart'
     as _i99;
 import '../../features/health_data_import/application/bloc/health_import_bloc.dart'
-    as _i247;
-import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i248;
+import '../../features/health_data_import/application/health_import_cubit.dart'
+    as _i249;
 import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i182;
+    as _i183;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
-    as _i47;
+    as _i46;
 import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
     as _i109;
 import '../../features/health_data_import/infrastructure/data_source.dart'
     as _i117;
 import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i183;
-import '../../features/health_record/application/bloc/health_record_cubit.dart'
-    as _i249;
-import '../../features/health_record/domain/repositories/health_record_repository.dart'
     as _i184;
-import '../../features/health_record/domain/usecases/get_all_records_usecase.dart'
-    as _i242;
-import '../../features/health_record/domain/usecases/save_record_usecase.dart'
-    as _i208;
-import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+import '../../features/health_record/application/bloc/health_record_cubit.dart'
+    as _i250;
+import '../../features/health_record/domain/repositories/health_record_repository.dart'
     as _i185;
+import '../../features/health_record/domain/usecases/get_all_records_usecase.dart'
+    as _i243;
+import '../../features/health_record/domain/usecases/save_record_usecase.dart'
+    as _i209;
+import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
+    as _i186;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i37;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
     as _i56;
 import '../../features/health_record/infrastructure/services/ocr_service.dart'
     as _i100;
-import '../../features/health_sharing/application/sharing_cubit.dart' as _i261;
+import '../../features/health_sharing/application/sharing_cubit.dart' as _i262;
 import '../../features/health_sharing/domain/repositories/sharing_repository.dart'
     as _i121;
 import '../../features/health_sharing/domain/usecases/cancel_sharing_usecase.dart'
     as _i148;
 import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
-    as _i215;
-import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
     as _i216;
+import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
+    as _i217;
 import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
     as _i147;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i17;
 import '../../features/health_sharing/infrastructure/datasources/health_sharing_local_datasource.dart'
-    as _i48;
+    as _i47;
 import '../../features/health_sharing/infrastructure/datasources/health_sharing_remote_datasource.dart'
-    as _i49;
+    as _i48;
 import '../../features/health_sharing/infrastructure/nfc_handler.dart' as _i92;
 import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
     as _i94;
@@ -237,20 +237,20 @@ import '../../features/health_sharing/infrastructure/repositories/health_sharing
     as _i122;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
     as _i140;
-import '../../features/home/application/home_cubit.dart' as _i269;
-import '../../features/home/domain/repositories/home_repository.dart' as _i250;
+import '../../features/home/application/home_cubit.dart' as _i270;
+import '../../features/home/domain/repositories/home_repository.dart' as _i251;
 import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
-    as _i267;
+    as _i268;
 import '../../features/home/infrastructure/datasources/health_summary_datasource.dart'
-    as _i50;
+    as _i49;
 import '../../features/home/infrastructure/datasources/home_local_datasource.dart'
     as _i51;
 import '../../features/home/infrastructure/datasources/home_remote_datasource.dart'
     as _i53;
 import '../../features/home/infrastructure/repositories/home_repository_impl.dart'
-    as _i251;
+    as _i252;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i214;
+    as _i215;
 import '../../features/local_agent/data/datasources/chat_message_local_datasource.dart'
     as _i149;
 import '../../features/local_agent/data/datasources/local_model_local_datasource.dart'
@@ -265,22 +265,22 @@ import '../../features/local_agent/domain/usecases/get_chat_history_usecase.dart
 import '../../features/local_agent/domain/usecases/send_chat_message_usecase.dart'
     as _i115;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i66;
+    as _i65;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i40;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i187;
+    as _i188;
 import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i42;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i188;
+    as _i189;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i65;
+    as _i66;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i191;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i190;
+    as _i192;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i191;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
-    as _i252;
+    as _i253;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
     as _i71;
 import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
@@ -288,19 +288,19 @@ import '../../features/local_agent/infrastructure/repositories/json_medical_know
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
     as _i132;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i189;
+    as _i190;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i67;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i270;
+    as _i271;
 import '../../features/local_agent/infrastructure/services/model_download_service.dart'
     as _i85;
 import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i257;
+    as _i258;
 import '../../features/medical_research/application/medical_research_cubit.dart'
-    as _i271;
+    as _i272;
 import '../../features/medical_research/domain/repositories/medical_research_repository.dart'
-    as _i253;
+    as _i254;
 import '../../features/medical_research/domain/services/medical_scraper_service.dart'
     as _i73;
 import '../../features/medical_research/domain/services/medical_standards_service.dart'
@@ -308,13 +308,13 @@ import '../../features/medical_research/domain/services/medical_standards_servic
 import '../../features/medical_research/domain/services/medical_web_search_service.dart'
     as _i77;
 import '../../features/medical_research/domain/usecases/get_research_history.dart'
-    as _i268;
+    as _i269;
 import '../../features/medical_research/domain/usecases/search_medical_research.dart'
-    as _i260;
+    as _i261;
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i18;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i195;
+    as _i196;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i74;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
@@ -322,29 +322,29 @@ import '../../features/medical_research/infrastructure/medical_standards_service
 import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
     as _i78;
 import '../../features/medical_research/infrastructure/repositories/medical_research_repository_impl.dart'
-    as _i254;
-import '../../features/medications/application/bloc/medication_bloc.dart'
     as _i255;
-import '../../features/medications/application/medications_cubit.dart' as _i198;
+import '../../features/medications/application/bloc/medication_bloc.dart'
+    as _i256;
+import '../../features/medications/application/medications_cubit.dart' as _i199;
 import '../../features/medications/domain/repositories/medication_adherence_repository.dart'
     as _i79;
 import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i196;
+    as _i197;
 import '../../features/medications/domain/usecases/get_all_medications_usecase.dart'
-    as _i241;
+    as _i242;
 import '../../features/medications/domain/usecases/save_medication_usecase.dart'
-    as _i207;
+    as _i208;
 import '../../features/medications/infrastructure/datasources/adherence_sqlite_datasource.dart'
     as _i5;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i197;
+    as _i198;
 import '../../features/medications/infrastructure/repositories/sqlite_medication_adherence_repository.dart'
     as _i80;
 import '../../features/medications/infrastructure/services/pharmacy_api_service.dart'
     as _i101;
 import '../../features/medications/infrastructure/services/rxnorm_api_service.dart'
     as _i102;
-import '../../features/meditation/application/meditation_cubit.dart' as _i199;
+import '../../features/meditation/application/meditation_cubit.dart' as _i200;
 import '../../features/meditation/domain/repositories/meditation_repository.dart'
     as _i82;
 import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
@@ -361,7 +361,7 @@ import '../../features/meditation/infrastructure/datasources/meditation_local_da
     as _i81;
 import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
     as _i83;
-import '../../features/network/application/network_cubit.dart' as _i200;
+import '../../features/network/application/network_cubit.dart' as _i201;
 import '../../features/network/domain/repositories/network_peer_repository.dart'
     as _i88;
 import '../../features/network/governance/domain/repositories/governance_repository.dart'
@@ -381,7 +381,7 @@ import '../../features/network/infrastructure/datasources/network_p2p_api.dart'
 import '../../features/network/infrastructure/repositories/network_peer_repository_impl.dart'
     as _i89;
 import '../../features/network/network_health/application/network_health_cubit.dart'
-    as _i201;
+    as _i202;
 import '../../features/network/network_health/domain/repositories/network_repository.dart'
     as _i90;
 import '../../features/network/network_health/domain/usecases/connect_node.dart'
@@ -394,21 +394,21 @@ import '../../features/network/network_health/infrastructure/datasources/network
     as _i86;
 import '../../features/network/network_health/infrastructure/repositories/network_repository_impl.dart'
     as _i91;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i256;
-import '../../features/onboarding/application/sync_cubit.dart' as _i217;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i257;
+import '../../features/onboarding/application/sync_cubit.dart' as _i218;
 import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i202;
-import '../../features/onboarding/domain/usecases/complete_onboarding_usecase.dart'
-    as _i232;
-import '../../features/onboarding/domain/usecases/get_onboarding_profile_usecase.dart'
-    as _i245;
-import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
     as _i203;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i258;
+import '../../features/onboarding/domain/usecases/complete_onboarding_usecase.dart'
+    as _i233;
+import '../../features/onboarding/domain/usecases/get_onboarding_profile_usecase.dart'
+    as _i246;
+import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
+    as _i204;
+import '../../features/reports/application/bloc/report_bloc.dart' as _i259;
 import '../../features/reports/domain/repositories/report_repository.dart'
     as _i107;
 import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i204;
+    as _i205;
 import '../../features/reports/domain/usecases/get_reports_usecase.dart'
     as _i176;
 import '../../features/reports/domain/usecases/save_report_usecase.dart'
@@ -416,10 +416,10 @@ import '../../features/reports/domain/usecases/save_report_usecase.dart'
 import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i108;
 import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i205;
+    as _i206;
 import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i84;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i192;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i193;
 import '../../features/settings/domain/repositories/settings_repository.dart'
     as _i119;
 import '../../features/settings/domain/services/device_capability_service.dart'
@@ -428,15 +428,15 @@ import '../../features/settings/infrastructure/datasources/settings_local_dataso
     as _i118;
 import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
     as _i120;
-import '../../features/sync/application/sync_cubit.dart' as _i240;
+import '../../features/sync/application/sync_cubit.dart' as _i241;
 import '../../features/sync/domain/repositories/sync_repository.dart' as _i125;
 import '../../features/sync/domain/services/distributed_storage_service.dart'
     as _i156;
 import '../../features/sync/domain/services/node_discovery_service.dart'
     as _i95;
-import '../../features/sync/domain/services/sync_service.dart' as _i218;
+import '../../features/sync/domain/services/sync_service.dart' as _i219;
 import '../../features/sync/domain/usecases/distributed_cache_usecase.dart'
-    as _i237;
+    as _i238;
 import '../../features/sync/infrastructure/datasources/filecoin_datasource.dart'
     as _i38;
 import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
@@ -448,9 +448,9 @@ import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i157;
 import '../../features/sync/infrastructure/services/node_discovery_service.dart'
     as _i96;
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
-    as _i219;
-import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
     as _i220;
+import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
+    as _i221;
 import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
     as _i127;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
@@ -460,26 +460,26 @@ import '../../features/user_profile/domain/services/user_profile_service.dart'
 import '../../features/user_profile/domain/usecases/get_user_profile_usecase.dart'
     as _i178;
 import '../../features/user_profile/domain/usecases/save_user_profile_usecase.dart'
-    as _i209;
+    as _i210;
 import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
     as _i129;
-import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i222;
+import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i223;
 import '../../features/vitals/application/vitals_cubit.dart' as _i135;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
     as _i133;
 import '../../features/vitals/domain/usecases/get_all_vital_signs_usecase.dart'
     as _i167;
 import '../../features/vitals/domain/usecases/save_vital_signs_usecase.dart'
-    as _i210;
+    as _i211;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
     as _i134;
-import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i223;
+import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i224;
 import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
     as _i136;
 import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
     as _i168;
 import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
-    as _i212;
+    as _i213;
 import '../../features/voice_chat/infrastructure/datasources/chat_ai_datasource.dart'
     as _i25;
 import '../../features/voice_chat/infrastructure/repositories/voice_chat_repository_impl.dart'
@@ -492,11 +492,12 @@ import '../services/audio/audio_recorder_service.dart' as _i14;
 import '../services/device_capability_service.dart' as _i30;
 import '../services/privacy_anonymizer.dart' as _i103;
 import '../services/secure_storage_service.dart' as _i114;
-import 'database_module.dart' as _i275;
-import 'fhir_module.dart' as _i276;
-import 'memory_module.dart' as _i274;
-import 'network_module.dart' as _i273;
-import 'service_module.dart' as _i272;
+import '../utils/health_wrapper.dart' as _i50;
+import 'database_module.dart' as _i276;
+import 'fhir_module.dart' as _i277;
+import 'memory_module.dart' as _i275;
+import 'network_module.dart' as _i274;
+import 'service_module.dart' as _i273;
 
 const String _desktop = 'desktop';
 const String _test = 'test';
@@ -575,25 +576,21 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i39.FlutterAppAuth>(() => serviceModule.appAuth);
     gh.lazySingleton<_i40.FlutterGemmaWrapper>(
         () => _i40.FlutterGemmaWrapper());
-    await gh.lazySingletonAsync<_i41.FlutterSecureStorage>(
-      () => serviceModule.storage(gh<_i30.DeviceCapabilityService>()),
-      preResolve: true,
-    );
+    gh.lazySingleton<_i41.FlutterSecureStorage>(() => serviceModule.storage);
     gh.lazySingleton<_i42.GeminiModelWrapper>(
         () => _i42.GeminiModelWrapper(gh<_i43.GenerativeModel>()));
     gh.factory<_i44.GetAllAppointmentsUseCase>(
         () => _i44.GetAllAppointmentsUseCase(gh<_i8.AppointmentRepository>()));
     gh.lazySingleton<_i45.Health>(() => serviceModule.health);
-    gh.lazySingleton<_i46.HealthConnectDataSource>(
-        () => _i46.HealthConnectDataSourceImpl(gh<_i45.Health>()));
-    gh.lazySingleton<_i47.HealthDataImportService>(
-        () => _i47.HealthDataImportService());
-    gh.lazySingleton<_i48.HealthSharingLocalDataSource>(
-        () => _i48.HealthSharingLocalDataSource());
-    gh.lazySingleton<_i49.HealthSharingRemoteDataSource>(
-        () => _i49.HealthSharingRemoteDataSource(gh<_i31.Dio>()));
-    gh.factory<_i50.HealthSummaryDatasource>(
-        () => _i50.HealthSummaryDatasource());
+    gh.lazySingleton<_i46.HealthDataImportService>(
+        () => _i46.HealthDataImportService());
+    gh.lazySingleton<_i47.HealthSharingLocalDataSource>(
+        () => _i47.HealthSharingLocalDataSource());
+    gh.lazySingleton<_i48.HealthSharingRemoteDataSource>(
+        () => _i48.HealthSharingRemoteDataSource(gh<_i31.Dio>()));
+    gh.factory<_i49.HealthSummaryDatasource>(
+        () => _i49.HealthSummaryDatasource());
+    gh.lazySingleton<_i50.HealthWrapper>(() => serviceModule.healthWrapper);
     gh.factory<_i51.HomeLocalDataSource>(
         () => _i51.HomeLocalDataSource(gh<_i52.SharedPreferences>()));
     gh.factory<_i53.HomeRemoteDataSource>(
@@ -620,12 +617,12 @@ extension GetItInjectableX on _i1.GetIt {
         _i63.LicenseVerifier(
             await getAsync<_i62.LicenseRegistryLocalDataSource>()));
     gh.lazySingleton<_i64.LlmAdapter>(
-      () => _i65.OpenaiCompatibleAdapter(),
-      instanceName: 'openai',
+      () => _i65.FlutterGemmaAdapter(wrapper: gh<_i40.FlutterGemmaWrapper>()),
+      instanceName: 'gemma',
     );
     gh.lazySingleton<_i64.LlmAdapter>(
-      () => _i66.FlutterGemmaAdapter(wrapper: gh<_i40.FlutterGemmaWrapper>()),
-      instanceName: 'gemma',
+      () => _i66.OpenaiCompatibleAdapter(),
+      instanceName: 'openai',
     );
     gh.lazySingleton<_i67.LocalLlmService>(() => _i67.LocalLlmService());
     gh.lazySingleton<_i68.LocalModelLocalDataSource>(
@@ -704,24 +701,22 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i107.ReportRepository>(
         () => _i108.IsarReportRepository(gh<_i61.Isar>()));
     gh.factory<_i109.RequestHealthAuthUseCase>(() =>
-        _i109.RequestHealthAuthUseCase(gh<_i47.HealthDataImportService>()));
+        _i109.RequestHealthAuthUseCase(gh<_i46.HealthDataImportService>()));
     gh.factory<_i110.SaveAppointmentUseCase>(
         () => _i110.SaveAppointmentUseCase(gh<_i8.AppointmentRepository>()));
     gh.factory<_i111.SaveReportUseCase>(
         () => _i111.SaveReportUseCase(gh<_i107.ReportRepository>()));
     gh.lazySingleton<_i112.SecondOpinionRepository>(
         () => _i113.IsarSecondOpinionRepository(gh<_i61.Isar>()));
-    gh.lazySingleton<_i114.SecureStorageService>(
-        () => _i114.SecureStorageServiceImpl(
-              storage: gh<_i41.FlutterSecureStorage>(),
-              capabilityService: gh<_i30.DeviceCapabilityService>(),
-            ));
+    gh.lazySingleton<_i114.SecureStorageService>(() =>
+        _i114.SecureStorageServiceImpl(
+            storage: gh<_i41.FlutterSecureStorage>()));
     gh.factory<_i115.SendChatMessageUseCase>(() => _i115.SendChatMessageUseCase(
           gh<_i64.LlmAdapter>(),
           gh<_i70.MedicalKnowledgeRepository>(),
         ));
     gh.lazySingleton<_i116.SensorApiDataSource>(
-        () => _i116.SensorApiDataSourceImpl(gh<_i45.Health>()));
+        () => _i116.SensorApiDataSourceImpl(gh<_i50.HealthWrapper>()));
     gh.lazySingleton<_i117.SensorHealthDataSource>(
         () => _i117.SensorHealthDataSourceImpl());
     gh.lazySingleton<_i118.SettingsLocalDataSource>(
@@ -730,7 +725,7 @@ extension GetItInjectableX on _i1.GetIt {
         _i120.SettingsRepositoryImpl(gh<_i118.SettingsLocalDataSource>()));
     gh.lazySingleton<_i121.SharingRepository>(() =>
         _i122.HealthSharingRepositoryImpl(
-            gh<_i48.HealthSharingLocalDataSource>()));
+            gh<_i47.HealthSharingLocalDataSource>()));
     gh.lazySingleton<_i123.StartSessionUseCase>(
         () => _i123.StartSessionUseCase(gh<_i82.MeditationRepository>()));
     gh.factory<_i124.SyncEmailAppointmentsUseCase>(
@@ -848,7 +843,7 @@ extension GetItInjectableX on _i1.GetIt {
     gh.factory<_i167.GetAllVitalSignsUseCase>(
         () => _i167.GetAllVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
     gh.factory<_i109.GetAvailableSourcesUseCase>(() =>
-        _i109.GetAvailableSourcesUseCase(gh<_i47.HealthDataImportService>()));
+        _i109.GetAvailableSourcesUseCase(gh<_i46.HealthDataImportService>()));
     gh.factory<_i168.GetChatHistoryUseCase>(
         () => _i168.GetChatHistoryUseCase(gh<_i136.VoiceChatRepository>()));
     gh.factory<_i169.GetChatHistoryUseCase>(
@@ -875,25 +870,27 @@ extension GetItInjectableX on _i1.GetIt {
         () => _i179.GovernanceIpfsDatasource(gh<_i60.IpfsDatasource>()));
     gh.lazySingleton<_i180.GovernanceRepository>(() =>
         _i181.GovernanceRepositoryImpl(gh<_i179.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i182.HealthDataImportRepository>(
-        () => _i183.HealthDataImportRepositoryImpl(
+    gh.lazySingleton<_i182.HealthConnectDataSource>(
+        () => _i182.HealthConnectDataSourceImpl(gh<_i50.HealthWrapper>()));
+    gh.lazySingleton<_i183.HealthDataImportRepository>(
+        () => _i184.HealthDataImportRepositoryImpl(
               gh<_i117.SensorHealthDataSource>(),
               gh<_i117.FileHealthDataSource>(),
             ));
-    gh.lazySingleton<_i184.HealthRecordRepository>(
-        () => _i185.HealthRecordRepositoryImpl(gh<_i61.Isar>()));
-    gh.factory<_i186.ImportCalendarUseCase>(() => _i186.ImportCalendarUseCase(
+    gh.lazySingleton<_i185.HealthRecordRepository>(
+        () => _i186.HealthRecordRepositoryImpl(gh<_i61.Isar>()));
+    gh.factory<_i187.ImportCalendarUseCase>(() => _i187.ImportCalendarUseCase(
           gh<_i21.CalendarImportRepository>(),
           gh<_i8.AppointmentRepository>(),
           gh<_i128.UserProfileRepository>(),
         ));
     gh.factory<_i109.ImportHealthDataUseCase>(
         () => _i109.ImportHealthDataUseCase(
-              gh<_i47.HealthDataImportService>(),
+              gh<_i46.HealthDataImportService>(),
               gh<_i133.VitalSignRepository>(),
             ));
     gh.lazySingleton<_i64.LlmAdapter>(
-      () => _i187.GeminiLlmAdapter(
+      () => _i188.GeminiLlmAdapter(
         scrubber: gh<_i103.PromptScrubber>(),
         userProfileRepository: gh<_i128.UserProfileRepository>(),
         modelWrapper: gh<_i42.GeminiModelWrapper>(),
@@ -901,300 +898,300 @@ extension GetItInjectableX on _i1.GetIt {
       instanceName: 'gemini',
     );
     gh.factory<_i64.LlmAdapter>(
-      () => _i188.MockLlmAdapter(gh<_i103.PromptScrubber>()),
+      () => _i189.MockLlmAdapter(gh<_i103.PromptScrubber>()),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i189.LlmAdapterFactory>(
-        () => _i189.LlmAdapterFactory(gh<_i119.SettingsRepository>()));
-    gh.lazySingleton<_i190.LlmService>(() => _i191.GemmaLlmService(
+    gh.lazySingleton<_i190.LlmAdapterFactory>(
+        () => _i190.LlmAdapterFactory(gh<_i119.SettingsRepository>()));
+    gh.lazySingleton<_i191.LlmService>(() => _i192.GemmaLlmService(
           gh<_i131.VectorStoreService>(),
           gh<_i128.UserProfileRepository>(),
           gh<_i64.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i192.LlmSettingsCubit>(() => _i192.LlmSettingsCubit(
+    gh.factory<_i193.LlmSettingsCubit>(() => _i193.LlmSettingsCubit(
           gh<_i119.SettingsRepository>(),
           gh<_i29.DeviceCapabilityService>(),
           gh<_i64.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i193.LoginUseCase>(() => _i193.LoginUseCase(
+    gh.factory<_i194.LoginUseCase>(() => _i194.LoginUseCase(
           gh<_i145.AuthRepository>(),
           gh<_i163.EncryptionService>(),
           gh<_i16.BiometricService>(),
         ));
-    gh.factory<_i194.LogoutUseCase>(
-        () => _i194.LogoutUseCase(gh<_i145.AuthRepository>()));
-    gh.lazySingleton<_i195.MedicalResearchService>(
-        () => _i195.MedicalResearchService(
+    gh.factory<_i195.LogoutUseCase>(
+        () => _i195.LogoutUseCase(gh<_i145.AuthRepository>()));
+    gh.lazySingleton<_i196.MedicalResearchService>(
+        () => _i196.MedicalResearchService(
               gh<_i77.MedicalWebSearchService>(),
               gh<_i73.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i196.MedicationRepository>(
-        () => _i197.IsarMedicationRepository(
+    gh.lazySingleton<_i197.MedicationRepository>(
+        () => _i198.IsarMedicationRepository(
               gh<_i61.Isar>(),
               gh<_i101.PharmacyApiService>(),
             ));
-    gh.factory<_i198.MedicationsCubit>(
-        () => _i198.MedicationsCubit(gh<_i196.MedicationRepository>()));
-    gh.factory<_i199.MeditationCubit>(() => _i199.MeditationCubit(
+    gh.factory<_i199.MedicationsCubit>(
+        () => _i199.MedicationsCubit(gh<_i197.MedicationRepository>()));
+    gh.factory<_i200.MeditationCubit>(() => _i200.MeditationCubit(
           gh<_i106.RecommendScriptUseCase>(),
           gh<_i123.StartSessionUseCase>(),
           gh<_i151.CompleteSessionUseCase>(),
           gh<_i175.GetProgressUseCase>(),
           gh<_i12.AudioService>(),
         ));
-    gh.factory<_i200.NetworkCubit>(() => _i200.NetworkCubit(
+    gh.factory<_i201.NetworkCubit>(() => _i201.NetworkCubit(
           gh<_i88.NetworkPeerRepository>(),
           gh<_i87.NetworkP2PApi>(),
         ));
-    gh.factory<_i201.NetworkHealthCubit>(() => _i201.NetworkHealthCubit(
+    gh.factory<_i202.NetworkHealthCubit>(() => _i202.NetworkHealthCubit(
           gh<_i173.GetNetworkHealth>(),
           gh<_i152.ConnectNode>(),
           gh<_i90.NetworkRepository>(),
         ));
-    gh.lazySingleton<_i202.OnboardingRepository>(() =>
-        _i203.OnboardingRepositoryImpl(gh<_i128.UserProfileRepository>()));
-    gh.lazySingleton<_i204.ReportGenerationService>(
-        () => _i205.GemmaReportGenerationService(
+    gh.lazySingleton<_i203.OnboardingRepository>(() =>
+        _i204.OnboardingRepositoryImpl(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i205.ReportGenerationService>(
+        () => _i206.GemmaReportGenerationService(
               gh<_i64.LlmAdapter>(instanceName: 'gemma'),
               gh<_i131.VectorStoreService>(),
               gh<_i128.UserProfileRepository>(),
               gh<_i103.PromptScrubber>(),
             ));
-    gh.factory<_i206.SaveCredentialsUseCase>(
-        () => _i206.SaveCredentialsUseCase(gh<_i145.AuthRepository>()));
-    gh.factory<_i207.SaveMedicationUseCase>(
-        () => _i207.SaveMedicationUseCase(gh<_i196.MedicationRepository>()));
-    gh.factory<_i208.SaveRecordUseCase>(
-        () => _i208.SaveRecordUseCase(gh<_i184.HealthRecordRepository>()));
-    gh.factory<_i209.SaveUserProfileUseCase>(
-        () => _i209.SaveUserProfileUseCase(gh<_i128.UserProfileRepository>()));
-    gh.factory<_i210.SaveVitalSignsUseCase>(
-        () => _i210.SaveVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
-    gh.factory<_i211.SecondOpinionCubit>(
-        () => _i211.SecondOpinionCubit(gh<_i112.SecondOpinionRepository>()));
-    gh.factory<_i212.SendMessageUseCase>(
-        () => _i212.SendMessageUseCase(gh<_i136.VoiceChatRepository>()));
-    gh.factory<_i213.SetPinUseCase>(() => _i213.SetPinUseCase(
+    gh.factory<_i207.SaveCredentialsUseCase>(
+        () => _i207.SaveCredentialsUseCase(gh<_i145.AuthRepository>()));
+    gh.factory<_i208.SaveMedicationUseCase>(
+        () => _i208.SaveMedicationUseCase(gh<_i197.MedicationRepository>()));
+    gh.factory<_i209.SaveRecordUseCase>(
+        () => _i209.SaveRecordUseCase(gh<_i185.HealthRecordRepository>()));
+    gh.factory<_i210.SaveUserProfileUseCase>(
+        () => _i210.SaveUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.factory<_i211.SaveVitalSignsUseCase>(
+        () => _i211.SaveVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i212.SecondOpinionCubit>(
+        () => _i212.SecondOpinionCubit(gh<_i112.SecondOpinionRepository>()));
+    gh.factory<_i213.SendMessageUseCase>(
+        () => _i213.SendMessageUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i214.SetPinUseCase>(() => _i214.SetPinUseCase(
           gh<_i145.AuthRepository>(),
           gh<_i163.EncryptionService>(),
         ));
-    gh.lazySingleton<_i214.SmartSearchUseCase>(
-        () => _i214.SmartSearchUseCase(gh<_i131.VectorStoreService>()));
-    gh.lazySingleton<_i215.StartListeningUseCase>(
-        () => _i215.StartListeningUseCase(
+    gh.lazySingleton<_i215.SmartSearchUseCase>(
+        () => _i215.SmartSearchUseCase(gh<_i131.VectorStoreService>()));
+    gh.lazySingleton<_i216.StartListeningUseCase>(
+        () => _i216.StartListeningUseCase(
               gh<_i147.BleSharingService>(),
               gh<_i94.NfcSharingService>(),
               gh<_i140.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i216.StartSharingUseCase>(() => _i216.StartSharingUseCase(
+    gh.lazySingleton<_i217.StartSharingUseCase>(() => _i217.StartSharingUseCase(
           gh<_i147.BleSharingService>(),
           gh<_i94.NfcSharingService>(),
           gh<_i140.WifiDirectService>(),
         ));
-    gh.factory<_i217.SyncCubit>(() => _i217.SyncCubit(
+    gh.factory<_i218.SyncCubit>(() => _i218.SyncCubit(
           gh<_i69.SyncService>(),
           gh<_i131.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i218.SyncService>(() => _i219.SyncServiceImpl(
+    gh.lazySingleton<_i219.SyncService>(() => _i220.SyncServiceImpl(
           gh<_i125.SyncRepository>(),
           gh<_i69.SyncService>(),
         ));
-    gh.factory<_i220.UserProfileCubit>(
-        () => _i220.UserProfileCubit(gh<_i128.UserProfileRepository>()));
-    gh.factory<_i221.ValidateSessionUseCase>(
-        () => _i221.ValidateSessionUseCase(gh<_i145.AuthRepository>()));
-    gh.factory<_i222.VitalSignBloc>(
-        () => _i222.VitalSignBloc(gh<_i133.VitalSignRepository>()));
-    gh.factory<_i223.VoiceChatCubit>(() => _i223.VoiceChatCubit(
-          gh<_i212.SendMessageUseCase>(),
+    gh.factory<_i221.UserProfileCubit>(
+        () => _i221.UserProfileCubit(gh<_i128.UserProfileRepository>()));
+    gh.factory<_i222.ValidateSessionUseCase>(
+        () => _i222.ValidateSessionUseCase(gh<_i145.AuthRepository>()));
+    gh.factory<_i223.VitalSignBloc>(
+        () => _i223.VitalSignBloc(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i224.VoiceChatCubit>(() => _i224.VoiceChatCubit(
+          gh<_i213.SendMessageUseCase>(),
           gh<_i168.GetChatHistoryUseCase>(),
           gh<_i136.VoiceChatRepository>(),
           gh<_i12.AudioService>(),
         ));
-    gh.factory<_i224.VouchCubit>(
-        () => _i224.VouchCubit(gh<_i138.VouchRepository>()));
-    gh.lazySingleton<_i225.AllergyRepository>(() => _i226.AllergyRepositoryImpl(
+    gh.factory<_i225.VouchCubit>(
+        () => _i225.VouchCubit(gh<_i138.VouchRepository>()));
+    gh.lazySingleton<_i226.AllergyRepository>(() => _i227.AllergyRepositoryImpl(
           gh<_i143.AllergyLocalDataSource>(),
           encryptionService: gh<_i163.EncryptionService>(),
         ));
-    gh.factory<_i227.AuthCubit>(() => _i227.AuthCubit(
+    gh.factory<_i228.AuthCubit>(() => _i228.AuthCubit(
           gh<_i145.AuthRepository>(),
           gh<_i16.BiometricService>(),
-          gh<_i193.LoginUseCase>(),
-          gh<_i194.LogoutUseCase>(),
-          gh<_i221.ValidateSessionUseCase>(),
-          gh<_i213.SetPinUseCase>(),
+          gh<_i194.LoginUseCase>(),
+          gh<_i195.LogoutUseCase>(),
+          gh<_i222.ValidateSessionUseCase>(),
+          gh<_i214.SetPinUseCase>(),
           gh<_i150.CheckSessionTimeoutUseCase>(),
         ));
-    gh.lazySingleton<_i228.AuthService>(
-        () => _i228.AuthServiceImpl(gh<_i163.EncryptionService>()));
-    gh.lazySingleton<_i229.BadgeCalculator>(() => _i229.BadgeCalculator(
+    gh.lazySingleton<_i229.AuthService>(
+        () => _i229.AuthServiceImpl(gh<_i163.EncryptionService>()));
+    gh.lazySingleton<_i230.BadgeCalculator>(() => _i230.BadgeCalculator(
           gh<_i158.DoctorProfileRepository>(),
           gh<_i104.RatingRepository>(),
           gh<_i138.VouchRepository>(),
         ));
-    gh.factory<_i230.BadgeCubit>(
-        () => _i230.BadgeCubit(gh<_i229.BadgeCalculator>()));
-    gh.factory<_i231.CalendarImportCubit>(() => _i231.CalendarImportCubit(
+    gh.factory<_i231.BadgeCubit>(
+        () => _i231.BadgeCubit(gh<_i230.BadgeCalculator>()));
+    gh.factory<_i232.CalendarImportCubit>(() => _i232.CalendarImportCubit(
           gh<_i21.CalendarImportRepository>(),
-          gh<_i186.ImportCalendarUseCase>(),
+          gh<_i187.ImportCalendarUseCase>(),
         ));
-    gh.factory<_i232.CompleteOnboardingUseCase>(() =>
-        _i232.CompleteOnboardingUseCase(gh<_i202.OnboardingRepository>()));
-    gh.lazySingleton<_i233.DashboardRepository>(
-        () => _i234.DashboardRepositoryImpl(
+    gh.factory<_i233.CompleteOnboardingUseCase>(() =>
+        _i233.CompleteOnboardingUseCase(gh<_i203.OnboardingRepository>()));
+    gh.lazySingleton<_i234.DashboardRepository>(
+        () => _i235.DashboardRepositoryImpl(
               gh<_i27.DashboardRemoteDataSource>(),
               gh<_i133.VitalSignRepository>(),
-              gh<_i196.MedicationRepository>(),
+              gh<_i197.MedicationRepository>(),
               gh<_i107.ReportRepository>(),
             ));
-    gh.lazySingleton<_i235.DataSourceRepository>(
-        () => _i236.DataSourceRepositoryImpl(
+    gh.lazySingleton<_i236.DataSourceRepository>(
+        () => _i237.DataSourceRepositoryImpl(
               gh<_i116.SensorApiDataSource>(),
               gh<_i164.FileImportDataSource>(),
-              gh<_i46.HealthConnectDataSource>(),
+              gh<_i182.HealthConnectDataSource>(),
             ));
-    gh.lazySingleton<_i237.DistributedCacheUsecase>(() =>
-        _i237.DistributedCacheUsecase(gh<_i156.DistributedStorageService>()));
-    gh.factory<_i238.EpsConnectionBloc>(() => _i238.EpsConnectionBloc(
+    gh.lazySingleton<_i238.DistributedCacheUsecase>(() =>
+        _i238.DistributedCacheUsecase(gh<_i156.DistributedStorageService>()));
+    gh.factory<_i239.EpsConnectionBloc>(() => _i239.EpsConnectionBloc(
           gh<_i170.GetConnectionsUseCase>(),
           gh<_i153.ConnectProviderUseCase>(),
           gh<_i155.DisconnectProviderUseCase>(),
         ));
-    gh.factory<_i239.EpsConnectionCubit>(() => _i239.EpsConnectionCubit(
+    gh.factory<_i240.EpsConnectionCubit>(() => _i240.EpsConnectionCubit(
           gh<_i170.GetConnectionsUseCase>(),
           gh<_i153.ConnectProviderUseCase>(),
           gh<_i155.DisconnectProviderUseCase>(),
         ));
-    gh.factory<_i240.FhirSyncCubit>(() => _i240.FhirSyncCubit(
-          gh<_i218.SyncService>(),
+    gh.factory<_i241.FhirSyncCubit>(() => _i241.FhirSyncCubit(
+          gh<_i219.SyncService>(),
           gh<_i95.NodeDiscoveryService>(),
         ));
-    gh.factory<_i241.GetAllMedicationsUseCase>(
-        () => _i241.GetAllMedicationsUseCase(gh<_i196.MedicationRepository>()));
-    gh.factory<_i242.GetAllRecordsUseCase>(
-        () => _i242.GetAllRecordsUseCase(gh<_i184.HealthRecordRepository>()));
-    gh.factory<_i243.GetAllergiesUseCase>(
-        () => _i243.GetAllergiesUseCase(gh<_i225.AllergyRepository>()));
-    gh.factory<_i244.GetDashboardStatsUseCase>(
-        () => _i244.GetDashboardStatsUseCase(gh<_i233.DashboardRepository>()));
-    gh.factory<_i245.GetOnboardingProfileUseCase>(() =>
-        _i245.GetOnboardingProfileUseCase(gh<_i202.OnboardingRepository>()));
-    gh.factory<_i246.GetRecentActivityUseCase>(
-        () => _i246.GetRecentActivityUseCase(gh<_i233.DashboardRepository>()));
-    gh.factory<_i247.HealthImportBloc>(() => _i247.HealthImportBloc(
+    gh.factory<_i242.GetAllMedicationsUseCase>(
+        () => _i242.GetAllMedicationsUseCase(gh<_i197.MedicationRepository>()));
+    gh.factory<_i243.GetAllRecordsUseCase>(
+        () => _i243.GetAllRecordsUseCase(gh<_i185.HealthRecordRepository>()));
+    gh.factory<_i244.GetAllergiesUseCase>(
+        () => _i244.GetAllergiesUseCase(gh<_i226.AllergyRepository>()));
+    gh.factory<_i245.GetDashboardStatsUseCase>(
+        () => _i245.GetDashboardStatsUseCase(gh<_i234.DashboardRepository>()));
+    gh.factory<_i246.GetOnboardingProfileUseCase>(() =>
+        _i246.GetOnboardingProfileUseCase(gh<_i203.OnboardingRepository>()));
+    gh.factory<_i247.GetRecentActivityUseCase>(
+        () => _i247.GetRecentActivityUseCase(gh<_i234.DashboardRepository>()));
+    gh.factory<_i248.HealthImportBloc>(() => _i248.HealthImportBloc(
           gh<_i109.GetAvailableSourcesUseCase>(),
           gh<_i109.RequestHealthAuthUseCase>(),
           gh<_i109.ImportHealthDataUseCase>(),
         ));
-    gh.factory<_i248.HealthImportCubit>(() => _i248.HealthImportCubit(
+    gh.factory<_i249.HealthImportCubit>(() => _i249.HealthImportCubit(
           gh<_i109.GetAvailableSourcesUseCase>(),
           gh<_i109.RequestHealthAuthUseCase>(),
           gh<_i109.ImportHealthDataUseCase>(),
         ));
-    gh.factory<_i249.HealthRecordCubit>(() => _i249.HealthRecordCubit(
-          gh<_i184.HealthRecordRepository>(),
+    gh.factory<_i250.HealthRecordCubit>(() => _i250.HealthRecordCubit(
+          gh<_i185.HealthRecordRepository>(),
           gh<_i37.FilePickerService>(),
           gh<_i56.ImagePickerService>(),
           gh<_i100.OcrService>(),
           gh<_i131.VectorStoreService>(),
         ));
-    gh.lazySingleton<_i250.HomeRepository>(() => _i251.HomeRepositoryImpl(
+    gh.lazySingleton<_i251.HomeRepository>(() => _i252.HomeRepositoryImpl(
           gh<_i133.VitalSignRepository>(),
           gh<_i8.AppointmentRepository>(),
-          gh<_i196.MedicationRepository>(),
+          gh<_i197.MedicationRepository>(),
           gh<_i51.HomeLocalDataSource>(),
           gh<_i53.HomeRemoteDataSource>(),
-          gh<_i50.HealthSummaryDatasource>(),
+          gh<_i49.HealthSummaryDatasource>(),
         ));
-    gh.lazySingleton<_i190.LlmService>(
-      () => _i252.RagLlmService(
+    gh.lazySingleton<_i191.LlmService>(
+      () => _i253.RagLlmService(
         gh<_i131.VectorStoreService>(),
-        gh<_i195.MedicalResearchService>(),
+        gh<_i196.MedicalResearchService>(),
         gh<_i128.UserProfileRepository>(),
         gh<_i64.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
-    gh.lazySingleton<_i253.MedicalResearchRepository>(
-        () => _i254.MedicalResearchRepositoryImpl(
-              gh<_i195.MedicalResearchService>(),
+    gh.lazySingleton<_i254.MedicalResearchRepository>(
+        () => _i255.MedicalResearchRepositoryImpl(
+              gh<_i196.MedicalResearchService>(),
               gh<_i61.Isar>(),
             ));
-    gh.factory<_i255.MedicationBloc>(
-        () => _i255.MedicationBloc(gh<_i196.MedicationRepository>()));
-    gh.factory<_i256.OnboardingCubit>(
-        () => _i256.OnboardingCubit(gh<_i202.OnboardingRepository>()));
-    gh.lazySingleton<_i257.PatientContextIndexer>(
-      () => _i257.PatientContextIndexer(
+    gh.factory<_i256.MedicationBloc>(
+        () => _i256.MedicationBloc(gh<_i197.MedicationRepository>()));
+    gh.factory<_i257.OnboardingCubit>(
+        () => _i257.OnboardingCubit(gh<_i203.OnboardingRepository>()));
+    gh.lazySingleton<_i258.PatientContextIndexer>(
+      () => _i258.PatientContextIndexer(
         gh<_i61.Isar>(),
         gh<_i131.VectorStoreService>(),
-        gh<_i184.HealthRecordRepository>(),
-        gh<_i196.MedicationRepository>(),
-        gh<_i225.AllergyRepository>(),
+        gh<_i185.HealthRecordRepository>(),
+        gh<_i197.MedicationRepository>(),
+        gh<_i226.AllergyRepository>(),
         gh<_i133.VitalSignRepository>(),
         gh<_i8.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.factory<_i258.ReportBloc>(() => _i258.ReportBloc(
+    gh.factory<_i259.ReportBloc>(() => _i259.ReportBloc(
           gh<_i107.ReportRepository>(),
-          gh<_i204.ReportGenerationService>(),
+          gh<_i205.ReportGenerationService>(),
         ));
-    gh.factory<_i259.SaveAllergyUseCase>(
-        () => _i259.SaveAllergyUseCase(gh<_i225.AllergyRepository>()));
-    gh.factory<_i260.SearchMedicalResearch>(() =>
-        _i260.SearchMedicalResearch(gh<_i253.MedicalResearchRepository>()));
-    gh.factory<_i261.SharingCubit>(() => _i261.SharingCubit(
+    gh.factory<_i260.SaveAllergyUseCase>(
+        () => _i260.SaveAllergyUseCase(gh<_i226.AllergyRepository>()));
+    gh.factory<_i261.SearchMedicalResearch>(() =>
+        _i261.SearchMedicalResearch(gh<_i254.MedicalResearchRepository>()));
+    gh.factory<_i262.SharingCubit>(() => _i262.SharingCubit(
           bleService: gh<_i147.BleSharingService>(),
           nfcService: gh<_i94.NfcSharingService>(),
           wifiService: gh<_i140.WifiDirectService>(),
-          startSharingUseCase: gh<_i216.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i215.StartListeningUseCase>(),
+          startSharingUseCase: gh<_i217.StartSharingUseCase>(),
+          startListeningUseCase: gh<_i216.StartListeningUseCase>(),
           cancelSharingUseCase: gh<_i148.CancelSharingUseCase>(),
           walletService: gh<_i35.WalletService>(),
           walletEncryption: gh<_i35.EncryptionService>(),
         ));
-    gh.factory<_i262.AllergiesCubit>(
-        () => _i262.AllergiesCubit(gh<_i225.AllergyRepository>()));
-    gh.factory<_i263.AllergyBloc>(
-        () => _i263.AllergyBloc(gh<_i225.AllergyRepository>()));
-    gh.factory<_i264.AuthCubit>(() => _i264.AuthCubit(gh<_i228.AuthService>()));
-    gh.factory<_i265.DashboardCubit>(() => _i265.DashboardCubit(
-          gh<_i244.GetDashboardStatsUseCase>(),
-          gh<_i246.GetRecentActivityUseCase>(),
+    gh.factory<_i263.AllergiesCubit>(
+        () => _i263.AllergiesCubit(gh<_i226.AllergyRepository>()));
+    gh.factory<_i264.AllergyBloc>(
+        () => _i264.AllergyBloc(gh<_i226.AllergyRepository>()));
+    gh.factory<_i265.AuthCubit>(() => _i265.AuthCubit(gh<_i229.AuthService>()));
+    gh.factory<_i266.DashboardCubit>(() => _i266.DashboardCubit(
+          gh<_i245.GetDashboardStatsUseCase>(),
+          gh<_i247.GetRecentActivityUseCase>(),
         ));
-    gh.factory<_i266.DataSourceCubit>(
-        () => _i266.DataSourceCubit(gh<_i235.DataSourceRepository>()));
-    gh.factory<_i267.GetHealthSummaryUseCase>(
-        () => _i267.GetHealthSummaryUseCase(gh<_i250.HomeRepository>()));
-    gh.factory<_i268.GetResearchHistory>(
-        () => _i268.GetResearchHistory(gh<_i253.MedicalResearchRepository>()));
-    gh.factory<_i269.HomeCubit>(() => _i269.HomeCubit(
-          gh<_i267.GetHealthSummaryUseCase>(),
-          gh<_i250.HomeRepository>(),
+    gh.factory<_i267.DataSourceCubit>(
+        () => _i267.DataSourceCubit(gh<_i236.DataSourceRepository>()));
+    gh.factory<_i268.GetHealthSummaryUseCase>(
+        () => _i268.GetHealthSummaryUseCase(gh<_i251.HomeRepository>()));
+    gh.factory<_i269.GetResearchHistory>(
+        () => _i269.GetResearchHistory(gh<_i254.MedicalResearchRepository>()));
+    gh.factory<_i270.HomeCubit>(() => _i270.HomeCubit(
+          gh<_i268.GetHealthSummaryUseCase>(),
+          gh<_i251.HomeRepository>(),
         ));
-    gh.lazySingleton<_i270.MedicalIndexingService>(
-        () => _i270.MedicalIndexingService(
+    gh.lazySingleton<_i271.MedicalIndexingService>(
+        () => _i271.MedicalIndexingService(
               gh<_i70.MedicalKnowledgeRepository>(),
               gh<_i131.VectorStoreService>(),
-              gh<_i257.PatientContextIndexer>(),
+              gh<_i258.PatientContextIndexer>(),
             ));
-    gh.factory<_i271.MedicalResearchCubit>(() => _i271.MedicalResearchCubit(
-          gh<_i260.SearchMedicalResearch>(),
-          gh<_i268.GetResearchHistory>(),
+    gh.factory<_i272.MedicalResearchCubit>(() => _i272.MedicalResearchCubit(
+          gh<_i261.SearchMedicalResearch>(),
+          gh<_i269.GetResearchHistory>(),
           gh<_i75.MedicalStandardsService>(),
         ));
     return this;
   }
 }
 
-class _$ServiceModule extends _i272.ServiceModule {}
+class _$ServiceModule extends _i273.ServiceModule {}
 
-class _$NetworkModule extends _i273.NetworkModule {}
+class _$NetworkModule extends _i274.NetworkModule {}
 
-class _$MemoryModule extends _i274.MemoryModule {}
+class _$MemoryModule extends _i275.MemoryModule {}
 
-class _$DatabaseModule extends _i275.DatabaseModule {}
+class _$DatabaseModule extends _i276.DatabaseModule {}
 
-class _$FhirModule extends _i276.FhirModule {}
+class _$FhirModule extends _i277.FhirModule {}

--- a/lib/core/di/service_module.dart
+++ b/lib/core/di/service_module.dart
@@ -4,11 +4,16 @@ import 'package:health/health.dart';
 import 'package:http/http.dart' as http;
 import 'package:injectable/injectable.dart';
 import '../services/device_capability_service.dart';
+import '../utils/health_helper.dart';
+import '../utils/health_wrapper.dart';
 
 @module
 abstract class ServiceModule {
   @lazySingleton
-  Health get health => Health();
+  HealthWrapper get healthWrapper => HealthWrapper(HealthHelper.createClient());
+
+  @lazySingleton
+  Health? get health => HealthHelper.createClient();
 
   @preResolve
   @lazySingleton

--- a/lib/core/utils/health_helper.dart
+++ b/lib/core/utils/health_helper.dart
@@ -1,0 +1,16 @@
+import 'package:health/health.dart';
+
+class HealthHelper {
+  /// Safely creates a Health client.
+  ///
+  /// Returns null if the Health client cannot be instantiated (e.g., on devices
+  /// where Health Connect is not available and the constructor throws).
+  static Health? createClient() {
+    try {
+      return Health();
+    } catch (e) {
+      // Log error or handle it silently
+      return null;
+    }
+  }
+}

--- a/lib/core/utils/health_wrapper.dart
+++ b/lib/core/utils/health_wrapper.dart
@@ -1,0 +1,9 @@
+import 'package:health/health.dart';
+
+class HealthWrapper {
+  final Health? health;
+
+  HealthWrapper(this.health);
+
+  bool get isAvailable => health != null;
+}

--- a/lib/features/data_sources/infrastructure/datasources/health_connect_datasource.dart
+++ b/lib/features/data_sources/infrastructure/datasources/health_connect_datasource.dart
@@ -1,5 +1,6 @@
 import 'package:health/health.dart';
 import 'package:injectable/injectable.dart';
+import '../../../../core/utils/health_wrapper.dart';
 
 abstract class HealthConnectDataSource {
   Future<bool> isAvailable();
@@ -9,33 +10,50 @@ abstract class HealthConnectDataSource {
 
 @LazySingleton(as: HealthConnectDataSource)
 class HealthConnectDataSourceImpl implements HealthConnectDataSource {
-  final Health _health;
+  final HealthWrapper _wrapper;
 
-  HealthConnectDataSourceImpl(this._health);
+  HealthConnectDataSourceImpl(this._wrapper);
+
+  Health? get _health => _wrapper.health;
 
   @override
   Future<bool> isAvailable() async {
+    if (_health == null) return false;
     // Check if Health Connect is installed and available
     // For now we use the health package's general check or platform check
-    return await _health.hasPermissions([]) ?? false; // Simplified for now
+    try {
+      return await _health!.hasPermissions([]) ?? false; // Simplified for now
+    } catch (_) {
+      return false;
+    }
   }
 
   @override
   Future<bool> requestPermissions() async {
-    return await _health.requestAuthorization([
-      HealthDataType.STEPS,
-      HealthDataType.HEART_RATE,
-    ]);
+    if (_health == null) return false;
+    try {
+      return await _health!.requestAuthorization([
+        HealthDataType.STEPS,
+        HealthDataType.HEART_RATE,
+      ]);
+    } catch (_) {
+      return false;
+    }
   }
 
   @override
   Future<void> syncData() async {
+    if (_health == null) return;
     final now = DateTime.now();
     final start = now.subtract(const Duration(days: 7));
-    await _health.getHealthDataFromTypes(
-      types: [HealthDataType.STEPS, HealthDataType.HEART_RATE],
-      startTime: start,
-      endTime: now,
-    );
+    try {
+      await _health!.getHealthDataFromTypes(
+        types: [HealthDataType.STEPS, HealthDataType.HEART_RATE],
+        startTime: start,
+        endTime: now,
+      );
+    } catch (_) {
+      // Handle or log error
+    }
   }
 }

--- a/lib/features/data_sources/infrastructure/datasources/sensor_api_datasource.dart
+++ b/lib/features/data_sources/infrastructure/datasources/sensor_api_datasource.dart
@@ -1,5 +1,6 @@
 import 'package:health/health.dart';
 import 'package:injectable/injectable.dart';
+import '../../../../core/utils/health_wrapper.dart';
 
 abstract class SensorApiDataSource {
   Future<bool> requestAuthorization();
@@ -9,9 +10,11 @@ abstract class SensorApiDataSource {
 
 @LazySingleton(as: SensorApiDataSource)
 class SensorApiDataSourceImpl implements SensorApiDataSource {
-  final Health _health;
+  final HealthWrapper _wrapper;
 
-  SensorApiDataSourceImpl(this._health);
+  SensorApiDataSourceImpl(this._wrapper);
+
+  Health? get _health => _wrapper.health;
 
   static const List<HealthDataType> _types = [
     HealthDataType.STEPS,
@@ -22,26 +25,41 @@ class SensorApiDataSourceImpl implements SensorApiDataSource {
 
   @override
   Future<bool> requestAuthorization() async {
-    return await _health.requestAuthorization(_types);
+    if (_health == null) return false;
+    try {
+      return await _health!.requestAuthorization(_types);
+    } catch (_) {
+      return false;
+    }
   }
 
   @override
   Future<bool> hasPermissions() async {
-    final result = await _health.hasPermissions(_types);
-    return result ?? false;
+    if (_health == null) return false;
+    try {
+      final result = await _health!.hasPermissions(_types);
+      return result ?? false;
+    } catch (_) {
+      return false;
+    }
   }
 
   @override
   Future<void> fetchAndSaveData() async {
+    if (_health == null) return;
     final now = DateTime.now();
     final yesterday = now.subtract(const Duration(days: 1));
 
     // In a real implementation, we would fetch and then save to another repository
     // For now, we simulate the fetch
-    await _health.getHealthDataFromTypes(
-      types: _types,
-      startTime: yesterday,
-      endTime: now,
-    );
+    try {
+      await _health!.getHealthDataFromTypes(
+        types: _types,
+        startTime: yesterday,
+        endTime: now,
+      );
+    } catch (_) {
+      // Handle or log error
+    }
   }
 }

--- a/lib/features/health_data_import/domain/services/health_data_import_service.dart
+++ b/lib/features/health_data_import/domain/services/health_data_import_service.dart
@@ -1,5 +1,6 @@
 import 'package:health/health.dart';
 import 'package:injectable/injectable.dart';
+import '../../../../core/utils/health_helper.dart';
 import '../../../vitals/domain/entities/vital_sign.dart';
 import '../entities/health_data_source.dart';
 
@@ -34,17 +35,23 @@ class HealthDataImportService {
     HealthDataAccess.READ,
   ];
 
-  Future<Health> _getHealthClient() async {
-    _healthClient ??= Health();
-    if (!_configured) {
-      await _healthClient!.configure();
-      _configured = true;
+  Future<Health?> _getHealthClient() async {
+    _healthClient ??= HealthHelper.createClient();
+    if (_healthClient != null && !_configured) {
+      try {
+        await _healthClient!.configure();
+        _configured = true;
+      } catch (_) {
+        return null;
+      }
     }
-    return _healthClient!;
+    return _healthClient;
   }
 
   Future<List<HealthDataSource>> getAvailableSources() async {
     final health = await _getHealthClient();
+    if (health == null) return [];
+
     final List<HealthDataSource> available = [];
 
     try {
@@ -66,22 +73,33 @@ class HealthDataImportService {
 
   Future<bool> requestAuthorization(HealthDataSource source) async {
     final health = await _getHealthClient();
-    return await health.requestAuthorization(
-      _desiredDataTypes,
-      permissions: _permissions,
-    );
+    if (health == null) return false;
+    try {
+      return await health.requestAuthorization(
+        _desiredDataTypes,
+        permissions: _permissions,
+      );
+    } catch (_) {
+      return false;
+    }
   }
 
   Future<List<HealthDataPoint>> _fetchData(HealthDataType type) async {
     final health = await _getHealthClient();
+    if (health == null) return [];
+
     final now = DateTime.now();
     final thirtyDaysAgo = now.subtract(const Duration(days: 30));
     
-    return await health.getHealthDataFromTypes(
-      types: [type],
-      startTime: thirtyDaysAgo,
-      endTime: now,
-    );
+    try {
+      return await health.getHealthDataFromTypes(
+        types: [type],
+        startTime: thirtyDaysAgo,
+        endTime: now,
+      );
+    } catch (_) {
+      return [];
+    }
   }
 
   Future<List<HealthDataPoint>> fetchSteps() => _fetchData(HealthDataType.STEPS);
@@ -92,21 +110,27 @@ class HealthDataImportService {
 
   Future<List<HealthDataPoint>> fetchBloodPressure() async {
     final health = await _getHealthClient();
+    if (health == null) return [];
+
     final now = DateTime.now();
     final thirtyDaysAgo = now.subtract(const Duration(days: 30));
     
-    final systolicData = await health.getHealthDataFromTypes(
-      types: [HealthDataType.BLOOD_PRESSURE_SYSTOLIC],
-      startTime: thirtyDaysAgo,
-      endTime: now,
-    );
-    final diastolicData = await health.getHealthDataFromTypes(
-      types: [HealthDataType.BLOOD_PRESSURE_DIASTOLIC],
-      startTime: thirtyDaysAgo,
-      endTime: now,
-    );
-    
-    return [...systolicData, ...diastolicData];
+    try {
+      final systolicData = await health.getHealthDataFromTypes(
+        types: [HealthDataType.BLOOD_PRESSURE_SYSTOLIC],
+        startTime: thirtyDaysAgo,
+        endTime: now,
+      );
+      final diastolicData = await health.getHealthDataFromTypes(
+        types: [HealthDataType.BLOOD_PRESSURE_DIASTOLIC],
+        startTime: thirtyDaysAgo,
+        endTime: now,
+      );
+
+      return [...systolicData, ...diastolicData];
+    } catch (_) {
+      return [];
+    }
   }
 
   Future<List<HealthDataPoint>> fetchHeight() => _fetchData(HealthDataType.HEIGHT);

--- a/lib/features/health_data_import/infrastructure/data_source.dart
+++ b/lib/features/health_data_import/infrastructure/data_source.dart
@@ -1,5 +1,6 @@
 import 'package:health/health.dart';
 import 'package:injectable/injectable.dart';
+import '../../../core/utils/health_helper.dart';
 import '../../health_record/infrastructure/services/file_picker_service.dart';
 import '../../health_record/infrastructure/services/ocr_service.dart';
 
@@ -11,26 +12,41 @@ abstract class SensorHealthDataSource {
 
 @LazySingleton(as: SensorHealthDataSource)
 class SensorHealthDataSourceImpl implements SensorHealthDataSource {
-  final Health _health = Health();
+  final Health? _health = HealthHelper.createClient();
 
   @override
   Future<bool> requestAuthorization(List<HealthDataType> types, List<HealthDataAccess> permissions) async {
-    return await _health.requestAuthorization(types, permissions: permissions);
+    if (_health == null) return false;
+    try {
+      return await _health!.requestAuthorization(types, permissions: permissions);
+    } catch (_) {
+      return false;
+    }
   }
 
   @override
   Future<List<HealthDataPoint>> fetchData(HealthDataType type, DateTime start, DateTime end) async {
-    return await _health.getHealthDataFromTypes(
-      types: [type],
-      startTime: start,
-      endTime: end,
-    );
+    if (_health == null) return [];
+    try {
+      return await _health!.getHealthDataFromTypes(
+        types: [type],
+        startTime: start,
+        endTime: end,
+      );
+    } catch (_) {
+      return [];
+    }
   }
 
   @override
   Future<bool> hasPermissions(List<HealthDataType> types) async {
-    final result = await _health.hasPermissions(types);
-    return result ?? false;
+    if (_health == null) return false;
+    try {
+      final result = await _health!.hasPermissions(types);
+      return result ?? false;
+    } catch (_) {
+      return false;
+    }
   }
 }
 

--- a/test/core/utils/health_helper_test.dart
+++ b/test/core/utils/health_helper_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:health/health.dart';
+import 'package:orionhealth_health/core/utils/health_helper.dart';
+
+void main() {
+  group('HealthHelper', () {
+    test('createClient returns a Health instance (in test environment)', () {
+      final client = HealthHelper.createClient();
+      expect(client, isA<Health>());
+    });
+  });
+}


### PR DESCRIPTION
This change addresses a crash that occurs when the `Health()` constructor from the `health` package is called on devices that do not have Health Connect installed (such as some Samsung S22+ models). 

Key changes:
1. **HealthHelper**: A new utility to safely instantiate `Health` by wrapping it in a try-catch block.
2. **HealthWrapper**: A container for the nullable `Health` client, allowing it to be safely injected via GetIt/Injectable without violating type bounds in the generated code.
3. **DI Migration**: Migrated core health data sources (`HealthConnectDataSource` and `SensorApiDataSource`) to use `HealthWrapper`. They now gracefully handle cases where the health client is unavailable.
4. **Internal Safety**: Added null checks and try-catch blocks to `HealthDataImportService` and `SensorHealthDataSourceImpl` to prevent runtime exceptions when the client is null or when platform calls fail.
5. **DI Regeneration**: Updated `injection.config.dart` to reflect the new dependency structure.

This ensures the app can start and run on all devices, even if health features are partially disabled due to missing platform requirements.

Fixes #1482

---
*PR created automatically by Jules for task [4893931477121265229](https://jules.google.com/task/4893931477121265229) started by @iberi22*