### PR TITLE
fix: 5 linter warnings in lib/

### DIFF
--- a/lib/core/di/database_module.dart
+++ b/lib/core/di/database_module.dart
@@ -29,7 +29,6 @@ import '../../features/network/domain/entities/network_message.dart';
 // import '../../features/ssi/infrastructure/persistence/isar_credential.dart';
 // import '../../features/ssi/infrastructure/persistence/isar_revocation_entry.dart';
 import '../../features/clinical_assessments/domain/entities/clinical_assessment_record.dart';
-import 'package:isar_agent_memory/isar_agent_memory.dart';
 import 'package:health_wallet/health_wallet.dart' as wallet;
 
 @module

--- a/lib/features/health_data_import/infrastructure/data_source.dart
+++ b/lib/features/health_data_import/infrastructure/data_source.dart
@@ -18,7 +18,7 @@ class SensorHealthDataSourceImpl implements SensorHealthDataSource {
   Future<bool> requestAuthorization(List<HealthDataType> types, List<HealthDataAccess> permissions) async {
     if (_health == null) return false;
     try {
-      return await _health!.requestAuthorization(types, permissions: permissions);
+      return await _health.requestAuthorization(types, permissions: permissions);
     } catch (_) {
       return false;
     }
@@ -28,7 +28,7 @@ class SensorHealthDataSourceImpl implements SensorHealthDataSource {
   Future<List<HealthDataPoint>> fetchData(HealthDataType type, DateTime start, DateTime end) async {
     if (_health == null) return [];
     try {
-      return await _health!.getHealthDataFromTypes(
+      return await _health.getHealthDataFromTypes(
         types: [type],
         startTime: start,
         endTime: end,
@@ -42,7 +42,7 @@ class SensorHealthDataSourceImpl implements SensorHealthDataSource {
   Future<bool> hasPermissions(List<HealthDataType> types) async {
     if (_health == null) return false;
     try {
-      final result = await _health!.hasPermissions(types);
+      final result = await _health.hasPermissions(types);
       return result ?? false;
     } catch (_) {
       return false;

--- a/lib/features/local_agent/infrastructure/services/isar_vector_store_service.dart
+++ b/lib/features/local_agent/infrastructure/services/isar_vector_store_service.dart
@@ -1,7 +1,6 @@
 import 'dart:math';
 
 import 'package:injectable/injectable.dart';
-import 'package:isar/isar.dart';
 import 'package:isar_agent_memory/isar_agent_memory.dart';
 import '../../domain/chat_message.dart';
 import '../../domain/services/vector_store_service.dart';

--- a/lib/features/onboarding/presentation/pages/hipaa_consent_page.dart
+++ b/lib/features/onboarding/presentation/pages/hipaa_consent_page.dart
@@ -371,12 +371,6 @@ class _HipaaConsentPageState extends State<HipaaConsentPage> {
     }
   }
 
-  /// Static method to check if consent has been previously granted.
-  static Future<bool> hasConsent() async {
-    const storage = FlutterSecureStorage();
-    final value = await storage.read(key: _consentKey);
-    return value == 'true';
-  }
 }
 
 const String _privacyPolicyText = '''


### PR DESCRIPTION
This PR fixes 5 linter warnings in the `lib/` directory:
1. Removed an unused import in `lib/core/di/database_module.dart`.
2. Fixed 3 unnecessary null assertions in `lib/features/health_data_import/infrastructure/data_source.dart` where the receiver was already non-nullable due to previous null checks.
3. Removed an unused import in `lib/features/local_agent/infrastructure/services/isar_vector_store_service.dart`.
4. Removed an unused static method `hasConsent` in `lib/features/onboarding/presentation/pages/hipaa_consent_page.dart`.

All changes were verified via static analysis and relevant unit tests.

Fixes #1503

---
*PR created automatically by Jules for task [15734073034164395618](https://jules.google.com/task/15734073034164395618) started by @iberi22*