### PR TITLE
fix: remove duplicate MockEncryptionService in allergy repository test

### DIFF
--- a/test/features/allergies/data/repositories/allergy_repository_impl_test.dart
+++ b/test/features/allergies/data/repositories/allergy_repository_impl_test.dart
@@ -4,11 +4,8 @@ import 'package:orionhealth_health/features/auth/infrastructure/services/encrypt
 import 'package:orionhealth_health/features/allergies/data/datasources/allergy_local_datasource.dart';
 import 'package:orionhealth_health/features/allergies/data/repositories/allergy_repository_impl.dart';
 import 'package:orionhealth_health/features/allergies/domain/entities/allergy.dart';
-import 'package:orionhealth_health/features/auth/infrastructure/services/encryption_service.dart';
 
 class MockAllergyLocalDataSource extends Mock implements AllergyLocalDataSource {}
-class MockEncryptionService extends Mock implements EncryptionService {}
-
 class MockEncryptionService extends Mock implements EncryptionService {}
 
 class FakeAllergy extends Fake implements Allergy {}
@@ -16,6 +13,7 @@ class FakeAllergy extends Fake implements Allergy {}
 void main() {
   late AllergyRepositoryImpl repository;
   late MockAllergyLocalDataSource mockLocalDataSource;
+  late MockEncryptionService mockEncryptionService;
 
   setUpAll(() {
     registerFallbackValue(FakeAllergy());
@@ -23,7 +21,14 @@ void main() {
 
   setUp(() {
     mockLocalDataSource = MockAllergyLocalDataSource();
-    repository = AllergyRepositoryImpl(mockLocalDataSource, encryptionService: MockEncryptionService());
+    mockEncryptionService = MockEncryptionService();
+    repository = AllergyRepositoryImpl(mockLocalDataSource, encryptionService: mockEncryptionService);
+
+    // Default stubs for encryption service
+    when(() => mockEncryptionService.encryptHealthData(any()))
+        .thenAnswer((invocation) async => invocation.positionalArguments[0] as String);
+    when(() => mockEncryptionService.decryptHealthData(any()))
+        .thenAnswer((invocation) async => invocation.positionalArguments[0] as String);
   });
 
   group('AllergyRepositoryImpl', () {
@@ -31,24 +36,39 @@ void main() {
       Allergy(id: 1, allergen: 'Peanuts', severity: AllergySeverity.severe),
     ];
 
-    test('getAllergies should delegate to local data source', () async {
+    test('getAllergies should delegate to local data source and decrypt data', () async {
+      final tAllergiesFromDb = [
+        Allergy(id: 1, severity: AllergySeverity.severe)
+          ..encryptedAllergen = 'Peanuts'
+          ..encryptedNotes = 'Avoid',
+      ];
+
       when(() => mockLocalDataSource.getAllergies())
-          .thenAnswer((_) async => tAllergies);
+          .thenAnswer((_) async => tAllergiesFromDb);
 
       final result = await repository.getAllergies();
 
-      expect(result, tAllergies);
+      expect(result, tAllergiesFromDb);
+      expect(result.first.allergen, 'Peanuts');
+      expect(result.first.notes, 'Avoid');
       verify(() => mockLocalDataSource.getAllergies()).called(1);
+      verify(() => mockEncryptionService.decryptHealthData('Peanuts')).called(1);
+      verify(() => mockEncryptionService.decryptHealthData('Avoid')).called(1);
     });
 
-    test('saveAllergy should delegate to local data source', () async {
-      final tAllergy = tAllergies.first;
+    test('saveAllergy should delegate to local data source and encrypt data', () async {
+      final tAllergy = Allergy(id: 1, allergen: 'Peanuts', severity: AllergySeverity.severe, notes: 'Avoid');
+
       when(() => mockLocalDataSource.saveAllergy(any()))
           .thenAnswer((_) async => {});
 
       await repository.saveAllergy(tAllergy);
 
+      expect(tAllergy.encryptedAllergen, 'Peanuts');
+      expect(tAllergy.encryptedNotes, 'Avoid');
       verify(() => mockLocalDataSource.saveAllergy(tAllergy)).called(1);
+      verify(() => mockEncryptionService.encryptHealthData('Peanuts')).called(1);
+      verify(() => mockEncryptionService.encryptHealthData('Avoid')).called(1);
     });
 
     test('deleteAllergy should delegate to local data source', () async {


### PR DESCRIPTION
This commit fixes several issues in `test/features/allergies/data/repositories/allergy_repository_impl_test.dart`:
1. Removes the duplicate definition of the `MockEncryptionService` class.
2. Removes a redundant import of the `encryption_service.dart` file.
3. Fixes the repository instantiation by properly declaring and initializing a `mockEncryptionService` variable and passing it to the constructor.
4. Adds necessary stubs for `encryptHealthData` and `decryptHealthData` to ensure the tests correctly handle the repository's encryption logic.
5. Updates the test cases to verify that data is correctly encrypted before saving and decrypted after fetching.

Fixes #1499

---
*PR created automatically by Jules for task [7825374646811156211](https://jules.google.com/task/7825374646811156211) started by @iberi22*