### PR TITLE
fix: update RPConsentDocument usage for Research Package v2+

### DIFF
--- a/lib/features/clinical_assessments/domain/models/consent_document.dart
+++ b/lib/features/clinical_assessments/domain/models/consent_document.dart
@@ -2,28 +2,23 @@ import 'package:research_package/research_package.dart';
 
 class LocalConsentDocument {
   static RPConsentDocument get consentDocument {
-    RPConsentDocument document = RPConsentDocument(
-      title: 'Consentimiento Informado - Orion Health',
-      signatures: [
-        RPConsentSignature(identifier: 'patient_signature')
-      ],
-    );
-
-    RPConsentSection dataGatheringSection = RPConsentSection(
+    final dataGatheringSection = RPConsentSection(
       type: RPConsentSectionType.DataGathering,
       summary: 'Recolección de Datos Locales',
-      content: 'Esta aplicación utiliza tu dispositivo móvil para recolectar información sobre tu salud. Todos los datos, incluyendo métricas y respuestas, se procesan y almacenan EXCLUSIVAMENTE en tu dispositivo personal.',
+      content:
+          'Esta aplicación utiliza tu dispositivo móvil para recolectar información sobre tu salud. Todos los datos, incluyendo métricas y respuestas, se procesan y almacenan EXCLUSIVAMENTE en tu dispositivo personal.',
     );
 
-    RPConsentSection privacySection = RPConsentSection(
+    final privacySection = RPConsentSection(
       type: RPConsentSectionType.Privacy,
       summary: 'Privacidad 100% Local',
-      content: 'Tus datos no se subirán a ninguna nube ni servidor externo. Orion Health opera de forma totalmente local, asegurando tu privacidad según los estándares HIPAA y garantizando que solo tú tienes acceso a esta información.',
+      content:
+          'Tus datos no se subirán a ninguna nube ni servidor externo. Orion Health opera de forma totalmente local, asegurando tu privacidad según los estándares HIPAA y garantizando que solo tú tienes acceso a esta información.',
     );
 
-    document.addSection(dataGatheringSection);
-    document.addSection(privacySection);
-
-    return document;
+    return RPConsentDocument(
+      title: 'Consentimiento Informado - Orion Health',
+      sections: [dataGatheringSection, privacySection],
+    )..signatures = [RPConsentSignature(identifier: 'patient_signature')];
   }
 }


### PR DESCRIPTION
Refactors LocalConsentDocument to comply with Research Package v2+ API changes. It now uses the required 'sections' named parameter in the RPConsentDocument constructor, removes the obsolete 'signatures' constructor parameter (replacing it with property assignment), and removes the non-existent 'addSection' method calls.

Fixes #1495

---
*PR created automatically by Jules for task [14218005585887995932](https://jules.google.com/task/14218005585887995932) started by @iberi22*