### PR TITLE
Fix Isar collection access and SDK conflict for vector store tests

### DIFF
--- a/lib/features/allergies/data/datasources/allergy_local_datasource.dart
+++ b/lib/features/allergies/data/datasources/allergy_local_datasource.dart
@@ -9,18 +9,18 @@ class AllergyLocalDataSource {
   AllergyLocalDataSource(this._isar);
 
   Future<List<Allergy>> getAllergies() async {
-    return await _isar.allergys.where().findAll();
+    return await _isar.collection<Allergy>().where().findAll();
   }
 
   Future<void> saveAllergy(Allergy allergy) async {
     await _isar.writeTxn(() async {
-      await _isar.allergys.put(allergy);
+      await _isar.collection<Allergy>().put(allergy);
     });
   }
 
   Future<void> deleteAllergy(Id id) async {
     await _isar.writeTxn(() async {
-      await _isar.allergys.delete(id);
+      await _isar.collection<Allergy>().delete(id);
     });
   }
 }

--- a/lib/features/allergies/infrastructure/repositories/isar_allergy_repository.dart
+++ b/lib/features/allergies/infrastructure/repositories/isar_allergy_repository.dart
@@ -9,20 +9,20 @@ class IsarAllergyRepository implements AllergyRepository {
 
   @override
   Future<List<Allergy>> getAllergies() async {
-    return _isar.allergys.where().findAll();
+    return _isar.collection<Allergy>().where().findAll();
   }
 
   @override
   Future<void> saveAllergy(Allergy allergy) async {
     await _isar.writeTxn(() async {
-      await _isar.allergys.put(allergy);
+      await _isar.collection<Allergy>().put(allergy);
     });
   }
 
   @override
   Future<void> deleteAllergy(Id id) async {
     await _isar.writeTxn(() async {
-      await _isar.allergys.delete(id);
+      await _isar.collection<Allergy>().delete(id);
     });
   }
 }

