### PR TITLE
fix: health_connect + sensor_api datasource tests - MockHealth vs HealthWrapper

### DIFF
--- a/test/features/data_sources/infrastructure/datasources/health_connect_datasource_test.dart
+++ b/test/features/data_sources/infrastructure/datasources/health_connect_datasource_test.dart
@@ -1,17 +1,23 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:health/health.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/core/utils/health_wrapper.dart';
 import 'package:orionhealth_health/features/data_sources/infrastructure/datasources/health_connect_datasource.dart';
 
 class MockHealth extends Mock implements Health {}
 
+class MockHealthWrapper extends Mock implements HealthWrapper {}
+
 void main() {
   late HealthConnectDataSourceImpl dataSource;
+  late MockHealthWrapper mockWrapper;
   late MockHealth mockHealth;
 
   setUp(() {
+    mockWrapper = MockHealthWrapper();
     mockHealth = MockHealth();
-    dataSource = HealthConnectDataSourceImpl(mockHealth);
+    when(() => mockWrapper.health).thenReturn(mockHealth);
+    dataSource = HealthConnectDataSourceImpl(mockWrapper);
   });
 
   group('HealthConnectDataSourceImpl', () {
@@ -43,18 +49,36 @@ void main() {
 
     test('syncData calls health package with correct types and date range', () async {
       when(() => mockHealth.getHealthDataFromTypes(
-        types: any(named: 'types'),
-        startTime: any(named: 'startTime'),
-        endTime: any(named: 'endTime'),
-      )).thenAnswer((_) async => []);
+            types: any(named: 'types'),
+            startTime: any(named: 'startTime'),
+            endTime: any(named: 'endTime'),
+          )).thenAnswer((_) async => []);
 
       await dataSource.syncData();
 
       verify(() => mockHealth.getHealthDataFromTypes(
-        types: [HealthDataType.STEPS, HealthDataType.HEART_RATE],
-        startTime: any(named: 'startTime'),
-        endTime: any(named: 'endTime'),
-      )).called(1);
+            types: [HealthDataType.STEPS, HealthDataType.HEART_RATE],
+            startTime: any(named: 'startTime'),
+            endTime: any(named: 'endTime'),
+          )).called(1);
+    });
+
+    test('isAvailable returns false if health is null', () async {
+      when(() => mockWrapper.health).thenReturn(null);
+      final result = await dataSource.isAvailable();
+      expect(result, isFalse);
+    });
+
+    test('requestPermissions returns false if health is null', () async {
+      when(() => mockWrapper.health).thenReturn(null);
+      final result = await dataSource.requestPermissions();
+      expect(result, isFalse);
+    });
+
+    test('syncData does nothing if health is null', () async {
+      when(() => mockWrapper.health).thenReturn(null);
+      await dataSource.syncData();
+      // Should not throw
     });
   });
 }

--- a/test/features/data_sources/infrastructure/datasources/sensor_api_datasource_test.dart
+++ b/test/features/data_sources/infrastructure/datasources/sensor_api_datasource_test.dart
@@ -1,12 +1,16 @@
 import 'package:flutter_test/flutter_test.dart';
 import 'package:health/health.dart';
 import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/core/utils/health_wrapper.dart';
 import 'package:orionhealth_health/features/data_sources/infrastructure/datasources/sensor_api_datasource.dart';
 
 class MockHealth extends Mock implements Health {}
 
+class MockHealthWrapper extends Mock implements HealthWrapper {}
+
 void main() {
   late SensorApiDataSourceImpl dataSource;
+  late MockHealthWrapper mockWrapper;
   late MockHealth mockHealth;
 
   final types = [
@@ -17,8 +21,10 @@ void main() {
   ];
 
   setUp(() {
+    mockWrapper = MockHealthWrapper();
     mockHealth = MockHealth();
-    dataSource = SensorApiDataSourceImpl(mockHealth);
+    when(() => mockWrapper.health).thenReturn(mockHealth);
+    dataSource = SensorApiDataSourceImpl(mockWrapper);
   });
 
   group('SensorApiDataSourceImpl', () {
@@ -49,18 +55,36 @@ void main() {
 
     test('fetchAndSaveData calls getHealthDataFromTypes', () async {
       when(() => mockHealth.getHealthDataFromTypes(
-        types: any(named: 'types'),
-        startTime: any(named: 'startTime'),
-        endTime: any(named: 'endTime'),
-      )).thenAnswer((_) async => []);
+            types: any(named: 'types'),
+            startTime: any(named: 'startTime'),
+            endTime: any(named: 'endTime'),
+          )).thenAnswer((_) async => []);
 
       await dataSource.fetchAndSaveData();
 
       verify(() => mockHealth.getHealthDataFromTypes(
-        types: types,
-        startTime: any(named: 'startTime'),
-        endTime: any(named: 'endTime'),
-      )).called(1);
+            types: types,
+            startTime: any(named: 'startTime'),
+            endTime: any(named: 'endTime'),
+          )).called(1);
+    });
+
+    test('requestAuthorization returns false if health is null', () async {
+      when(() => mockWrapper.health).thenReturn(null);
+      final result = await dataSource.requestAuthorization();
+      expect(result, isFalse);
+    });
+
+    test('hasPermissions returns false if health is null', () async {
+      when(() => mockWrapper.health).thenReturn(null);
+      final result = await dataSource.hasPermissions();
+      expect(result, isFalse);
+    });
+
+    test('fetchAndSaveData does nothing if health is null', () async {
+      when(() => mockWrapper.health).thenReturn(null);
+      await dataSource.fetchAndSaveData();
+      // Should not throw
     });
   });
 }


### PR DESCRIPTION
This PR fixes the type mismatch errors in `health_connect_datasource_test.dart` and `sensor_api_datasource_test.dart` where `MockHealth` was being passed to constructors now requiring `HealthWrapper`. 

Changes:
- Introduced `MockHealthWrapper` in both test files.
- Updated `setUp` to configure `MockHealthWrapper` to return a `MockHealth` instance.
- Added tests to verify that the data sources correctly handle cases where the underlying `health` client is null (e.g., on unsupported devices).
- Cleaned up indentation in test files.

Fixes #1500

---
*PR created automatically by Jules for task [7119735381251824286](https://jules.google.com/task/7119735381251824286) started by @iberi22*