### PR TITLE
Fix FlutterSecureStorage failure on Android emulators

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -25,30 +25,25 @@ import 'package:just_audio/just_audio.dart' as _i13;
 import 'package:medical_standards/medical_standards.dart' as _i69;
 import 'package:shared_preferences/shared_preferences.dart' as _i52;
 
-import '../../features/about/application/about_cubit.dart' as _i142;
-import '../../features/about/application/about_cubit.dart' as _i143;
+import '../../features/about/application/about_cubit.dart' as _i141;
 import '../../features/about/domain/repositories/i_about_repository.dart'
     as _i54;
 import '../../features/about/domain/usecases/get_about_info_usecase.dart'
-    as _i167;
+    as _i165;
 import '../../features/about/infrastructure/datasources/about_local_datasource.dart'
     as _i4;
 import '../../features/about/infrastructure/datasources/about_remote_datasource.dart'
-    as _i143;
-    as _i168;
-    as _i144;
+    as _i142;
 import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
     as _i55;
 import '../../features/allergies/application/allergies_cubit.dart' as _i262;
 import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i263;
 import '../../features/allergies/data/datasources/allergy_local_datasource.dart'
-    as _i144;
+    as _i143;
 import '../../features/allergies/data/repositories/allergy_repository_impl.dart'
     as _i226;
 import '../../features/allergies/domain/repositories/allergy_repository.dart'
     as _i225;
-    as _i145;
-    as _i227;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i6;
 import '../../features/allergies/domain/usecases/get_allergies_usecase.dart'
     as _i243;
@@ -67,55 +62,38 @@ import '../../features/appointments/domain/usecases/delete_appointment_usecase.d
 import '../../features/appointments/domain/usecases/get_all_appointments_usecase.dart'
     as _i44;
 import '../../features/appointments/domain/usecases/save_appointment_usecase.dart'
-    as _i109;
-import '../../features/auth/application/auth_cubit.dart' as _i263;
+    as _i110;
+import '../../features/auth/application/auth_cubit.dart' as _i264;
 import '../../features/auth/application/bloc/auth_cubit.dart' as _i227;
 import '../../features/auth/data/datasources/auth_local_datasource.dart'
-    as _i145;
+    as _i144;
 import '../../features/auth/data/repositories/auth_repository_impl.dart'
-    as _i147;
+    as _i146;
 import '../../features/auth/domain/auth_service.dart' as _i228;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i146;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i145;
 import '../../features/auth/domain/usecases/check_session_timeout.dart'
-    as _i151;
+    as _i150;
 import '../../features/auth/domain/usecases/get_credentials_usecase.dart'
-    as _i173;
-import '../../features/auth/domain/usecases/login_usecase.dart' as _i195;
-import '../../features/auth/domain/usecases/logout_usecase.dart' as _i196;
+    as _i171;
+import '../../features/auth/domain/usecases/login_usecase.dart' as _i193;
+import '../../features/auth/domain/usecases/logout_usecase.dart' as _i194;
 import '../../features/auth/domain/usecases/save_credentials_usecase.dart'
-    as _i208;
-import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i215;
+    as _i206;
+import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i213;
 import '../../features/auth/domain/usecases/validate_session_usecase.dart'
     as _i221;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i16;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i164;
+    as _i163;
 import '../../features/calendar_import/application/calendar_import_cubit.dart'
     as _i231;
-    as _i110;
-import '../../features/auth/application/auth_cubit.dart' as _i264;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i228;
-    as _i146;
-    as _i148;
-import '../../features/auth/domain/auth_service.dart' as _i229;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i147;
-    as _i152;
-    as _i174;
-import '../../features/auth/domain/usecases/login_usecase.dart' as _i196;
-import '../../features/auth/domain/usecases/logout_usecase.dart' as _i197;
-    as _i209;
-import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i216;
-    as _i222;
-    as _i165;
-    as _i232;
 import '../../features/calendar_import/domain/repositories/calendar_import_repository.dart'
     as _i21;
 import '../../features/calendar_import/domain/services/calendar_parser_service.dart'
     as _i23;
 import '../../features/calendar_import/domain/usecases/import_calendar_usecase.dart'
-    as _i188;
-    as _i189;
+    as _i186;
 import '../../features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart'
     as _i19;
 import '../../features/calendar_import/infrastructure/repositories/calendar_import_repository_impl.dart'
@@ -125,83 +103,65 @@ import '../../features/calendar_import/infrastructure/services/calendar_parser_s
 import '../../features/dashboard/application/dashboard_cubit.dart' as _i265;
 import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
     as _i233;
-    as _i234;
 import '../../features/dashboard/domain/usecases/get_dashboard_stats_usecase.dart'
     as _i244;
 import '../../features/dashboard/domain/usecases/get_recent_activity_usecase.dart'
     as _i246;
 import '../../features/dashboard/infrastructure/datasources/dashboard_local_datasource.dart'
-    as _i155;
+    as _i154;
 import '../../features/dashboard/infrastructure/datasources/dashboard_remote_datasource.dart'
     as _i27;
 import '../../features/dashboard/infrastructure/repositories/dashboard_repository_impl.dart'
     as _i234;
 import '../../features/data_sources/application/data_source_cubit.dart'
-    as _i265;
+    as _i266;
 import '../../features/data_sources/domain/repositories/data_source_repository.dart'
     as _i235;
 import '../../features/data_sources/infrastructure/datasources/file_import_datasource.dart'
-    as _i166;
+    as _i164;
 import '../../features/data_sources/infrastructure/datasources/health_connect_datasource.dart'
-    as _i45;
+    as _i46;
 import '../../features/data_sources/infrastructure/datasources/sensor_api_datasource.dart'
-    as _i115;
+    as _i116;
 import '../../features/data_sources/infrastructure/repositories/data_source_repository_impl.dart'
     as _i236;
 import '../../features/doctor_verification/application/badge_cubit.dart'
     as _i230;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
-    as _i161;
+    as _i160;
 import '../../features/doctor_verification/application/second_opinion_cubit.dart'
-    as _i213;
+    as _i211;
 import '../../features/doctor_verification/application/vouch_cubit.dart'
     as _i224;
 import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
-    as _i159;
+    as _i158;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
-    as _i103;
+    as _i104;
 import '../../features/doctor_verification/domain/repositories/second_opinion_repository.dart'
-    as _i111;
+    as _i112;
 import '../../features/doctor_verification/domain/repositories/vouch_repository.dart'
-    as _i139;
+    as _i138;
 import '../../features/doctor_verification/domain/services/badge_calculator.dart'
     as _i229;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
-    as _i62;
-import '../../features/doctor_verification/domain/usecases/get_all_doctors_usecase.dart'
-    as _i168;
-import '../../features/doctor_verification/domain/usecases/get_doctor_profile_usecase.dart'
-    as _i174;
-import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
-    as _i61;
-import '../../features/doctor_verification/infrastructure/repositories/isar_doctor_profile_repository.dart'
-    as _i160;
-import '../../features/doctor_verification/infrastructure/repositories/isar_rating_repository.dart'
-    as _i104;
-import '../../features/doctor_verification/infrastructure/repositories/isar_second_opinion_repository.dart'
-    as _i112;
-import '../../features/doctor_verification/infrastructure/repositories/isar_vouch_repository.dart'
-    as _i140;
-import '../../features/email-citas/application/bloc/email_citas_bloc.dart'
-    as _i162;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i163;
-    as _i156;
-    as _i266;
-    as _i167;
-    as _i46;
-    as _i116;
-    as _i237;
-    as _i231;
-    as _i214;
-    as _i225;
     as _i63;
-    as _i169;
-    as _i175;
+import '../../features/doctor_verification/domain/usecases/get_all_doctors_usecase.dart'
+    as _i166;
+import '../../features/doctor_verification/domain/usecases/get_doctor_profile_usecase.dart'
+    as _i172;
+import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
+    as _i62;
+import '../../features/doctor_verification/infrastructure/repositories/isar_doctor_profile_repository.dart'
+    as _i159;
+import '../../features/doctor_verification/infrastructure/repositories/isar_rating_repository.dart'
     as _i105;
+import '../../features/doctor_verification/infrastructure/repositories/isar_second_opinion_repository.dart'
     as _i113;
-    as _i141;
-    as _i163;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i164;
+import '../../features/doctor_verification/infrastructure/repositories/isar_vouch_repository.dart'
+    as _i139;
+import '../../features/email-citas/application/bloc/email_citas_bloc.dart'
+    as _i161;
+import '../../features/email-citas/application/email_citas_cubit.dart' as _i162;
 import '../../features/email-citas/domain/repositories/email_repository.dart'
     as _i32;
 import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
@@ -213,45 +173,23 @@ import '../../features/eps_connection/application/bloc/eps_connection_bloc.dart'
 import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
     as _i239;
 import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
-    as _i97;
-import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
-    as _i154;
-import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
-    as _i156;
-import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
-    as _i172;
-import '../../features/eps_connection/infrastructure/datasources/oauth_local_datasource.dart'
-    as _i96;
-import '../../features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart'
-    as _i240;
     as _i98;
 import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
-    as _i155;
+    as _i153;
 import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
-    as _i157;
+    as _i155;
 import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
-    as _i173;
+    as _i170;
 import '../../features/eps_connection/infrastructure/datasources/oauth_local_datasource.dart'
     as _i97;
 import '../../features/eps_connection/infrastructure/repositories/oauth_repository_impl.dart'
     as _i99;
 import '../../features/health_data_import/application/bloc/health_import_bloc.dart'
     as _i247;
-import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i184;
-import '../../features/health_data_import/domain/services/health_data_import_service.dart'
-    as _i46;
-import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
-    as _i108;
-import '../../features/health_data_import/infrastructure/data_source.dart'
-    as _i116;
-import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i185;
-import '../../features/health_record/application/bloc/health_record_cubit.dart'
 import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i248;
 import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i185;
+    as _i182;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i47;
 import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
@@ -259,20 +197,17 @@ import '../../features/health_data_import/domain/usecases/health_import_usecases
 import '../../features/health_data_import/infrastructure/data_source.dart'
     as _i117;
 import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i186;
+    as _i183;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
     as _i249;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i186;
-    as _i187;
+    as _i184;
 import '../../features/health_record/domain/usecases/get_all_records_usecase.dart'
     as _i242;
 import '../../features/health_record/domain/usecases/save_record_usecase.dart'
-    as _i210;
+    as _i208;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i187;
-    as _i211;
-    as _i188;
+    as _i185;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i37;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
@@ -283,30 +218,16 @@ import '../../features/health_sharing/application/sharing_cubit.dart' as _i261;
 import '../../features/health_sharing/domain/repositories/sharing_repository.dart'
     as _i121;
 import '../../features/health_sharing/domain/usecases/cancel_sharing_usecase.dart'
-    as _i149;
-import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
-    as _i217;
-import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
-    as _i218;
-import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
     as _i148;
-    as _i150;
-    as _i219;
+import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
+    as _i215;
+import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
+    as _i216;
+import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
+    as _i147;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i17;
 import '../../features/health_sharing/infrastructure/datasources/health_sharing_local_datasource.dart'
     as _i48;
-import '../../features/health_sharing/infrastructure/nfc_handler.dart' as _i91;
-import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
-    as _i93;
-import '../../features/health_sharing/infrastructure/repositories/health_sharing_repository_impl.dart'
-    as _i121;
-import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i141;
-import '../../features/home/application/home_cubit.dart' as _i268;
-import '../../features/home/domain/repositories/home_repository.dart' as _i249;
-import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
-    as _i266;
-import '../../features/home/infrastructure/datasources/health_summary_datasource.dart'
 import '../../features/health_sharing/infrastructure/datasources/health_sharing_remote_datasource.dart'
     as _i49;
 import '../../features/health_sharing/infrastructure/nfc_handler.dart' as _i92;
@@ -315,7 +236,7 @@ import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
 import '../../features/health_sharing/infrastructure/repositories/health_sharing_repository_impl.dart'
     as _i122;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i142;
+    as _i140;
 import '../../features/home/application/home_cubit.dart' as _i269;
 import '../../features/home/domain/repositories/home_repository.dart' as _i250;
 import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
@@ -329,71 +250,45 @@ import '../../features/home/infrastructure/datasources/home_remote_datasource.da
 import '../../features/home/infrastructure/repositories/home_repository_impl.dart'
     as _i251;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i216;
+    as _i214;
 import '../../features/local_agent/data/datasources/chat_message_local_datasource.dart'
-    as _i150;
-    as _i217;
-    as _i151;
+    as _i149;
 import '../../features/local_agent/data/datasources/local_model_local_datasource.dart'
     as _i68;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i70;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i64;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i132;
+    as _i131;
 import '../../features/local_agent/domain/usecases/get_chat_history_usecase.dart'
-    as _i171;
-    as _i133;
-    as _i172;
+    as _i169;
 import '../../features/local_agent/domain/usecases/send_chat_message_usecase.dart'
     as _i115;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
-    as _i65;
+    as _i66;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i40;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i189;
-    as _i191;
+    as _i187;
 import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i42;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i190;
+    as _i188;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
-    as _i64;
+    as _i65;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i193;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i192;
-    as _i66;
-    as _i194;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i193;
+    as _i191;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i190;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
     as _i252;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