--- a/lib/features/local_agent/infrastructure/services/isar_vector_store_service.dart
+++ b/lib/features/local_agent/infrastructure/services/isar_vector_store_service.dart
@@ -272,9 +272,9 @@ class IsarVectorStoreService implements VectorStoreService {
   }) async {
     final childNodeIntIds = <int>[];
 
-    final count = await _memoryGraph.isar.memoryNodes.count();
+    final count = await _memoryGraph.isar.collection<MemoryNode>().count();
     for (var i = 0; i < count; i++) {
-      final node = await _memoryGraph.isar.memoryNodes.get(i + 1);
+      final node = await _memoryGraph.isar.collection<MemoryNode>().get(i + 1);
       if (node != null &&
           node.metadata != null &&
           node.metadata!.containsKey('externalId')) {
@@ -318,7 +318,7 @@ class IsarVectorStoreService implements VectorStoreService {
 
   @override
   Future<List<ChatMessage>> getRecentMessages({int limit = 20}) async {
-    final nodes = await _memoryGraph.isar.memoryNodes
+    final nodes = await _memoryGraph.isar.collection<MemoryNode>()
         .filter()
         .typeEqualTo('chat_message')
         .sortByCreatedAtDesc()

--- a/packages/isar_agent_memory/pubspec.yaml
+++ b/packages/isar_agent_memory/pubspec.yaml
@@ -45,6 +45,7 @@ dev_dependencies:
   build_runner: ^2.4.6
   objectbox_generator: ^5.0.0
   json_serializable: ^6.11.2
+  isar_generator: ^3.1.0+1
 
 dart_pre_commit:
   tasks:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -65,6 +65,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.0.4"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: a96e8b390886ee8abb49b7bd3ac8df6f451c621619f52a26e815fdcf568959ff
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.0.9"
   argon2:
     dependency: "direct main"
     description:
@@ -101,58 +109,58 @@ packages:
     dependency: transitive
     description:
       name: audioplayers
-      sha256: "2ba4bb2944baacbdd5372ff8254a8e7feb8c10d7739545e392f5605a8f618745"
+      sha256: f16640453cc47487b7de72a2b28d37c7df1ac97999849f4a46d92b1d2b0f093d
       url: "https://pub.dev"
     source: hosted
-    version: "6.8.1"
+    version: "6.7.1"
   audioplayers_android:
     dependency: transitive
     description:
       name: audioplayers_android
-      sha256: f5ff5b15620fbab8cb0849e9636c48e2b96c3f0f71723bbbe2ad3c761b205f05
+      sha256: "60a6728277228413a85755bd3ffd6fab98f6555608923813ce383b190a360605"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.2.1"
   audioplayers_darwin:
     dependency: transitive
     description:
       name: audioplayers_darwin
-      sha256: "1ca553add991384ecf421b9569da850f3ab2472ffb83f6970b0416365abc51be"
+      sha256: c994b3bb3a921e4904ac40e013fbc94488e824fd7c1de6326f549943b0b44a91
       url: "https://pub.dev"
     source: hosted
-    version: "6.5.0"
+    version: "6.4.0"
   audioplayers_linux:
     dependency: transitive
     description:
       name: audioplayers_linux
-      sha256: "15178b726b7cdee5364d0463c8d445630c4e0fb7d26612b73c767e7d25de9417"
+      sha256: f75bce1ce864170ef5e6a2c6a61cd3339e1a17ce11e99a25bae4474ea491d001
       url: "https://pub.dev"
     source: hosted
-    version: "4.3.0"
+    version: "4.2.1"
   audioplayers_platform_interface:
     dependency: transitive
     description:
       name: audioplayers_platform_interface
-      sha256: "765f6f0e6dca55cb471c9483fc77700564b3484d19198aca4ebb5147c6c85acb"
+      sha256: "0e2f6a919ab56d0fec272e801abc07b26ae7f31980f912f24af4748763e5a656"
       url: "https://pub.dev"
     source: hosted
-    version: "7.2.0"
+    version: "7.1.1"
   audioplayers_web:
     dependency: transitive
     description:
       name: audioplayers_web
-      sha256: ae1e0103c865a03e273f6d13d97b93f5595eac09915729cd5e37ef96e2857319
+      sha256: "24a6f258062bd7da8cb2157e83fccb9816a08dd306cbaaa24f9813d071470545"
       url: "https://pub.dev"
     source: hosted
-    version: "5.3.0"
+    version: "5.2.1"
   audioplayers_windows:
     dependency: transitive
     description:
       name: audioplayers_windows
-      sha256: a70ae82bba2dfcb6eb03dd4815d737a2d46d33ea5a96a03f535cfcaac490e413
+      sha256: "95f875a96c88c3dbbcb608d4f8288e300b0113d256a81d0b3197fcc18f0dc91a"
       url: "https://pub.dev"
     source: hosted
-    version: "4.4.1"
+    version: "4.3.1"
   background_downloader:
     dependency: transitive
     description:
@@ -1054,6 +1062,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.1.2"
+  image:
+    dependency: transitive
+    description:
+      name: image
+      sha256: f9881ff4998044947ec38d098bc7c8316ae1186fa786eddffdb867b9bc94dfce
+      url: "https://pub.dev"
+    source: hosted
+    version: "4.8.0"
   image_picker:
     dependency: "direct main"
     description:
@@ -1374,10 +1390,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1397,10 +1413,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -1665,6 +1681,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "1.5.2"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: "185ef7606574f789b40f289c233efa52e96dead518aed988e040a10737febb07"
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.5.0"
   process:
     dependency: transitive
     description:
@@ -1789,10 +1813,10 @@ packages:
     dependency: "direct main"
     description:
       name: research_package
-      sha256: "0d01ca0af01179d98c63d3e9de4b94113f4c2a839c21f8dfed11346716d2eb35"
+      sha256: "399b3ed901aeb35641039dcf0a9ae3c96288054e30833b6ee4ae4cbbce566a3d"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.0"
+    version: "2.3.0"
   retry:
     dependency: transitive
     description:
@@ -1973,10 +1997,10 @@ packages:
     dependency: transitive
     description:
       name: signature
-      sha256: f3d14bd6dae46d3b4802c6a091d6d39c9c6080d999e8c5380581d3725c30e360
+      sha256: "8056e091ad59c2eb5735fee975ec649d0caf8ce802bb1ffb1e0955b00a6d0daa"
       url: "https://pub.dev"
     source: hosted
-    version: "6.3.0"
+    version: "5.5.0"
   sky_engine:
     dependency: transitive
     description: flutter
@@ -2114,10 +2138,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:
@@ -2266,18 +2290,18 @@ packages:
     dependency: transitive
     description:
       name: video_player
-      sha256: "0431179e1a7a2234a1148f64dde63c73167ca23829815169b24cc0bc6b9444a3"
+      sha256: "48a7bdaa38a3d50ec10c78627abdbfad863fdf6f0d6e08c7c3c040cfd80ae36f"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.11.1"
   video_player_android:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "5121de08444d00363efdda630a69ad4d27a208a9f7586482d4909a44a1cdbc63"
+      sha256: "877a6c7ba772456077d7bfd71314629b3fe2b73733ce503fc77c3314d43a0ca0"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.0"
+    version: "2.9.5"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -2431,5 +2455,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.12.2 <4.0.0"
-  flutter: ">=3.44.0"
+  dart: ">=3.11.0 <4.0.0"
+  flutter: ">=3.41.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -93,7 +93,7 @@ dependencies:
   sherpa_onnx: ^1.13.4
   flutter_tts: ^4.2.5
   freezed_annotation: ^2.4.1
-  research_package: ^2.4.0
+  research_package: ^2.3.0
 
 dev_dependencies:
   flutter_test:

--- a/test/features/local_agent/infrastructure/services/isar_vector_store_service_test.dart
+++ b/test/features/local_agent/infrastructure/services/isar_vector_store_service_test.dart
@@ -147,7 +147,7 @@ void main() {
         final mockCollection = MockMemoryNodeCollection();
 
         when(() => mockMemoryGraph.isar).thenReturn(mockIsar);
-        when(() => mockIsar.memoryNodes).thenReturn(mockCollection);
+        when(() => mockIsar.collection<MemoryNode>()).thenReturn(mockCollection);
         when(() => mockCollection.count()).thenAnswer((_) async => 0);
 
         await expectLater(


### PR DESCRIPTION
Updated Isar collection access pattern in IsarVectorStoreService and its tests to fix compilation errors caused by Isar 0.5.0-beta API changes. Also resolved a blocking SDK conflict by downgrading research_package.

Fixes #1501

---
*PR created automatically by Jules for task [10279148612569511794](https://jules.google.com/task/10279148612569511794) started by @iberi22*