### PR TITLE
fix 7 warnings in test/ - unused imports, unused variable

### DIFF
--- a/test/core/network/http_client_test.dart
+++ b/test/core/network/http_client_test.dart
@@ -47,7 +47,6 @@ void main() {
     test('validateCertificate returns null for unpinned hosts to use system validation', () {
       final dio = HttpClientFactory.createDio();
       if (dio.httpClientAdapter is IOHttpClientAdapter) {
-        final adapter = dio.httpClientAdapter as IOHttpClientAdapter;
         // Mocking a certificate is complex, but we can check the logic if we could call it
         // Since we can't easily mock X509Certificate, we rely on code inspection and
         // the fact that we return null for unknown hosts.

--- a/test/features/auth/presentation/golden/auth_gate_golden_test.dart
+++ b/test/features/auth/presentation/golden/auth_gate_golden_test.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 import 'package:flutter_test/flutter_test.dart';
-import 'package:flutter/material.dart';
 import 'package:get_it/get_it.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:orionhealth_health/features/auth/presentation/auth_gate.dart';

--- a/test/features/doctor_verification/presentation/golden/doctor_list_page_golden_test.dart
+++ b/test/features/doctor_verification/presentation/golden/doctor_list_page_golden_test.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/doctor_verification/presentation/pages/doctor_list_page.dart';
 import 'package:orionhealth_health/features/doctor_verification/application/doctor_verification_cubit.dart';
 import 'package:orionhealth_health/features/doctor_verification/application/doctor_verification_state.dart';

--- a/test/features/health_sharing/presentation/golden/receive_page_golden_test.dart
+++ b/test/features/health_sharing/presentation/golden/receive_page_golden_test.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/health_sharing/presentation/pages/receive_page.dart';
 import 'package:orionhealth_health/features/health_sharing/application/sharing_cubit.dart';
 import 'package:orionhealth_health/features/auth/application/bloc/auth_cubit.dart';

--- a/test/features/health_sharing/presentation/golden/share_page_golden_test.dart
+++ b/test/features/health_sharing/presentation/golden/share_page_golden_test.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/health_sharing/presentation/pages/share_page.dart';
 import 'package:orionhealth_health/features/health_sharing/application/sharing_cubit.dart';
 import 'package:orionhealth_health/features/auth/application/bloc/auth_cubit.dart';

--- a/test/features/medical_research/presentation/golden/interaction_checker_widget_golden_test.dart
+++ b/test/features/medical_research/presentation/golden/interaction_checker_widget_golden_test.dart
@@ -3,7 +3,6 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/medical_research/presentation/widgets/interaction_checker_widget.dart';
 import 'package:orionhealth_health/features/medical_research/application/medical_research_cubit.dart';
 import 'package:orionhealth_health/core/di/injection.dart';

--- a/test/features/medical_research/presentation/golden/medical_research_page_golden_test.dart
+++ b/test/features/medical_research/presentation/golden/medical_research_page_golden_test.dart
@@ -1,8 +1,6 @@
 import 'dart:async';
-import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:get_it/get_it.dart';
 import 'package:orionhealth_health/features/medical_research/application/medical_research_cubit.dart';
 import 'package:orionhealth_health/features/medical_research/presentation/pages/medical_research_page.dart';
 import 'package:orionhealth_health/core/di/injection.dart';


### PR DESCRIPTION
Fixed 7 lint warnings in the test directory:
1. Removed an unused local variable 'adapter' in `test/core/network/http_client_test.dart`.
2. Removed unused `package:flutter/material.dart` and `package:get_it/get_it.dart` imports from several golden test files across different features.

These changes are limited to the `test/` directory and improve code quality by following clean code practices and addressing linter feedback.

Fixes #1504

---
*PR created automatically by Jules for task [6254200585654485064](https://jules.google.com/task/6254200585654485064) started by @iberi22*