-    as _i70;
-import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i71;
-import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i133;
-import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i191;
-import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
-    as _i66;
-import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
-    as _i269;
-import '../../features/local_agent/infrastructure/services/model_download_service.dart'
-    as _i84;
-import '../../features/local_agent/infrastructure/services/patient_context_indexer.dart'
-    as _i256;
-import '../../features/medical_research/application/medical_research_cubit.dart'
-    as _i270;
-import '../../features/medical_research/domain/repositories/medical_research_repository.dart'
-    as _i252;
-import '../../features/medical_research/domain/services/medical_scraper_service.dart'
+import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i72;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i134;
+    as _i132;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i192;
+    as _i189;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i67;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
@@ -419,236 +314,182 @@ import '../../features/medical_research/domain/usecases/search_medical_research.
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i18;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i197;
-    as _i198;
+    as _i195;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i74;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
     as _i76;
 import '../../features/medical_research/infrastructure/medical_web_search_service_impl.dart'
-    as _i77;
-import '../../features/medical_research/infrastructure/repositories/medical_research_repository_impl.dart'
-    as _i253;
-import '../../features/medications/application/bloc/medication_bloc.dart'
-    as _i254;
-import '../../features/medications/application/medications_cubit.dart' as _i200;
-import '../../features/medications/domain/repositories/medication_adherence_repository.dart'
     as _i78;
+import '../../features/medical_research/infrastructure/repositories/medical_research_repository_impl.dart'
+    as _i254;
+import '../../features/medications/application/bloc/medication_bloc.dart'
     as _i255;
-import '../../features/medications/application/medications_cubit.dart' as _i201;
+import '../../features/medications/application/medications_cubit.dart' as _i198;
+import '../../features/medications/domain/repositories/medication_adherence_repository.dart'
     as _i79;
 import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i198;
-    as _i199;
+    as _i196;
 import '../../features/medications/domain/usecases/get_all_medications_usecase.dart'
     as _i241;
 import '../../features/medications/domain/usecases/save_medication_usecase.dart'
-    as _i209;
+    as _i207;
 import '../../features/medications/infrastructure/datasources/adherence_sqlite_datasource.dart'
     as _i5;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i199;
+    as _i197;
 import '../../features/medications/infrastructure/repositories/sqlite_medication_adherence_repository.dart'
-    as _i79;
-import '../../features/medications/infrastructure/services/pharmacy_api_service.dart'
-    as _i100;
-import '../../features/medications/infrastructure/services/rxnorm_api_service.dart'
-    as _i101;
-import '../../features/meditation/application/meditation_cubit.dart' as _i201;
-import '../../features/meditation/domain/repositories/meditation_repository.dart'
-    as _i81;
-import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
-    as _i152;
-import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
-    as _i177;
-import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
-    as _i179;
-import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
-    as _i105;
-import '../../features/meditation/domain/usecases/start_session_usecase.dart'
-    as _i122;
-import '../../features/meditation/infrastructure/datasources/meditation_local_datasource.dart'
     as _i80;
-import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
+import '../../features/medications/infrastructure/services/pharmacy_api_service.dart'
+    as _i101;
+import '../../features/medications/infrastructure/services/rxnorm_api_service.dart'
+    as _i102;
+import '../../features/meditation/application/meditation_cubit.dart' as _i199;
+import '../../features/meditation/domain/repositories/meditation_repository.dart'
     as _i82;
-import '../../features/network/application/network_cubit.dart' as _i202;
-import '../../features/network/domain/repositories/network_peer_repository.dart'
-    as _i87;
-import '../../features/network/governance/domain/repositories/governance_repository.dart'
-    as _i182;
-import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
-    as _i181;
-import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
-    as _i183;
-import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
-    as _i57;
-import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
-    as _i56;
-import '../../features/network/incentives/infrastructure/repositories/incentive_repository_impl.dart'
-    as _i58;
-import '../../features/network/infrastructure/datasources/network_p2p_api.dart'
-    as _i86;
-import '../../features/network/infrastructure/repositories/network_peer_repository_impl.dart'
-    as _i88;
-import '../../features/network/network_health/application/network_health_cubit.dart'
-    as _i203;
-import '../../features/network/network_health/domain/repositories/network_repository.dart'
-    as _i89;
-import '../../features/network/network_health/domain/usecases/connect_node.dart'
-    as _i153;
-import '../../features/network/network_health/domain/usecases/get_network_health.dart'
+import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
+    as _i151;
+import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
     as _i175;
-import '../../features/network/network_health/domain/usecases/get_node_stats.dart'
-    as _i176;
-import '../../features/network/network_health/infrastructure/datasources/network_datasource.dart'
-    as _i85;
-import '../../features/network/network_health/infrastructure/repositories/network_repository_impl.dart'
+import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
+    as _i177;
+import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
+    as _i106;
+import '../../features/meditation/domain/usecases/start_session_usecase.dart'
+    as _i123;
+import '../../features/meditation/infrastructure/datasources/meditation_local_datasource.dart'
+    as _i81;
+import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
+    as _i83;
+import '../../features/network/application/network_cubit.dart' as _i200;
+import '../../features/network/domain/repositories/network_peer_repository.dart'
+    as _i88;
+import '../../features/network/governance/domain/repositories/governance_repository.dart'
+    as _i180;
+import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
+    as _i179;
+import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
+    as _i181;
+import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
+    as _i58;
+import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
+    as _i57;
+import '../../features/network/incentives/infrastructure/repositories/incentive_repository_impl.dart'
+    as _i59;
+import '../../features/network/infrastructure/datasources/network_p2p_api.dart'
+    as _i87;
+import '../../features/network/infrastructure/repositories/network_peer_repository_impl.dart'
+    as _i89;
+import '../../features/network/network_health/application/network_health_cubit.dart'
+    as _i201;
+import '../../features/network/network_health/domain/repositories/network_repository.dart'
     as _i90;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i255;
-import '../../features/onboarding/application/sync_cubit.dart' as _i219;
+import '../../features/network/network_health/domain/usecases/connect_node.dart'
+    as _i152;
+import '../../features/network/network_health/domain/usecases/get_network_health.dart'
+    as _i173;
+import '../../features/network/network_health/domain/usecases/get_node_stats.dart'
+    as _i174;
+import '../../features/network/network_health/infrastructure/datasources/network_datasource.dart'
+    as _i86;
+import '../../features/network/network_health/infrastructure/repositories/network_repository_impl.dart'
+    as _i91;
+import '../../features/onboarding/application/onboarding_cubit.dart' as _i256;
+import '../../features/onboarding/application/sync_cubit.dart' as _i217;
 import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i204;
+    as _i202;
 import '../../features/onboarding/domain/usecases/complete_onboarding_usecase.dart'
     as _i232;
 import '../../features/onboarding/domain/usecases/get_onboarding_profile_usecase.dart'
-    as _i244;
-import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
-    as _i205;
-import '../../features/reports/application/bloc/report_bloc.dart' as _i257;
-import '../../features/reports/domain/repositories/report_repository.dart'
-    as _i106;
-import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i206;
-import '../../features/reports/domain/usecases/get_reports_usecase.dart'
-    as _i178;
-import '../../features/reports/domain/usecases/save_report_usecase.dart'
-    as _i110;
-import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
-    as _i107;
-import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i207;
-import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
-    as _i83;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i194;
-    as _i210;
-    as _i200;
-    as _i102;
-import '../../features/meditation/application/meditation_cubit.dart' as _i202;
-    as _i180;
-    as _i123;
-import '../../features/network/application/network_cubit.dart' as _i203;
-    as _i184;
-    as _i59;
-    as _i154;
-    as _i91;
-import '../../features/onboarding/application/onboarding_cubit.dart' as _i256;
-import '../../features/onboarding/application/sync_cubit.dart' as _i220;
-    as _i233;
     as _i245;
+import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
+    as _i203;
 import '../../features/reports/application/bloc/report_bloc.dart' as _i258;
+import '../../features/reports/domain/repositories/report_repository.dart'
+    as _i107;
+import '../../features/reports/domain/services/report_generation_service.dart'
+    as _i204;
+import '../../features/reports/domain/usecases/get_reports_usecase.dart'
+    as _i176;
+import '../../features/reports/domain/usecases/save_report_usecase.dart'
     as _i111;
+import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i108;
-    as _i208;
+import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
+    as _i205;
+import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i84;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i195;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i192;
 import '../../features/settings/domain/repositories/settings_repository.dart'
     as _i119;
 import '../../features/settings/domain/services/device_capability_service.dart'
-    as _i30;
+    as _i29;
 import '../../features/settings/infrastructure/datasources/settings_local_datasource.dart'
     as _i118;
 import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
-    as _i119;
-import '../../features/sync/application/sync_cubit.dart' as _i165;
-import '../../features/sync/domain/repositories/sync_repository.dart' as _i124;
+    as _i120;
+import '../../features/sync/application/sync_cubit.dart' as _i240;
+import '../../features/sync/domain/repositories/sync_repository.dart' as _i125;
 import '../../features/sync/domain/services/distributed_storage_service.dart'
-    as _i157;
+    as _i156;
 import '../../features/sync/domain/services/node_discovery_service.dart'
-    as _i94;
-import '../../features/sync/domain/services/sync_service.dart' as _i126;
+    as _i95;
+import '../../features/sync/domain/services/sync_service.dart' as _i218;
 import '../../features/sync/domain/usecases/distributed_cache_usecase.dart'
     as _i237;
-    as _i120;
-import '../../features/sync/application/sync_cubit.dart' as _i166;
-import '../../features/sync/domain/repositories/sync_repository.dart' as _i125;
-    as _i158;
-    as _i95;
-import '../../features/sync/domain/services/sync_service.dart' as _i127;
-    as _i238;
 import '../../features/sync/infrastructure/datasources/filecoin_datasource.dart'
     as _i38;
 import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
     as _i60;
 import '../../features/sync/infrastructure/repositories/sync_repository_impl.dart'
-    as _i125;
+    as _i126;
 import '../../features/sync/infrastructure/services/fhir_client.dart' as _i36;
-import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i158;
+import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i157;
 import '../../features/sync/infrastructure/services/node_discovery_service.dart'
-    as _i95;
+    as _i96;
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
-    as _i127;
+    as _i219;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
     as _i220;
 import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
-    as _i128;
+    as _i127;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i129;
+    as _i128;
 import '../../features/user_profile/domain/services/user_profile_service.dart'
-    as _i131;
-import '../../features/user_profile/domain/usecases/get_user_profile_usecase.dart'
-    as _i180;
-import '../../features/user_profile/domain/usecases/save_user_profile_usecase.dart'
-    as _i211;
-import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
     as _i130;
+import '../../features/user_profile/domain/usecases/get_user_profile_usecase.dart'
+    as _i178;
+import '../../features/user_profile/domain/usecases/save_user_profile_usecase.dart'
+    as _i209;
+import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
+    as _i129;
 import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i222;
-import '../../features/vitals/application/vitals_cubit.dart' as _i136;
+import '../../features/vitals/application/vitals_cubit.dart' as _i135;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i134;
+    as _i133;
 import '../../features/vitals/domain/usecases/get_all_vital_signs_usecase.dart'
-    as _i169;
+    as _i167;
 import '../../features/vitals/domain/usecases/save_vital_signs_usecase.dart'
-    as _i212;
+    as _i210;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
-    as _i135;
+    as _i134;
 import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i223;
 import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
-    as _i137;
+    as _i136;
 import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
-    as _i170;
+    as _i168;
 import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
-    as _i214;
+    as _i212;
 import '../../features/voice_chat/infrastructure/datasources/chat_ai_datasource.dart'
     as _i25;
 import '../../features/voice_chat/infrastructure/repositories/voice_chat_repository_impl.dart'
-    as _i138;
-    as _i126;
-import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i159;
-    as _i96;
-    as _i221;
-    as _i132;
-    as _i181;
-import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i223;
-import '../../features/vitals/application/vitals_cubit.dart' as _i137;
-    as _i213;
-    as _i136;
-import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i224;
-    as _i171;
-    as _i215;
-    as _i139;
+    as _i137;
 import '../logging/audit_logger.dart' as _i15;
 import '../services/aicore_service.dart' as _i3;
 import '../services/asr/asr_service.dart' as _i11;
 import '../services/audio/audio_player_service.dart' as _i12;
 import '../services/audio/audio_recorder_service.dart' as _i14;
-import '../services/device_capability_service.dart' as _i29;
-import '../services/privacy_anonymizer.dart' as _i102;
-import '../services/secure_storage_service.dart' as _i113;
-import 'database_module.dart' as _i274;
-import 'fhir_module.dart' as _i275;
-import 'memory_module.dart' as _i273;
-import 'network_module.dart' as _i272;
-import 'service_module.dart' as _i271;
+import '../services/device_capability_service.dart' as _i30;
 import '../services/privacy_anonymizer.dart' as _i103;
 import '../services/secure_storage_service.dart' as _i114;
 import 'database_module.dart' as _i275;
@@ -657,9 +498,9 @@ import 'memory_module.dart' as _i274;
 import 'network_module.dart' as _i273;
 import 'service_module.dart' as _i272;
 
-const String _mobile = 'mobile';
 const String _desktop = 'desktop';
 const String _test = 'test';
+const String _mobile = 'mobile';
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -734,7 +575,10 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i39.FlutterAppAuth>(() => serviceModule.appAuth);
     gh.lazySingleton<_i40.FlutterGemmaWrapper>(
         () => _i40.FlutterGemmaWrapper());
-    gh.lazySingleton<_i41.FlutterSecureStorage>(() => serviceModule.storage);
+    await gh.lazySingletonAsync<_i41.FlutterSecureStorage>(
+      () => serviceModule.storage(gh<_i30.DeviceCapabilityService>()),
+      preResolve: true,
+    );
     gh.lazySingleton<_i42.GeminiModelWrapper>(
         () => _i42.GeminiModelWrapper(gh<_i43.GenerativeModel>()));
     gh.factory<_i44.GetAllAppointmentsUseCase>(
@@ -776,33 +620,29 @@ extension GetItInjectableX on _i1.GetIt {
         _i63.LicenseVerifier(
             await getAsync<_i62.LicenseRegistryLocalDataSource>()));
     gh.lazySingleton<_i64.LlmAdapter>(
-      () => _i65.FlutterGemmaAdapter(wrapper: gh<_i40.FlutterGemmaWrapper>()),
-      instanceName: 'gemma',
+      () => _i65.OpenaiCompatibleAdapter(),
+      instanceName: 'openai',
     );
     gh.lazySingleton<_i64.LlmAdapter>(
-      () => _i66.OpenaiCompatibleAdapter(),
-      instanceName: 'openai',
+      () => _i66.FlutterGemmaAdapter(wrapper: gh<_i40.FlutterGemmaWrapper>()),
+      instanceName: 'gemma',
     );
     gh.lazySingleton<_i67.LocalLlmService>(() => _i67.LocalLlmService());
     gh.lazySingleton<_i68.LocalModelLocalDataSource>(
         () => _i68.LocalModelLocalDataSource());
     gh.lazySingleton<_i69.MedicalContextProvider>(
         () => networkModule.medicalContextProvider);
-    gh.factory<_i69.MedicalKnowledgeRepository>(
-      () => _i70.AssetMedicalKnowledgeRepository(),
-      registerFor: {_mobile},
-    );
-      () => _i71.JsonMedicalKnowledgeRepository(),
     gh.factory<_i70.MedicalKnowledgeRepository>(
       () => _i71.AssetMedicalKnowledgeRepository(),
+      registerFor: {_mobile},
+    );
+    gh.factory<_i70.MedicalKnowledgeRepository>(
       () => _i72.JsonMedicalKnowledgeRepository(),
       registerFor: {
         _desktop,
         _test,
       },
     );
-    gh.lazySingleton<_i72.MedicalScraperService>(
-        () => _i73.MedicalScraperServiceImpl(
     gh.lazySingleton<_i73.MedicalScraperService>(
         () => _i74.MedicalScraperServiceImpl(
               gh<_i31.Dio>(),
@@ -871,9 +711,11 @@ extension GetItInjectableX on _i1.GetIt {
         () => _i111.SaveReportUseCase(gh<_i107.ReportRepository>()));
     gh.lazySingleton<_i112.SecondOpinionRepository>(
         () => _i113.IsarSecondOpinionRepository(gh<_i61.Isar>()));
-    gh.lazySingleton<_i114.SecureStorageService>(() =>
-        _i114.SecureStorageServiceImpl(
-            storage: gh<_i41.FlutterSecureStorage>()));
+    gh.lazySingleton<_i114.SecureStorageService>(
+        () => _i114.SecureStorageServiceImpl(
+              storage: gh<_i41.FlutterSecureStorage>(),
+              capabilityService: gh<_i30.DeviceCapabilityService>(),
+            ));
     gh.factory<_i115.SendChatMessageUseCase>(() => _i115.SendChatMessageUseCase(
           gh<_i64.LlmAdapter>(),
           gh<_i70.MedicalKnowledgeRepository>(),
@@ -899,714 +741,431 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i41.FlutterSecureStorage>(),
           gh<_i95.NodeDiscoveryService>(),
         ));
-    gh.lazySingleton<_i68.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i126.SyncService>(() => _i127.SyncServiceImpl(
-          gh<_i124.SyncRepository>(),
-          gh<_i68.SyncService>(),
-        ));
-    gh.lazySingleton<_i128.UserProfileLocalDataSource>(
-        () => _i128.UserProfileLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i129.UserProfileRepository>(
-        () => _i130.UserProfileRepositoryImpl(gh<_i60.Isar>()));
-    gh.lazySingleton<_i131.UserProfileService>(
-        () => _i131.UserProfileService(gh<_i129.UserProfileRepository>()));
-    gh.lazySingleton<_i132.VectorStoreService>(
-        () => _i133.IsarVectorStoreService(
     gh.lazySingleton<_i69.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i127.SyncService>(() => _i128.SyncServiceImpl(
-          gh<_i125.SyncRepository>(),
-          gh<_i69.SyncService>(),
-    gh.lazySingleton<_i129.UserProfileLocalDataSource>(
-        () => _i129.UserProfileLocalDataSource(gh<_i61.Isar>()));
-    gh.lazySingleton<_i130.UserProfileRepository>(
-        () => _i131.UserProfileRepositoryImpl(gh<_i61.Isar>()));
-    gh.lazySingleton<_i132.UserProfileService>(
-        () => _i132.UserProfileService(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i133.VectorStoreService>(
-        () => _i134.IsarVectorStoreService(
+    gh.lazySingleton<_i127.UserProfileLocalDataSource>(
+        () => _i127.UserProfileLocalDataSource(gh<_i61.Isar>()));
+    gh.lazySingleton<_i128.UserProfileRepository>(
+        () => _i129.UserProfileRepositoryImpl(gh<_i61.Isar>()));
+    gh.lazySingleton<_i130.UserProfileService>(
+        () => _i130.UserProfileService(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i131.VectorStoreService>(
+        () => _i132.IsarVectorStoreService(
               gh<_i34.MemoryGraph>(),
               gh<_i70.MedicalKnowledgeRepository>(),
             ));
-    gh.lazySingleton<_i134.VitalSignRepository>(
-        () => _i135.VitalSignRepositoryImpl(gh<_i60.Isar>()));
-    gh.factory<_i136.VitalsCubit>(
-        () => _i136.VitalsCubit(gh<_i134.VitalSignRepository>()));
-    gh.lazySingleton<_i137.VoiceChatRepository>(
-        () => _i138.VoiceChatRepositoryImpl(gh<_i25.ChatAiDatasource>()));
-    gh.lazySingleton<_i139.VouchRepository>(
-        () => _i140.IsarVouchRepository(gh<_i60.Isar>()));
-    gh.lazySingleton<_i135.VitalSignRepository>(
-        () => _i136.VitalSignRepositoryImpl(gh<_i61.Isar>()));
-    gh.factory<_i137.VitalsCubit>(
-        () => _i137.VitalsCubit(gh<_i135.VitalSignRepository>()));
-    gh.lazySingleton<_i138.VoiceChatRepository>(
-        () => _i139.VoiceChatRepositoryImpl(gh<_i25.ChatAiDatasource>()));
-    gh.lazySingleton<_i140.VouchRepository>(
-        () => _i141.IsarVouchRepository(gh<_i61.Isar>()));
+    gh.lazySingleton<_i133.VitalSignRepository>(
+        () => _i134.VitalSignRepositoryImpl(gh<_i61.Isar>()));
+    gh.factory<_i135.VitalsCubit>(
+        () => _i135.VitalsCubit(gh<_i133.VitalSignRepository>()));
+    gh.lazySingleton<_i136.VoiceChatRepository>(
+        () => _i137.VoiceChatRepositoryImpl(gh<_i25.ChatAiDatasource>()));
+    gh.lazySingleton<_i138.VouchRepository>(
+        () => _i139.IsarVouchRepository(gh<_i61.Isar>()));
     gh.lazySingleton<_i35.WalletService>(() => databaseModule.walletService(
           gh<_i61.Isar>(),
           gh<_i35.EncryptionService>(),
         ));
-    gh.lazySingleton<_i141.WifiDirectService>(() => _i141.WifiDirectService());
-    gh.factory<_i142.AboutCubit>(
-        () => _i142.AboutCubit(gh<_i53.IAboutRepository>()));
-    gh.lazySingleton<_i143.AboutRemoteDataSource>(
-        () => _i143.AboutRemoteDataSource(gh<_i31.Dio>()));
-    gh.lazySingleton<_i144.AllergyLocalDataSource>(
-        () => _i144.AllergyLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i145.AuthLocalDataSource>(
-        () => _i145.AuthLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i146.AuthRepository>(() => _i147.AuthRepositoryImpl(
-          gh<_i145.AuthLocalDataSource>(),
-          gh<_i113.SecureStorageService>(),
-        ));
-    gh.lazySingleton<_i148.BleSharingService>(
-        () => _i148.BleSharingService(gh<_i17.BleWrapper>()));
-    gh.lazySingleton<_i149.CancelSharingUseCase>(
-        () => _i149.CancelSharingUseCase(
-              gh<_i148.BleSharingService>(),
-              gh<_i93.NfcSharingService>(),
-              gh<_i141.WifiDirectService>(),
-            ));
-    gh.lazySingleton<_i150.ChatMessageLocalDataSource>(
-        () => _i150.ChatMessageLocalDataSource(gh<_i60.Isar>()));
-    gh.factory<_i151.CheckSessionTimeoutUseCase>(
-        () => _i151.CheckSessionTimeoutUseCase(gh<_i146.AuthRepository>()));
-    gh.lazySingleton<_i152.CompleteSessionUseCase>(
-        () => _i152.CompleteSessionUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i123.ConnectEmailProviderUseCase>(
-        () => _i123.ConnectEmailProviderUseCase(gh<_i32.EmailRepository>()));
-    gh.lazySingleton<_i153.ConnectNode>(
-        () => _i153.ConnectNode(gh<_i89.NetworkRepository>()));
-    gh.factory<_i154.ConnectProviderUseCase>(() => _i154.ConnectProviderUseCase(
-          gh<_i97.OAuthRepository>(),
-          gh<_i129.UserProfileRepository>(),
-    gh.lazySingleton<_i155.DashboardLocalDataSource>(
-        () => _i155.DashboardLocalDataSource(gh<_i60.Isar>()));
-    gh.factory<_i156.DisconnectProviderUseCase>(
-        () => _i156.DisconnectProviderUseCase(
-              gh<_i97.OAuthRepository>(),
-              gh<_i129.UserProfileRepository>(),
-    gh.lazySingleton<_i157.DistributedStorageService>(() => _i158.IpfsService(
-          gh<_i59.IpfsDatasource>(),
-          gh<_i38.FilecoinDatasource>(),
-    gh.lazySingleton<_i159.DoctorProfileRepository>(
-        () => _i160.IsarDoctorProfileRepository(gh<_i60.Isar>()));
-    gh.factoryAsync<_i161.DoctorVerificationCubit>(
-        () async => _i161.DoctorVerificationCubit(
-              gh<_i159.DoctorProfileRepository>(),
-              gh<_i103.RatingRepository>(),
-              await getAsync<_i62.LicenseVerifier>(),
-    gh.factory<_i162.EmailCitasBloc>(() => _i162.EmailCitasBloc(
-          gh<_i123.ConnectEmailProviderUseCase>(),
-          gh<_i123.SyncEmailAppointmentsUseCase>(),
-          gh<_i32.EmailRepository>(),
-          gh<_i8.AppointmentRepository>(),
-    gh.factory<_i163.EmailCitasCubit>(() => _i163.EmailCitasCubit(
-    gh.lazySingleton<_i164.EncryptionService>(
-        () => _i164.EncryptionService(gh<_i113.SecureStorageService>()));
-    gh.factory<_i165.FhirSyncCubit>(() => _i165.FhirSyncCubit(
-          gh<_i126.SyncService>(),
-          gh<_i94.NodeDiscoveryService>(),
-    gh.lazySingleton<_i116.FileHealthDataSource>(
-        () => _i116.FileHealthDataSourceImpl(
-    gh.lazySingleton<_i142.WifiDirectService>(() => _i142.WifiDirectService());
-    gh.factory<_i143.AboutCubit>(
-        () => _i143.AboutCubit(gh<_i54.IAboutRepository>()));
-    gh.lazySingleton<_i144.AboutRemoteDataSource>(
-        () => _i144.AboutRemoteDataSource(gh<_i31.Dio>()));
-    gh.lazySingleton<_i145.AllergyLocalDataSource>(
-        () => _i145.AllergyLocalDataSource(gh<_i61.Isar>()));
-    gh.lazySingleton<_i146.AuthLocalDataSource>(
-        () => _i146.AuthLocalDataSource(gh<_i61.Isar>()));
-    gh.lazySingleton<_i147.AuthRepository>(() => _i148.AuthRepositoryImpl(
-          gh<_i146.AuthLocalDataSource>(),
+    gh.lazySingleton<_i140.WifiDirectService>(() => _i140.WifiDirectService());
+    gh.factory<_i141.AboutCubit>(
+        () => _i141.AboutCubit(gh<_i54.IAboutRepository>()));
+    gh.lazySingleton<_i142.AboutRemoteDataSource>(
+        () => _i142.AboutRemoteDataSource(gh<_i31.Dio>()));
+    gh.lazySingleton<_i143.AllergyLocalDataSource>(
+        () => _i143.AllergyLocalDataSource(gh<_i61.Isar>()));
+    gh.lazySingleton<_i144.AuthLocalDataSource>(
+        () => _i144.AuthLocalDataSource(gh<_i61.Isar>()));
+    gh.lazySingleton<_i145.AuthRepository>(() => _i146.AuthRepositoryImpl(
+          gh<_i144.AuthLocalDataSource>(),
           gh<_i114.SecureStorageService>(),
-    gh.lazySingleton<_i149.BleSharingService>(
-        () => _i149.BleSharingService(gh<_i17.BleWrapper>()));
-    gh.lazySingleton<_i150.CancelSharingUseCase>(
-        () => _i150.CancelSharingUseCase(
-              gh<_i149.BleSharingService>(),
+        ));
+    gh.lazySingleton<_i147.BleSharingService>(
+        () => _i147.BleSharingService(gh<_i17.BleWrapper>()));
+    gh.lazySingleton<_i148.CancelSharingUseCase>(
+        () => _i148.CancelSharingUseCase(
+              gh<_i147.BleSharingService>(),
               gh<_i94.NfcSharingService>(),
-              gh<_i142.WifiDirectService>(),
-    gh.lazySingleton<_i151.ChatMessageLocalDataSource>(
-        () => _i151.ChatMessageLocalDataSource(gh<_i61.Isar>()));
-    gh.factory<_i152.CheckSessionTimeoutUseCase>(
-        () => _i152.CheckSessionTimeoutUseCase(gh<_i147.AuthRepository>()));
-    gh.lazySingleton<_i153.CompleteSessionUseCase>(
-        () => _i153.CompleteSessionUseCase(gh<_i82.MeditationRepository>()));
+              gh<_i140.WifiDirectService>(),
+            ));
+    gh.lazySingleton<_i149.ChatMessageLocalDataSource>(
+        () => _i149.ChatMessageLocalDataSource(gh<_i61.Isar>()));
+    gh.factory<_i150.CheckSessionTimeoutUseCase>(
+        () => _i150.CheckSessionTimeoutUseCase(gh<_i145.AuthRepository>()));
+    gh.lazySingleton<_i151.CompleteSessionUseCase>(
+        () => _i151.CompleteSessionUseCase(gh<_i82.MeditationRepository>()));
     gh.factory<_i124.ConnectEmailProviderUseCase>(
         () => _i124.ConnectEmailProviderUseCase(gh<_i32.EmailRepository>()));
-    gh.lazySingleton<_i154.ConnectNode>(
-        () => _i154.ConnectNode(gh<_i90.NetworkRepository>()));
-    gh.factory<_i155.ConnectProviderUseCase>(() => _i155.ConnectProviderUseCase(
+    gh.lazySingleton<_i152.ConnectNode>(
+        () => _i152.ConnectNode(gh<_i90.NetworkRepository>()));
+    gh.factory<_i153.ConnectProviderUseCase>(() => _i153.ConnectProviderUseCase(
           gh<_i98.OAuthRepository>(),
-          gh<_i130.UserProfileRepository>(),
-    gh.lazySingleton<_i156.DashboardLocalDataSource>(
-        () => _i156.DashboardLocalDataSource(gh<_i61.Isar>()));
-    gh.factory<_i157.DisconnectProviderUseCase>(
-        () => _i157.DisconnectProviderUseCase(
+          gh<_i128.UserProfileRepository>(),
+        ));
+    gh.lazySingleton<_i154.DashboardLocalDataSource>(
+        () => _i154.DashboardLocalDataSource(gh<_i61.Isar>()));
+    gh.factory<_i155.DisconnectProviderUseCase>(
+        () => _i155.DisconnectProviderUseCase(
               gh<_i98.OAuthRepository>(),
-              gh<_i130.UserProfileRepository>(),
-    gh.lazySingleton<_i158.DistributedStorageService>(() => _i159.IpfsService(
+              gh<_i128.UserProfileRepository>(),
+            ));
+    gh.lazySingleton<_i156.DistributedStorageService>(() => _i157.IpfsService(
           gh<_i60.IpfsDatasource>(),
-    gh.lazySingleton<_i160.DoctorProfileRepository>(
-        () => _i161.IsarDoctorProfileRepository(gh<_i61.Isar>()));
-    gh.factoryAsync<_i162.DoctorVerificationCubit>(
-        () async => _i162.DoctorVerificationCubit(
-              gh<_i160.DoctorProfileRepository>(),
+          gh<_i38.FilecoinDatasource>(),
+        ));
+    gh.lazySingleton<_i158.DoctorProfileRepository>(
+        () => _i159.IsarDoctorProfileRepository(gh<_i61.Isar>()));
+    gh.factoryAsync<_i160.DoctorVerificationCubit>(
+        () async => _i160.DoctorVerificationCubit(
+              gh<_i158.DoctorProfileRepository>(),
               gh<_i104.RatingRepository>(),
               await getAsync<_i63.LicenseVerifier>(),
-    gh.factory<_i163.EmailCitasBloc>(() => _i163.EmailCitasBloc(
+            ));
+    gh.factory<_i161.EmailCitasBloc>(() => _i161.EmailCitasBloc(
           gh<_i124.ConnectEmailProviderUseCase>(),
           gh<_i124.SyncEmailAppointmentsUseCase>(),
-    gh.factory<_i164.EmailCitasCubit>(() => _i164.EmailCitasCubit(
-    gh.lazySingleton<_i165.EncryptionService>(
-        () => _i165.EncryptionService(gh<_i114.SecureStorageService>()));
-    gh.factory<_i166.FhirSyncCubit>(() => _i166.FhirSyncCubit(
-          gh<_i127.SyncService>(),
-          gh<_i95.NodeDiscoveryService>(),
+          gh<_i32.EmailRepository>(),
+          gh<_i8.AppointmentRepository>(),
+        ));
+    gh.factory<_i162.EmailCitasCubit>(() => _i162.EmailCitasCubit(
+          gh<_i32.EmailRepository>(),
+          gh<_i8.AppointmentRepository>(),
+        ));
+    gh.lazySingleton<_i163.EncryptionService>(
+        () => _i163.EncryptionService(gh<_i114.SecureStorageService>()));
     gh.lazySingleton<_i117.FileHealthDataSource>(
         () => _i117.FileHealthDataSourceImpl(
               gh<_i37.FilePickerService>(),
               gh<_i100.OcrService>(),
             ));
-    gh.lazySingleton<_i166.FileImportDataSource>(
-        () => _i166.FileImportDataSourceImpl(
-    gh.lazySingleton<_i167.FileImportDataSource>(
-        () => _i167.FileImportDataSourceImpl(
+    gh.lazySingleton<_i164.FileImportDataSource>(
+        () => _i164.FileImportDataSourceImpl(
               gh<_i37.FilePickerService>(),
               gh<_i100.OcrService>(),
             ));
-    gh.factory<_i167.GetAboutInfoUseCase>(
-        () => _i167.GetAboutInfoUseCase(gh<_i53.IAboutRepository>()));
-    gh.factory<_i168.GetAllDoctorsUseCase>(
-        () => _i168.GetAllDoctorsUseCase(gh<_i159.DoctorProfileRepository>()));
-    gh.factory<_i169.GetAllVitalSignsUseCase>(
-        () => _i169.GetAllVitalSignsUseCase(gh<_i134.VitalSignRepository>()));
-    gh.factory<_i108.GetAvailableSourcesUseCase>(() =>
-        _i108.GetAvailableSourcesUseCase(gh<_i46.HealthDataImportService>()));
-    gh.factory<_i170.GetChatHistoryUseCase>(
-        () => _i170.GetChatHistoryUseCase(gh<_i137.VoiceChatRepository>()));
-    gh.factory<_i171.GetChatHistoryUseCase>(
-        () => _i171.GetChatHistoryUseCase(gh<_i132.VectorStoreService>()));
-    gh.factory<_i172.GetConnectionsUseCase>(
-        () => _i172.GetConnectionsUseCase(gh<_i97.OAuthRepository>()));
-    gh.factory<_i173.GetCredentialsUseCase>(
-        () => _i173.GetCredentialsUseCase(gh<_i146.AuthRepository>()));
-    gh.factory<_i174.GetDoctorProfileUseCase>(() =>
-        _i174.GetDoctorProfileUseCase(gh<_i159.DoctorProfileRepository>()));
-    gh.lazySingleton<_i175.GetNetworkHealth>(
-        () => _i175.GetNetworkHealth(gh<_i89.NetworkRepository>()));
-    gh.lazySingleton<_i176.GetNodeStats>(
-        () => _i176.GetNodeStats(gh<_i89.NetworkRepository>()));
-    gh.lazySingleton<_i177.GetProgressUseCase>(
-        () => _i177.GetProgressUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i178.GetReportsUseCase>(
-        () => _i178.GetReportsUseCase(gh<_i106.ReportRepository>()));
-    gh.lazySingleton<_i179.GetScriptsUseCase>(
-        () => _i179.GetScriptsUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i180.GetUserProfileUseCase>(
-        () => _i180.GetUserProfileUseCase(gh<_i129.UserProfileRepository>()));
-    gh.lazySingleton<_i181.GovernanceIpfsDatasource>(
-        () => _i181.GovernanceIpfsDatasource(gh<_i59.IpfsDatasource>()));
-    gh.lazySingleton<_i182.GovernanceRepository>(() =>
-        _i183.GovernanceRepositoryImpl(gh<_i181.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i184.HealthDataImportRepository>(
-        () => _i185.HealthDataImportRepositoryImpl(
-              gh<_i116.SensorHealthDataSource>(),
-              gh<_i116.FileHealthDataSource>(),
-            ));
-    gh.lazySingleton<_i186.HealthRecordRepository>(
-        () => _i187.HealthRecordRepositoryImpl(gh<_i60.Isar>()));
-    gh.factory<_i188.ImportCalendarUseCase>(() => _i188.ImportCalendarUseCase(
-          gh<_i21.CalendarImportRepository>(),
-          gh<_i8.AppointmentRepository>(),
-          gh<_i129.UserProfileRepository>(),
-        ));
-    gh.factory<_i108.ImportHealthDataUseCase>(
-        () => _i108.ImportHealthDataUseCase(
-              gh<_i46.HealthDataImportService>(),
-              gh<_i134.VitalSignRepository>(),
-    gh.lazySingleton<_i63.LlmAdapter>(
-      () => _i189.GeminiLlmAdapter(
-        scrubber: gh<_i102.PromptScrubber>(),
-        userProfileRepository: gh<_i129.UserProfileRepository>(),
-    gh.factory<_i168.GetAboutInfoUseCase>(
-        () => _i168.GetAboutInfoUseCase(gh<_i54.IAboutRepository>()));
-    gh.factory<_i169.GetAllDoctorsUseCase>(
-        () => _i169.GetAllDoctorsUseCase(gh<_i160.DoctorProfileRepository>()));
-    gh.factory<_i170.GetAllVitalSignsUseCase>(
-        () => _i170.GetAllVitalSignsUseCase(gh<_i135.VitalSignRepository>()));
+    gh.factory<_i165.GetAboutInfoUseCase>(
+        () => _i165.GetAboutInfoUseCase(gh<_i54.IAboutRepository>()));
+    gh.factory<_i166.GetAllDoctorsUseCase>(
+        () => _i166.GetAllDoctorsUseCase(gh<_i158.DoctorProfileRepository>()));
+    gh.factory<_i167.GetAllVitalSignsUseCase>(
+        () => _i167.GetAllVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
     gh.factory<_i109.GetAvailableSourcesUseCase>(() =>
         _i109.GetAvailableSourcesUseCase(gh<_i47.HealthDataImportService>()));
-        () => _i171.GetChatHistoryUseCase(gh<_i138.VoiceChatRepository>()));
-    gh.factory<_i172.GetChatHistoryUseCase>(
-        () => _i172.GetChatHistoryUseCase(gh<_i133.VectorStoreService>()));
-    gh.factory<_i173.GetConnectionsUseCase>(
-        () => _i173.GetConnectionsUseCase(gh<_i98.OAuthRepository>()));
-    gh.factory<_i174.GetCredentialsUseCase>(
-        () => _i174.GetCredentialsUseCase(gh<_i147.AuthRepository>()));
-    gh.factory<_i175.GetDoctorProfileUseCase>(() =>
-        _i175.GetDoctorProfileUseCase(gh<_i160.DoctorProfileRepository>()));
-    gh.lazySingleton<_i176.GetNetworkHealth>(
-        () => _i176.GetNetworkHealth(gh<_i90.NetworkRepository>()));
-    gh.lazySingleton<_i177.GetNodeStats>(
-        () => _i177.GetNodeStats(gh<_i90.NetworkRepository>()));
-    gh.lazySingleton<_i178.GetProgressUseCase>(
-        () => _i178.GetProgressUseCase(gh<_i82.MeditationRepository>()));
-    gh.factory<_i179.GetReportsUseCase>(
-        () => _i179.GetReportsUseCase(gh<_i107.ReportRepository>()));
-    gh.lazySingleton<_i180.GetScriptsUseCase>(
-        () => _i180.GetScriptsUseCase(gh<_i82.MeditationRepository>()));
-    gh.factory<_i181.GetUserProfileUseCase>(
-        () => _i181.GetUserProfileUseCase(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i182.GovernanceIpfsDatasource>(
-        () => _i182.GovernanceIpfsDatasource(gh<_i60.IpfsDatasource>()));
-    gh.lazySingleton<_i183.GovernanceRepository>(() =>
-        _i184.GovernanceRepositoryImpl(gh<_i182.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i185.HealthDataImportRepository>(
-        () => _i186.HealthDataImportRepositoryImpl(
+    gh.factory<_i168.GetChatHistoryUseCase>(
+        () => _i168.GetChatHistoryUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i169.GetChatHistoryUseCase>(
+        () => _i169.GetChatHistoryUseCase(gh<_i131.VectorStoreService>()));
+    gh.factory<_i170.GetConnectionsUseCase>(
+        () => _i170.GetConnectionsUseCase(gh<_i98.OAuthRepository>()));
+    gh.factory<_i171.GetCredentialsUseCase>(
+        () => _i171.GetCredentialsUseCase(gh<_i145.AuthRepository>()));
+    gh.factory<_i172.GetDoctorProfileUseCase>(() =>
+        _i172.GetDoctorProfileUseCase(gh<_i158.DoctorProfileRepository>()));
+    gh.lazySingleton<_i173.GetNetworkHealth>(
+        () => _i173.GetNetworkHealth(gh<_i90.NetworkRepository>()));
+    gh.lazySingleton<_i174.GetNodeStats>(
+        () => _i174.GetNodeStats(gh<_i90.NetworkRepository>()));
+    gh.lazySingleton<_i175.GetProgressUseCase>(
+        () => _i175.GetProgressUseCase(gh<_i82.MeditationRepository>()));
+    gh.factory<_i176.GetReportsUseCase>(
+        () => _i176.GetReportsUseCase(gh<_i107.ReportRepository>()));
+    gh.lazySingleton<_i177.GetScriptsUseCase>(
+        () => _i177.GetScriptsUseCase(gh<_i82.MeditationRepository>()));
+    gh.factory<_i178.GetUserProfileUseCase>(
+        () => _i178.GetUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i179.GovernanceIpfsDatasource>(
+        () => _i179.GovernanceIpfsDatasource(gh<_i60.IpfsDatasource>()));
+    gh.lazySingleton<_i180.GovernanceRepository>(() =>
+        _i181.GovernanceRepositoryImpl(gh<_i179.GovernanceIpfsDatasource>()));
+    gh.lazySingleton<_i182.HealthDataImportRepository>(
+        () => _i183.HealthDataImportRepositoryImpl(
               gh<_i117.SensorHealthDataSource>(),
               gh<_i117.FileHealthDataSource>(),
-    gh.lazySingleton<_i187.HealthRecordRepository>(
-        () => _i188.HealthRecordRepositoryImpl(gh<_i61.Isar>()));
-    gh.factory<_i189.ImportCalendarUseCase>(() => _i189.ImportCalendarUseCase(
-          gh<_i130.UserProfileRepository>(),
+            ));
+    gh.lazySingleton<_i184.HealthRecordRepository>(
+        () => _i185.HealthRecordRepositoryImpl(gh<_i61.Isar>()));
+    gh.factory<_i186.ImportCalendarUseCase>(() => _i186.ImportCalendarUseCase(
+          gh<_i21.CalendarImportRepository>(),
+          gh<_i8.AppointmentRepository>(),
+          gh<_i128.UserProfileRepository>(),
+        ));
     gh.factory<_i109.ImportHealthDataUseCase>(
         () => _i109.ImportHealthDataUseCase(
               gh<_i47.HealthDataImportService>(),
-              gh<_i135.VitalSignRepository>(),
-    gh.factory<_i64.LlmAdapter>(
-      () => _i190.MockLlmAdapter(gh<_i103.PromptScrubber>()),
-      instanceName: 'mock',
-    );
+              gh<_i133.VitalSignRepository>(),
+            ));
     gh.lazySingleton<_i64.LlmAdapter>(
-      () => _i191.GeminiLlmAdapter(
+      () => _i187.GeminiLlmAdapter(
         scrubber: gh<_i103.PromptScrubber>(),
-        userProfileRepository: gh<_i130.UserProfileRepository>(),
+        userProfileRepository: gh<_i128.UserProfileRepository>(),
         modelWrapper: gh<_i42.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
     );
-    gh.factory<_i63.LlmAdapter>(
-      () => _i190.MockLlmAdapter(gh<_i102.PromptScrubber>()),
+    gh.factory<_i64.LlmAdapter>(
+      () => _i188.MockLlmAdapter(gh<_i103.PromptScrubber>()),
       instanceName: 'mock',
     );
-    gh.lazySingleton<_i191.LlmAdapterFactory>(
-        () => _i191.LlmAdapterFactory(gh<_i118.SettingsRepository>()));
-    gh.lazySingleton<_i192.LlmService>(() => _i193.GemmaLlmService(
-          gh<_i132.VectorStoreService>(),
-          gh<_i129.UserProfileRepository>(),
-          gh<_i63.LlmAdapter>(instanceName: 'gemma'),
+    gh.lazySingleton<_i189.LlmAdapterFactory>(
+        () => _i189.LlmAdapterFactory(gh<_i119.SettingsRepository>()));
+    gh.lazySingleton<_i190.LlmService>(() => _i191.GemmaLlmService(
+          gh<_i131.VectorStoreService>(),
+          gh<_i128.UserProfileRepository>(),
+          gh<_i64.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i194.LlmSettingsCubit>(() => _i194.LlmSettingsCubit(
-          gh<_i118.SettingsRepository>(),
-          gh<_i30.DeviceCapabilityService>(),
-    gh.factory<_i195.LoginUseCase>(() => _i195.LoginUseCase(
-          gh<_i146.AuthRepository>(),
-          gh<_i164.EncryptionService>(),
+    gh.factory<_i192.LlmSettingsCubit>(() => _i192.LlmSettingsCubit(
+          gh<_i119.SettingsRepository>(),
+          gh<_i29.DeviceCapabilityService>(),
+          gh<_i64.LlmAdapter>(instanceName: 'gemma'),
+        ));
+    gh.factory<_i193.LoginUseCase>(() => _i193.LoginUseCase(
+          gh<_i145.AuthRepository>(),
+          gh<_i163.EncryptionService>(),
           gh<_i16.BiometricService>(),
-    gh.factory<_i196.LogoutUseCase>(
-        () => _i196.LogoutUseCase(gh<_i146.AuthRepository>()));
-    gh.lazySingleton<_i197.MedicalResearchService>(
-        () => _i197.MedicalResearchService(
-              gh<_i76.MedicalWebSearchService>(),
-              gh<_i72.MedicalScraperService>(),
+        ));
+    gh.factory<_i194.LogoutUseCase>(
+        () => _i194.LogoutUseCase(gh<_i145.AuthRepository>()));
+    gh.lazySingleton<_i195.MedicalResearchService>(
+        () => _i195.MedicalResearchService(
+              gh<_i77.MedicalWebSearchService>(),
+              gh<_i73.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i198.MedicationRepository>(
-        () => _i199.IsarMedicationRepository(
-              gh<_i60.Isar>(),
-              gh<_i100.PharmacyApiService>(),
-    gh.factory<_i200.MedicationsCubit>(
-        () => _i200.MedicationsCubit(gh<_i198.MedicationRepository>()));
-    gh.factory<_i201.MeditationCubit>(() => _i201.MeditationCubit(
-          gh<_i105.RecommendScriptUseCase>(),
-          gh<_i122.StartSessionUseCase>(),
-          gh<_i152.CompleteSessionUseCase>(),
-          gh<_i177.GetProgressUseCase>(),
+    gh.lazySingleton<_i196.MedicationRepository>(
+        () => _i197.IsarMedicationRepository(
+              gh<_i61.Isar>(),
+              gh<_i101.PharmacyApiService>(),
+            ));
+    gh.factory<_i198.MedicationsCubit>(
+        () => _i198.MedicationsCubit(gh<_i196.MedicationRepository>()));
+    gh.factory<_i199.MeditationCubit>(() => _i199.MeditationCubit(
+          gh<_i106.RecommendScriptUseCase>(),
+          gh<_i123.StartSessionUseCase>(),
+          gh<_i151.CompleteSessionUseCase>(),
+          gh<_i175.GetProgressUseCase>(),
           gh<_i12.AudioService>(),
-    gh.factory<_i202.NetworkCubit>(() => _i202.NetworkCubit(
-          gh<_i87.NetworkPeerRepository>(),
-          gh<_i86.NetworkP2PApi>(),
-    gh.factory<_i203.NetworkHealthCubit>(() => _i203.NetworkHealthCubit(
-          gh<_i175.GetNetworkHealth>(),
-          gh<_i153.ConnectNode>(),
-          gh<_i89.NetworkRepository>(),
-    gh.lazySingleton<_i204.OnboardingRepository>(() =>
-        _i205.OnboardingRepositoryImpl(gh<_i129.UserProfileRepository>()));
-    gh.lazySingleton<_i206.ReportGenerationService>(
-        () => _i207.GemmaReportGenerationService(
-              gh<_i63.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i132.VectorStoreService>(),
-              gh<_i129.UserProfileRepository>(),
-              gh<_i102.PromptScrubber>(),
-    gh.factory<_i208.SaveCredentialsUseCase>(
-        () => _i208.SaveCredentialsUseCase(gh<_i146.AuthRepository>()));
-    gh.factory<_i209.SaveMedicationUseCase>(
-        () => _i209.SaveMedicationUseCase(gh<_i198.MedicationRepository>()));
-    gh.factory<_i210.SaveRecordUseCase>(
-        () => _i210.SaveRecordUseCase(gh<_i186.HealthRecordRepository>()));
-    gh.factory<_i211.SaveUserProfileUseCase>(
-        () => _i211.SaveUserProfileUseCase(gh<_i129.UserProfileRepository>()));
-    gh.factory<_i212.SaveVitalSignsUseCase>(
-        () => _i212.SaveVitalSignsUseCase(gh<_i134.VitalSignRepository>()));
-    gh.factory<_i213.SecondOpinionCubit>(
-        () => _i213.SecondOpinionCubit(gh<_i111.SecondOpinionRepository>()));
-    gh.factory<_i214.SendMessageUseCase>(
-        () => _i214.SendMessageUseCase(gh<_i137.VoiceChatRepository>()));
-    gh.factory<_i215.SetPinUseCase>(() => _i215.SetPinUseCase(
-    gh.lazySingleton<_i216.SmartSearchUseCase>(
-        () => _i216.SmartSearchUseCase(gh<_i132.VectorStoreService>()));
-    gh.lazySingleton<_i217.StartListeningUseCase>(
-        () => _i217.StartListeningUseCase(
-              gh<_i148.BleSharingService>(),
-              gh<_i93.NfcSharingService>(),
-              gh<_i141.WifiDirectService>(),
-    gh.lazySingleton<_i218.StartSharingUseCase>(() => _i218.StartSharingUseCase(
-          gh<_i148.BleSharingService>(),
-          gh<_i93.NfcSharingService>(),
-          gh<_i141.WifiDirectService>(),
-    gh.factory<_i219.SyncCubit>(() => _i219.SyncCubit(
-          gh<_i68.SyncService>(),
+        ));
+    gh.factory<_i200.NetworkCubit>(() => _i200.NetworkCubit(
+          gh<_i88.NetworkPeerRepository>(),
+          gh<_i87.NetworkP2PApi>(),
+        ));
+    gh.factory<_i201.NetworkHealthCubit>(() => _i201.NetworkHealthCubit(
+          gh<_i173.GetNetworkHealth>(),
+          gh<_i152.ConnectNode>(),
+          gh<_i90.NetworkRepository>(),
+        ));
+    gh.lazySingleton<_i202.OnboardingRepository>(() =>
+        _i203.OnboardingRepositoryImpl(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i204.ReportGenerationService>(
+        () => _i205.GemmaReportGenerationService(
+              gh<_i64.LlmAdapter>(instanceName: 'gemma'),
+              gh<_i131.VectorStoreService>(),
+              gh<_i128.UserProfileRepository>(),
+              gh<_i103.PromptScrubber>(),
+            ));
+    gh.factory<_i206.SaveCredentialsUseCase>(
+        () => _i206.SaveCredentialsUseCase(gh<_i145.AuthRepository>()));
+    gh.factory<_i207.SaveMedicationUseCase>(
+        () => _i207.SaveMedicationUseCase(gh<_i196.MedicationRepository>()));
+    gh.factory<_i208.SaveRecordUseCase>(
+        () => _i208.SaveRecordUseCase(gh<_i184.HealthRecordRepository>()));
+    gh.factory<_i209.SaveUserProfileUseCase>(
+        () => _i209.SaveUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.factory<_i210.SaveVitalSignsUseCase>(
+        () => _i210.SaveVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i211.SecondOpinionCubit>(
+        () => _i211.SecondOpinionCubit(gh<_i112.SecondOpinionRepository>()));
+    gh.factory<_i212.SendMessageUseCase>(
+        () => _i212.SendMessageUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i213.SetPinUseCase>(() => _i213.SetPinUseCase(
+          gh<_i145.AuthRepository>(),
+          gh<_i163.EncryptionService>(),
+        ));
+    gh.lazySingleton<_i214.SmartSearchUseCase>(
+        () => _i214.SmartSearchUseCase(gh<_i131.VectorStoreService>()));
+    gh.lazySingleton<_i215.StartListeningUseCase>(
+        () => _i215.StartListeningUseCase(
+              gh<_i147.BleSharingService>(),
+              gh<_i94.NfcSharingService>(),
+              gh<_i140.WifiDirectService>(),
+            ));
+    gh.lazySingleton<_i216.StartSharingUseCase>(() => _i216.StartSharingUseCase(
+          gh<_i147.BleSharingService>(),
+          gh<_i94.NfcSharingService>(),
+          gh<_i140.WifiDirectService>(),
+        ));
+    gh.factory<_i217.SyncCubit>(() => _i217.SyncCubit(
+          gh<_i69.SyncService>(),
+          gh<_i131.VectorStoreService>(),
+        ));
+    gh.lazySingleton<_i218.SyncService>(() => _i219.SyncServiceImpl(
+          gh<_i125.SyncRepository>(),
+          gh<_i69.SyncService>(),
+        ));
     gh.factory<_i220.UserProfileCubit>(
-        () => _i220.UserProfileCubit(gh<_i129.UserProfileRepository>()));
+        () => _i220.UserProfileCubit(gh<_i128.UserProfileRepository>()));
     gh.factory<_i221.ValidateSessionUseCase>(
-        () => _i221.ValidateSessionUseCase(gh<_i146.AuthRepository>()));
+        () => _i221.ValidateSessionUseCase(gh<_i145.AuthRepository>()));
     gh.factory<_i222.VitalSignBloc>(
-        () => _i222.VitalSignBloc(gh<_i134.VitalSignRepository>()));
+        () => _i222.VitalSignBloc(gh<_i133.VitalSignRepository>()));
     gh.factory<_i223.VoiceChatCubit>(() => _i223.VoiceChatCubit(
-          gh<_i214.SendMessageUseCase>(),
-          gh<_i170.GetChatHistoryUseCase>(),
-          gh<_i137.VoiceChatRepository>(),
+          gh<_i212.SendMessageUseCase>(),
+          gh<_i168.GetChatHistoryUseCase>(),
+          gh<_i136.VoiceChatRepository>(),
+          gh<_i12.AudioService>(),
+        ));
     gh.factory<_i224.VouchCubit>(
-        () => _i224.VouchCubit(gh<_i139.VouchRepository>()));
+        () => _i224.VouchCubit(gh<_i138.VouchRepository>()));
     gh.lazySingleton<_i225.AllergyRepository>(() => _i226.AllergyRepositoryImpl(
-          gh<_i144.AllergyLocalDataSource>(),
-          encryptionService: gh<_i164.EncryptionService>(),
+          gh<_i143.AllergyLocalDataSource>(),
+          encryptionService: gh<_i163.EncryptionService>(),
+        ));
     gh.factory<_i227.AuthCubit>(() => _i227.AuthCubit(
-          gh<_i195.LoginUseCase>(),
-          gh<_i196.LogoutUseCase>(),
+          gh<_i145.AuthRepository>(),
+          gh<_i16.BiometricService>(),
+          gh<_i193.LoginUseCase>(),
+          gh<_i194.LogoutUseCase>(),
           gh<_i221.ValidateSessionUseCase>(),
-          gh<_i215.SetPinUseCase>(),
-          gh<_i151.CheckSessionTimeoutUseCase>(),
+          gh<_i213.SetPinUseCase>(),
+          gh<_i150.CheckSessionTimeoutUseCase>(),
+        ));
     gh.lazySingleton<_i228.AuthService>(
-        () => _i228.AuthServiceImpl(gh<_i164.EncryptionService>()));
+        () => _i228.AuthServiceImpl(gh<_i163.EncryptionService>()));
     gh.lazySingleton<_i229.BadgeCalculator>(() => _i229.BadgeCalculator(
-          gh<_i159.DoctorProfileRepository>(),
-          gh<_i103.RatingRepository>(),
-          gh<_i139.VouchRepository>(),
+          gh<_i158.DoctorProfileRepository>(),
+          gh<_i104.RatingRepository>(),
+          gh<_i138.VouchRepository>(),
+        ));
     gh.factory<_i230.BadgeCubit>(
         () => _i230.BadgeCubit(gh<_i229.BadgeCalculator>()));
     gh.factory<_i231.CalendarImportCubit>(() => _i231.CalendarImportCubit(
           gh<_i21.CalendarImportRepository>(),
-          gh<_i188.ImportCalendarUseCase>(),
+          gh<_i186.ImportCalendarUseCase>(),
+        ));
     gh.factory<_i232.CompleteOnboardingUseCase>(() =>
-        _i232.CompleteOnboardingUseCase(gh<_i204.OnboardingRepository>()));
+        _i232.CompleteOnboardingUseCase(gh<_i202.OnboardingRepository>()));
     gh.lazySingleton<_i233.DashboardRepository>(
         () => _i234.DashboardRepositoryImpl(
               gh<_i27.DashboardRemoteDataSource>(),
-              gh<_i134.VitalSignRepository>(),
-              gh<_i198.MedicationRepository>(),
-              gh<_i106.ReportRepository>(),
+              gh<_i133.VitalSignRepository>(),
+              gh<_i196.MedicationRepository>(),
+              gh<_i107.ReportRepository>(),
+            ));
     gh.lazySingleton<_i235.DataSourceRepository>(
         () => _i236.DataSourceRepositoryImpl(
-              gh<_i115.SensorApiDataSource>(),
-              gh<_i166.FileImportDataSource>(),
-              gh<_i45.HealthConnectDataSource>(),
-    gh.lazySingleton<_i237.DistributedCacheUsecase>(() =>
-        _i237.DistributedCacheUsecase(gh<_i157.DistributedStorageService>()));
-    gh.factory<_i238.EpsConnectionBloc>(() => _i238.EpsConnectionBloc(
-          gh<_i172.GetConnectionsUseCase>(),
-          gh<_i154.ConnectProviderUseCase>(),
-          gh<_i156.DisconnectProviderUseCase>(),
-    gh.factory<_i239.EpsConnectionCubit>(() => _i239.EpsConnectionCubit(
-    gh.factory<_i240.GetAllMedicationsUseCase>(
-        () => _i240.GetAllMedicationsUseCase(gh<_i198.MedicationRepository>()));
-    gh.factory<_i241.GetAllRecordsUseCase>(
-        () => _i241.GetAllRecordsUseCase(gh<_i186.HealthRecordRepository>()));
-    gh.factory<_i242.GetAllergiesUseCase>(
-        () => _i242.GetAllergiesUseCase(gh<_i225.AllergyRepository>()));
-    gh.factory<_i243.GetDashboardStatsUseCase>(
-        () => _i243.GetDashboardStatsUseCase(gh<_i233.DashboardRepository>()));
-    gh.factory<_i244.GetOnboardingProfileUseCase>(() =>
-        _i244.GetOnboardingProfileUseCase(gh<_i204.OnboardingRepository>()));
-    gh.factory<_i245.GetRecentActivityUseCase>(
-        () => _i245.GetRecentActivityUseCase(gh<_i233.DashboardRepository>()));
-    gh.factory<_i246.HealthImportBloc>(() => _i246.HealthImportBloc(
-          gh<_i108.GetAvailableSourcesUseCase>(),
-          gh<_i108.RequestHealthAuthUseCase>(),
-          gh<_i108.ImportHealthDataUseCase>(),
-    gh.factory<_i247.HealthImportCubit>(() => _i247.HealthImportCubit(
-    gh.factory<_i248.HealthRecordCubit>(() => _i248.HealthRecordCubit(
-          gh<_i186.HealthRecordRepository>(),
-          gh<_i37.FilePickerService>(),
-          gh<_i55.ImagePickerService>(),
-          gh<_i99.OcrService>(),
-    gh.lazySingleton<_i249.HomeRepository>(() => _i250.HomeRepositoryImpl(
-          gh<_i134.VitalSignRepository>(),
-          gh<_i8.AppointmentRepository>(),
-          gh<_i198.MedicationRepository>(),
-          gh<_i50.HomeLocalDataSource>(),
-          gh<_i52.HomeRemoteDataSource>(),
-          gh<_i49.HealthSummaryDatasource>(),
-    gh.lazySingleton<_i192.LlmService>(
-      () => _i251.RagLlmService(
-        gh<_i132.VectorStoreService>(),
-        gh<_i197.MedicalResearchService>(),
-        gh<_i129.UserProfileRepository>(),
-        gh<_i63.LlmAdapter>(instanceName: 'gemma'),
-      ),
-      instanceName: 'rag',
-    gh.lazySingleton<_i252.MedicalResearchRepository>(
-        () => _i253.MedicalResearchRepositoryImpl(
-              gh<_i197.MedicalResearchService>(),
-    gh.factory<_i254.MedicationBloc>(
-        () => _i254.MedicationBloc(gh<_i198.MedicationRepository>()));
-    gh.factory<_i255.OnboardingCubit>(
-        () => _i255.OnboardingCubit(gh<_i204.OnboardingRepository>()));
-    gh.lazySingleton<_i256.PatientContextIndexer>(
-      () => _i256.PatientContextIndexer(
-        gh<_i60.Isar>(),
-        gh<_i186.HealthRecordRepository>(),
-        gh<_i198.MedicationRepository>(),
-        gh<_i225.AllergyRepository>(),
-        gh<_i134.VitalSignRepository>(),
-    gh.lazySingleton<_i192.LlmAdapterFactory>(
-        () => _i192.LlmAdapterFactory(gh<_i119.SettingsRepository>()));
-    gh.lazySingleton<_i193.LlmService>(() => _i194.GemmaLlmService(
-          gh<_i133.VectorStoreService>(),
-          gh<_i130.UserProfileRepository>(),
-          gh<_i64.LlmAdapter>(instanceName: 'gemma'),
-    gh.factory<_i195.LlmSettingsCubit>(() => _i195.LlmSettingsCubit(
-          gh<_i119.SettingsRepository>(),
-    gh.factory<_i196.LoginUseCase>(() => _i196.LoginUseCase(
-          gh<_i147.AuthRepository>(),
-          gh<_i165.EncryptionService>(),
-    gh.factory<_i197.LogoutUseCase>(
-        () => _i197.LogoutUseCase(gh<_i147.AuthRepository>()));
-    gh.lazySingleton<_i198.MedicalResearchService>(
-        () => _i198.MedicalResearchService(
-              gh<_i77.MedicalWebSearchService>(),
-              gh<_i73.MedicalScraperService>(),
-    gh.lazySingleton<_i199.MedicationRepository>(
-        () => _i200.IsarMedicationRepository(
-              gh<_i61.Isar>(),
-              gh<_i101.PharmacyApiService>(),
-    gh.factory<_i201.MedicationsCubit>(
-        () => _i201.MedicationsCubit(gh<_i199.MedicationRepository>()));
-    gh.factory<_i202.MeditationCubit>(() => _i202.MeditationCubit(
-          gh<_i106.RecommendScriptUseCase>(),
-          gh<_i123.StartSessionUseCase>(),
-          gh<_i153.CompleteSessionUseCase>(),
-          gh<_i178.GetProgressUseCase>(),
-    gh.factory<_i203.NetworkCubit>(() => _i203.NetworkCubit(
-          gh<_i88.NetworkPeerRepository>(),
-          gh<_i87.NetworkP2PApi>(),
-    gh.factory<_i204.NetworkHealthCubit>(() => _i204.NetworkHealthCubit(
-          gh<_i176.GetNetworkHealth>(),
-          gh<_i154.ConnectNode>(),
-          gh<_i90.NetworkRepository>(),
-    gh.lazySingleton<_i205.OnboardingRepository>(() =>
-        _i206.OnboardingRepositoryImpl(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i207.ReportGenerationService>(
-        () => _i208.GemmaReportGenerationService(
-              gh<_i64.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i133.VectorStoreService>(),
-              gh<_i130.UserProfileRepository>(),
-              gh<_i103.PromptScrubber>(),
-    gh.factory<_i209.SaveCredentialsUseCase>(
-        () => _i209.SaveCredentialsUseCase(gh<_i147.AuthRepository>()));
-    gh.factory<_i210.SaveMedicationUseCase>(
-        () => _i210.SaveMedicationUseCase(gh<_i199.MedicationRepository>()));
-    gh.factory<_i211.SaveRecordUseCase>(
-        () => _i211.SaveRecordUseCase(gh<_i187.HealthRecordRepository>()));
-    gh.factory<_i212.SaveUserProfileUseCase>(
-        () => _i212.SaveUserProfileUseCase(gh<_i130.UserProfileRepository>()));
-    gh.factory<_i213.SaveVitalSignsUseCase>(
-        () => _i213.SaveVitalSignsUseCase(gh<_i135.VitalSignRepository>()));
-    gh.factory<_i214.SecondOpinionCubit>(
-        () => _i214.SecondOpinionCubit(gh<_i112.SecondOpinionRepository>()));
-    gh.factory<_i215.SendMessageUseCase>(
-        () => _i215.SendMessageUseCase(gh<_i138.VoiceChatRepository>()));
-    gh.factory<_i216.SetPinUseCase>(() => _i216.SetPinUseCase(
-    gh.lazySingleton<_i217.SmartSearchUseCase>(
-        () => _i217.SmartSearchUseCase(gh<_i133.VectorStoreService>()));
-    gh.lazySingleton<_i218.StartListeningUseCase>(
-        () => _i218.StartListeningUseCase(
-              gh<_i149.BleSharingService>(),
-              gh<_i94.NfcSharingService>(),
-              gh<_i142.WifiDirectService>(),
-    gh.lazySingleton<_i219.StartSharingUseCase>(() => _i219.StartSharingUseCase(
-          gh<_i149.BleSharingService>(),
-          gh<_i94.NfcSharingService>(),
-          gh<_i142.WifiDirectService>(),
-    gh.factory<_i220.SyncCubit>(() => _i220.SyncCubit(
-          gh<_i69.SyncService>(),
-    gh.factory<_i221.UserProfileCubit>(
-        () => _i221.UserProfileCubit(gh<_i130.UserProfileRepository>()));
-    gh.factory<_i222.ValidateSessionUseCase>(
-        () => _i222.ValidateSessionUseCase(gh<_i147.AuthRepository>()));
-    gh.factory<_i223.VitalSignBloc>(
-        () => _i223.VitalSignBloc(gh<_i135.VitalSignRepository>()));
-    gh.factory<_i224.VoiceChatCubit>(() => _i224.VoiceChatCubit(
-          gh<_i215.SendMessageUseCase>(),
-          gh<_i171.GetChatHistoryUseCase>(),
-          gh<_i138.VoiceChatRepository>(),
-    gh.factory<_i225.VouchCubit>(
-        () => _i225.VouchCubit(gh<_i140.VouchRepository>()));
-    gh.lazySingleton<_i226.AllergyRepository>(() => _i227.AllergyRepositoryImpl(
-          gh<_i145.AllergyLocalDataSource>(),
-          _encryptionService: gh<_i165.EncryptionService>(),
-    gh.factory<_i228.AuthCubit>(() => _i228.AuthCubit(
-          gh<_i196.LoginUseCase>(),
-          gh<_i197.LogoutUseCase>(),
-          gh<_i222.ValidateSessionUseCase>(),
-          gh<_i216.SetPinUseCase>(),
-          gh<_i152.CheckSessionTimeoutUseCase>(),
-    gh.lazySingleton<_i229.AuthService>(
-        () => _i229.AuthServiceImpl(gh<_i165.EncryptionService>()));
-    gh.lazySingleton<_i230.BadgeCalculator>(() => _i230.BadgeCalculator(
-          gh<_i160.DoctorProfileRepository>(),
-          gh<_i104.RatingRepository>(),
-          gh<_i140.VouchRepository>(),
-    gh.factory<_i231.BadgeCubit>(
-        () => _i231.BadgeCubit(gh<_i230.BadgeCalculator>()));
-    gh.factory<_i232.CalendarImportCubit>(() => _i232.CalendarImportCubit(
-          gh<_i189.ImportCalendarUseCase>(),
-    gh.factory<_i233.CompleteOnboardingUseCase>(() =>
-        _i233.CompleteOnboardingUseCase(gh<_i205.OnboardingRepository>()));
-    gh.lazySingleton<_i234.DashboardRepository>(
-        () => _i235.DashboardRepositoryImpl(
-              gh<_i135.VitalSignRepository>(),
-              gh<_i199.MedicationRepository>(),
-              gh<_i107.ReportRepository>(),
-    gh.lazySingleton<_i236.DataSourceRepository>(
-        () => _i237.DataSourceRepositoryImpl(
               gh<_i116.SensorApiDataSource>(),
-              gh<_i167.FileImportDataSource>(),
+              gh<_i164.FileImportDataSource>(),
               gh<_i46.HealthConnectDataSource>(),
-    gh.lazySingleton<_i238.DistributedCacheUsecase>(() =>
-        _i238.DistributedCacheUsecase(gh<_i158.DistributedStorageService>()));
-    gh.factory<_i239.EpsConnectionBloc>(() => _i239.EpsConnectionBloc(
-          gh<_i173.GetConnectionsUseCase>(),
-          gh<_i155.ConnectProviderUseCase>(),
-          gh<_i157.DisconnectProviderUseCase>(),
-    gh.factory<_i240.EpsConnectionCubit>(() => _i240.EpsConnectionCubit(
+            ));
+    gh.lazySingleton<_i237.DistributedCacheUsecase>(() =>
+        _i237.DistributedCacheUsecase(gh<_i156.DistributedStorageService>()));
+    gh.factory<_i238.EpsConnectionBloc>(() => _i238.EpsConnectionBloc(
+          gh<_i170.GetConnectionsUseCase>(),
+          gh<_i153.ConnectProviderUseCase>(),
+          gh<_i155.DisconnectProviderUseCase>(),
+        ));
+    gh.factory<_i239.EpsConnectionCubit>(() => _i239.EpsConnectionCubit(
+          gh<_i170.GetConnectionsUseCase>(),
+          gh<_i153.ConnectProviderUseCase>(),
+          gh<_i155.DisconnectProviderUseCase>(),
+        ));
+    gh.factory<_i240.FhirSyncCubit>(() => _i240.FhirSyncCubit(
+          gh<_i218.SyncService>(),
+          gh<_i95.NodeDiscoveryService>(),
+        ));
     gh.factory<_i241.GetAllMedicationsUseCase>(
-        () => _i241.GetAllMedicationsUseCase(gh<_i199.MedicationRepository>()));
+        () => _i241.GetAllMedicationsUseCase(gh<_i196.MedicationRepository>()));
     gh.factory<_i242.GetAllRecordsUseCase>(
-        () => _i242.GetAllRecordsUseCase(gh<_i187.HealthRecordRepository>()));
+        () => _i242.GetAllRecordsUseCase(gh<_i184.HealthRecordRepository>()));
     gh.factory<_i243.GetAllergiesUseCase>(
-        () => _i243.GetAllergiesUseCase(gh<_i226.AllergyRepository>()));
+        () => _i243.GetAllergiesUseCase(gh<_i225.AllergyRepository>()));
     gh.factory<_i244.GetDashboardStatsUseCase>(
-        () => _i244.GetDashboardStatsUseCase(gh<_i234.DashboardRepository>()));
+        () => _i244.GetDashboardStatsUseCase(gh<_i233.DashboardRepository>()));
     gh.factory<_i245.GetOnboardingProfileUseCase>(() =>
-        _i245.GetOnboardingProfileUseCase(gh<_i205.OnboardingRepository>()));
+        _i245.GetOnboardingProfileUseCase(gh<_i202.OnboardingRepository>()));
     gh.factory<_i246.GetRecentActivityUseCase>(
-        () => _i246.GetRecentActivityUseCase(gh<_i234.DashboardRepository>()));
+        () => _i246.GetRecentActivityUseCase(gh<_i233.DashboardRepository>()));
     gh.factory<_i247.HealthImportBloc>(() => _i247.HealthImportBloc(
           gh<_i109.GetAvailableSourcesUseCase>(),
           gh<_i109.RequestHealthAuthUseCase>(),
           gh<_i109.ImportHealthDataUseCase>(),
+        ));
     gh.factory<_i248.HealthImportCubit>(() => _i248.HealthImportCubit(
+          gh<_i109.GetAvailableSourcesUseCase>(),
+          gh<_i109.RequestHealthAuthUseCase>(),
+          gh<_i109.ImportHealthDataUseCase>(),
+        ));
     gh.factory<_i249.HealthRecordCubit>(() => _i249.HealthRecordCubit(
-          gh<_i187.HealthRecordRepository>(),
+          gh<_i184.HealthRecordRepository>(),
+          gh<_i37.FilePickerService>(),
           gh<_i56.ImagePickerService>(),
           gh<_i100.OcrService>(),
+          gh<_i131.VectorStoreService>(),
+        ));
     gh.lazySingleton<_i250.HomeRepository>(() => _i251.HomeRepositoryImpl(
-          gh<_i135.VitalSignRepository>(),
-          gh<_i199.MedicationRepository>(),
+          gh<_i133.VitalSignRepository>(),
+          gh<_i8.AppointmentRepository>(),
+          gh<_i196.MedicationRepository>(),
           gh<_i51.HomeLocalDataSource>(),
           gh<_i53.HomeRemoteDataSource>(),
           gh<_i50.HealthSummaryDatasource>(),
-    gh.lazySingleton<_i193.LlmService>(
+        ));
+    gh.lazySingleton<_i190.LlmService>(
       () => _i252.RagLlmService(
-        gh<_i133.VectorStoreService>(),
-        gh<_i198.MedicalResearchService>(),
-        gh<_i130.UserProfileRepository>(),
+        gh<_i131.VectorStoreService>(),
+        gh<_i195.MedicalResearchService>(),
+        gh<_i128.UserProfileRepository>(),
         gh<_i64.LlmAdapter>(instanceName: 'gemma'),
+      ),
+      instanceName: 'rag',
+    );
     gh.lazySingleton<_i253.MedicalResearchRepository>(
         () => _i254.MedicalResearchRepositoryImpl(
-              gh<_i198.MedicalResearchService>(),
+              gh<_i195.MedicalResearchService>(),
+              gh<_i61.Isar>(),
+            ));
     gh.factory<_i255.MedicationBloc>(
-        () => _i255.MedicationBloc(gh<_i199.MedicationRepository>()));
+        () => _i255.MedicationBloc(gh<_i196.MedicationRepository>()));
     gh.factory<_i256.OnboardingCubit>(
-        () => _i256.OnboardingCubit(gh<_i205.OnboardingRepository>()));
+        () => _i256.OnboardingCubit(gh<_i202.OnboardingRepository>()));
     gh.lazySingleton<_i257.PatientContextIndexer>(
       () => _i257.PatientContextIndexer(
         gh<_i61.Isar>(),
-        gh<_i187.HealthRecordRepository>(),
-        gh<_i199.MedicationRepository>(),
-        gh<_i226.AllergyRepository>(),
-        gh<_i135.VitalSignRepository>(),
+        gh<_i131.VectorStoreService>(),
+        gh<_i184.HealthRecordRepository>(),
+        gh<_i196.MedicationRepository>(),
+        gh<_i225.AllergyRepository>(),
+        gh<_i133.VitalSignRepository>(),
         gh<_i8.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
-    gh.factory<_i257.ReportBloc>(() => _i257.ReportBloc(
-          gh<_i106.ReportRepository>(),
-          gh<_i206.ReportGenerationService>(),
-        ));
-    gh.factory<_i258.SaveAllergyUseCase>(
-        () => _i258.SaveAllergyUseCase(gh<_i225.AllergyRepository>()));
-    gh.factory<_i259.SearchMedicalResearch>(() =>
-        _i259.SearchMedicalResearch(gh<_i252.MedicalResearchRepository>()));
-    gh.factory<_i260.SharingCubit>(() => _i260.SharingCubit(
-          bleService: gh<_i148.BleSharingService>(),
-          nfcService: gh<_i93.NfcSharingService>(),
-          wifiService: gh<_i141.WifiDirectService>(),
-          startSharingUseCase: gh<_i218.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i217.StartListeningUseCase>(),
-          cancelSharingUseCase: gh<_i149.CancelSharingUseCase>(),
-          walletService: gh<_i35.WalletService>(),
-          walletEncryption: gh<_i35.EncryptionService>(),
-    gh.factory<_i261.AllergiesCubit>(
-        () => _i261.AllergiesCubit(gh<_i225.AllergyRepository>()));
-    gh.factory<_i262.AllergyBloc>(
-        () => _i262.AllergyBloc(gh<_i225.AllergyRepository>()));
-    gh.factory<_i263.AuthCubit>(() => _i263.AuthCubit(gh<_i228.AuthService>()));
-    gh.factory<_i264.DashboardCubit>(() => _i264.DashboardCubit(
-          gh<_i243.GetDashboardStatsUseCase>(),
-          gh<_i245.GetRecentActivityUseCase>(),
-    gh.factory<_i265.DataSourceCubit>(
-        () => _i265.DataSourceCubit(gh<_i235.DataSourceRepository>()));
-    gh.factory<_i266.GetHealthSummaryUseCase>(
-        () => _i266.GetHealthSummaryUseCase(gh<_i249.HomeRepository>()));
-    gh.factory<_i267.GetResearchHistory>(
-        () => _i267.GetResearchHistory(gh<_i252.MedicalResearchRepository>()));
-    gh.factory<_i268.HomeCubit>(() => _i268.HomeCubit(
-          gh<_i266.GetHealthSummaryUseCase>(),
-          gh<_i249.HomeRepository>(),
-    gh.lazySingleton<_i269.MedicalIndexingService>(
-        () => _i269.MedicalIndexingService(
-              gh<_i69.MedicalKnowledgeRepository>(),
-              gh<_i132.VectorStoreService>(),
-              gh<_i256.PatientContextIndexer>(),
     gh.factory<_i258.ReportBloc>(() => _i258.ReportBloc(
           gh<_i107.ReportRepository>(),
-          gh<_i207.ReportGenerationService>(),
+          gh<_i204.ReportGenerationService>(),
+        ));
     gh.factory<_i259.SaveAllergyUseCase>(
-        () => _i259.SaveAllergyUseCase(gh<_i226.AllergyRepository>()));
+        () => _i259.SaveAllergyUseCase(gh<_i225.AllergyRepository>()));
     gh.factory<_i260.SearchMedicalResearch>(() =>
         _i260.SearchMedicalResearch(gh<_i253.MedicalResearchRepository>()));
     gh.factory<_i261.SharingCubit>(() => _i261.SharingCubit(
-          bleService: gh<_i149.BleSharingService>(),
+          bleService: gh<_i147.BleSharingService>(),
           nfcService: gh<_i94.NfcSharingService>(),
-          wifiService: gh<_i142.WifiDirectService>(),
-          startSharingUseCase: gh<_i219.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i218.StartListeningUseCase>(),
-          cancelSharingUseCase: gh<_i150.CancelSharingUseCase>(),
+          wifiService: gh<_i140.WifiDirectService>(),
+          startSharingUseCase: gh<_i216.StartSharingUseCase>(),
+          startListeningUseCase: gh<_i215.StartListeningUseCase>(),
+          cancelSharingUseCase: gh<_i148.CancelSharingUseCase>(),
+          walletService: gh<_i35.WalletService>(),
+          walletEncryption: gh<_i35.EncryptionService>(),
+        ));
     gh.factory<_i262.AllergiesCubit>(
-        () => _i262.AllergiesCubit(gh<_i226.AllergyRepository>()));
+        () => _i262.AllergiesCubit(gh<_i225.AllergyRepository>()));
     gh.factory<_i263.AllergyBloc>(
-        () => _i263.AllergyBloc(gh<_i226.AllergyRepository>()));
-    gh.factory<_i264.AuthCubit>(() => _i264.AuthCubit(gh<_i229.AuthService>()));
+        () => _i263.AllergyBloc(gh<_i225.AllergyRepository>()));
+    gh.factory<_i264.AuthCubit>(() => _i264.AuthCubit(gh<_i228.AuthService>()));
     gh.factory<_i265.DashboardCubit>(() => _i265.DashboardCubit(
           gh<_i244.GetDashboardStatsUseCase>(),
           gh<_i246.GetRecentActivityUseCase>(),
+        ));
     gh.factory<_i266.DataSourceCubit>(
-        () => _i266.DataSourceCubit(gh<_i236.DataSourceRepository>()));
+        () => _i266.DataSourceCubit(gh<_i235.DataSourceRepository>()));
     gh.factory<_i267.GetHealthSummaryUseCase>(
         () => _i267.GetHealthSummaryUseCase(gh<_i250.HomeRepository>()));
     gh.factory<_i268.GetResearchHistory>(
@@ -1614,10 +1173,11 @@ extension GetItInjectableX on _i1.GetIt {
     gh.factory<_i269.HomeCubit>(() => _i269.HomeCubit(
           gh<_i267.GetHealthSummaryUseCase>(),
           gh<_i250.HomeRepository>(),
+        ));
     gh.lazySingleton<_i270.MedicalIndexingService>(
         () => _i270.MedicalIndexingService(
               gh<_i70.MedicalKnowledgeRepository>(),
-              gh<_i133.VectorStoreService>(),
+              gh<_i131.VectorStoreService>(),
               gh<_i257.PatientContextIndexer>(),
             ));
     gh.factory<_i271.MedicalResearchCubit>(() => _i271.MedicalResearchCubit(
@@ -1638,5 +1198,3 @@ class _$MemoryModule extends _i274.MemoryModule {}
 class _$DatabaseModule extends _i275.DatabaseModule {}
 
 class _$FhirModule extends _i276.FhirModule {}
-
-

--- a/lib/core/di/service_module.dart
+++ b/lib/core/di/service_module.dart
@@ -3,14 +3,26 @@ import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:health/health.dart';
 import 'package:http/http.dart' as http;
 import 'package:injectable/injectable.dart';
+import '../services/device_capability_service.dart';
 
 @module
 abstract class ServiceModule {
   @lazySingleton
   Health get health => Health();
 
+  @preResolve
   @lazySingleton
-  FlutterSecureStorage get storage => const FlutterSecureStorage();
+  Future<FlutterSecureStorage> storage(DeviceCapabilityService capabilityService) async {
+    final isEmulator = await capabilityService.isEmulator();
+    return FlutterSecureStorage(
+      aOptions: AndroidOptions(
+        encryptedSharedPreferences: !isEmulator,
+      ),
+      iOptions: const IOSOptions(
+        accessibility: KeychainAccessibility.first_unlock_this_device,
+      ),
+    );
+  }
 
   @lazySingleton
   FlutterAppAuth get appAuth => const FlutterAppAuth();

--- a/lib/core/services/device_capability_service.dart
+++ b/lib/core/services/device_capability_service.dart
@@ -146,4 +146,24 @@ class DeviceCapabilityService {
     final caps = await getCapabilities();
     return caps.recommendation;
   }
+
+  /// Returns true if the device is an emulator.
+  Future<bool> isEmulator() async {
+    if (Platform.isAndroid) {
+      try {
+        final androidInfo = await _deviceInfo.androidInfo;
+        return !androidInfo.isPhysicalDevice;
+      } catch (_) {
+        return false;
+      }
+    } else if (Platform.isIOS) {
+      try {
+        final iosInfo = await _deviceInfo.iosInfo;
+        return !iosInfo.isPhysicalDevice;
+      } catch (_) {
+        return false;
+      }
+    }
+    return false;
+  }
 }

--- a/lib/core/services/secure_storage_service.dart
+++ b/lib/core/services/secure_storage_service.dart
@@ -2,9 +2,11 @@
 // SPDX-FileCopyrightText: 2025 SouthWest AI Labs
 
 import 'dart:convert';
+import 'dart:io';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:crypto/crypto.dart' show sha256;
 import 'package:injectable/injectable.dart';
+import 'device_capability_service.dart';
 
 /// Abstract secure storage service for sensitive data.
 ///
@@ -47,11 +49,15 @@ abstract class SecureStorageService {
 /// Default implementation backed by [FlutterSecureStorage].
 @LazySingleton(as: SecureStorageService)
 class SecureStorageServiceImpl implements SecureStorageService {
-  final FlutterSecureStorage _storage;
+  FlutterSecureStorage _storage;
+  final DeviceCapabilityService _capabilityService;
   final String _appKeySeed;
+  final bool _isStorageInjected;
+  bool _initialized = false;
 
   SecureStorageServiceImpl({
     FlutterSecureStorage? storage,
+    DeviceCapabilityService? capabilityService,
   })  : _storage = storage ??
             const FlutterSecureStorage(
               aOptions: AndroidOptions(
@@ -61,32 +67,57 @@ class SecureStorageServiceImpl implements SecureStorageService {
                 accessibility: KeychainAccessibility.first_unlock_this_device,
               ),
             ),
+        _capabilityService = capabilityService ?? DeviceCapabilityService(),
+        _isStorageInjected = storage != null,
         _appKeySeed = 'orionhealth_v1';
+
+  /// Ensures that the storage is correctly initialized,
+  /// especially for emulators where EncryptedSharedPreferences might fail.
+  Future<void> _ensureInitialized() async {
+    if (_initialized || _isStorageInjected) return;
+
+    if (Platform.isAndroid && await _capabilityService.isEmulator()) {
+      _storage = const FlutterSecureStorage(
+        aOptions: AndroidOptions(
+          encryptedSharedPreferences: false,
+        ),
+        iOptions: IOSOptions(
+          accessibility: KeychainAccessibility.first_unlock_this_device,
+        ),
+      );
+    }
+    _initialized = true;
+  }
 
   // ── Basic operations ──────────────────────────────────────
 
   @override
   Future<void> write(String key, String value) async {
+    await _ensureInitialized();
     await _storage.write(key: key, value: value);
   }
 
   @override
   Future<String?> read(String key) async {
+    await _ensureInitialized();
     return await _storage.read(key: key);
   }
 
   @override
   Future<void> delete(String key) async {
+    await _ensureInitialized();
     await _storage.delete(key: key);
   }
 
   @override
   Future<void> deleteAll() async {
+    await _ensureInitialized();
     await _storage.deleteAll();
   }
 
   @override
   Future<bool> containsKey(String key) async {
+    await _ensureInitialized();
     return await _storage.containsKey(key: key);
   }
 
@@ -94,18 +125,21 @@ class SecureStorageServiceImpl implements SecureStorageService {
 
   @override
   Future<void> writeSecure(String namespace, String key, String value) async {
+    await _ensureInitialized();
     final derivedKey = _deriveKey(namespace, key);
     await _storage.write(key: derivedKey, value: value);
   }
 
   @override
   Future<String?> readSecure(String namespace, String key) async {
+    await _ensureInitialized();
     final derivedKey = _deriveKey(namespace, key);
     return await _storage.read(key: derivedKey);
   }
 
   @override
   Future<void> deleteSecure(String namespace, String key) async {
+    await _ensureInitialized();
     final derivedKey = _deriveKey(namespace, key);
     await _storage.delete(key: derivedKey);
   }

--- a/test/core/di/service_module_test.dart
+++ b/test/core/di/service_module_test.dart
@@ -2,42 +2,53 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:get_it/get_it.dart';
 import 'package:injectable/injectable.dart' hide test;
 import 'package:orionhealth_health/core/di/service_module.dart';
+import 'package:orionhealth_health/core/services/device_capability_service.dart';
 import 'package:flutter_secure_storage/flutter_secure_storage.dart';
 import 'package:flutter_appauth/flutter_appauth.dart';
 import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
 
 class TestServiceModule extends ServiceModule {}
 
+class MockDeviceCapabilityService extends Mock
+    implements DeviceCapabilityService {}
+
 void main() {
   final getIt = GetIt.instance;
+  late MockDeviceCapabilityService mockCapabilityService;
 
   setUp(() async {
     await getIt.reset();
+    mockCapabilityService = MockDeviceCapabilityService();
+    when(() => mockCapabilityService.isEmulator()).thenAnswer((_) async => false);
   });
 
   group('ServiceModule DI', () {
-    test('should register all services in GetIt', () {
+    test('should register all services in GetIt', () async {
       final gh = GetItHelper(getIt);
       final module = TestServiceModule();
 
-      gh.lazySingleton<FlutterSecureStorage>(() => module.storage);
+      gh.lazySingletonAsync<FlutterSecureStorage>(
+          () => module.storage(mockCapabilityService));
       gh.lazySingleton<FlutterAppAuth>(() => module.appAuth);
       gh.lazySingleton<http.Client>(() => module.httpClient);
 
-      expect(getIt<FlutterSecureStorage>(), isA<FlutterSecureStorage>());
+      final storage = await getIt.getAsync<FlutterSecureStorage>();
+      expect(storage, isA<FlutterSecureStorage>());
       expect(getIt<FlutterAppAuth>(), isA<FlutterAppAuth>());
       expect(getIt<http.Client>(), isA<http.Client>());
     });
 
-    test('should register services as singletons', () {
+    test('should register services as singletons', () async {
       final gh = GetItHelper(getIt);
       final module = TestServiceModule();
 
-      gh.lazySingleton<FlutterSecureStorage>(() => module.storage);
+      gh.lazySingletonAsync<FlutterSecureStorage>(
+          () => module.storage(mockCapabilityService));
       gh.lazySingleton<http.Client>(() => module.httpClient);
 
-      final storage1 = getIt<FlutterSecureStorage>();
-      final storage2 = getIt<FlutterSecureStorage>();
+      final storage1 = await getIt.getAsync<FlutterSecureStorage>();
+      final storage2 = await getIt.getAsync<FlutterSecureStorage>();
       expect(storage1, same(storage2));
 
       final client1 = getIt<http.Client>();


### PR DESCRIPTION
FlutterSecureStorage fails on x86_64 Android emulators when `encryptedSharedPreferences: true` is set because these environments often lack a functional Android Keystore.

This PR implements a robust fix by:
1. Adding an `isEmulator()` check to `DeviceCapabilityService`.
2. Configuring the `FlutterSecureStorage` provider in `ServiceModule` as `@preResolve` to detect the emulator and set `encryptedSharedPreferences: false` accordingly.
3. Adding a lazy initialization fallback in `SecureStorageServiceImpl` to ensure compatibility even when used outside the DI container (e.g., in some tests).
4. Updating dependency injection configuration to reflect these changes.

Note: Kept using `aOptions` and `iOptions` as the project's current version of `flutter_secure_storage` does not yet support the renamed parameters.

Fixes #1483

---
*PR created automatically by Jules for task [6441448222659142679](https://jules.google.com/task/6441448222659142679) started by @iberi22*