### PR TITLE
Unit and widget tests for CountryDetector service

### DIFF
--- a/lib/features/onboarding/infrastructure/services/country_detector.dart
+++ b/lib/features/onboarding/infrastructure/services/country_detector.dart
@@ -81,7 +81,8 @@ class CountryDetector {
         .timeout(const Duration(seconds: 5));
     if (response.statusCode == 200) {
       final data = json.decode(response.body) as Map<String, dynamic>;
-      return data['country_code'] as String?;
+      final code = data['country_code'] as String?;
+      return code?.trim().toUpperCase();
     }
     return null;
   }
@@ -92,7 +93,8 @@ class CountryDetector {
         .timeout(const Duration(seconds: 5));
     if (response.statusCode == 200) {
       final data = json.decode(response.body) as Map<String, dynamic>;
-      return data['countryCode'] as String?;
+      final code = data['countryCode'] as String?;
+      return code?.trim().toUpperCase();
     }
     return null;
   }
@@ -103,7 +105,8 @@ class CountryDetector {
         .timeout(const Duration(seconds: 5));
     if (response.statusCode == 200) {
       final data = json.decode(response.body) as Map<String, dynamic>;
-      return data['country'] as String?;
+      final code = data['country'] as String?;
+      return code?.trim().toUpperCase();
     }
     return null;
   }

--- a/lib/features/onboarding/presentation/pages/onboarding_welcome_page.dart
+++ b/lib/features/onboarding/presentation/pages/onboarding_welcome_page.dart
@@ -27,12 +27,14 @@ class OnboardingWelcomePage extends StatefulWidget {
   final VoidCallback onNext;
   final void Function(Map<String, dynamic> epsData) onEpsDataReceived;
   final void Function(Set<String> connectedSources)? onHealthSourcesConnected;
+  final CountryDetector? countryDetector;
 
   const OnboardingWelcomePage({
     super.key,
     required this.onNext,
     required this.onEpsDataReceived,
     this.onHealthSourcesConnected,
+    this.countryDetector,
   });
 
   @override
@@ -89,9 +91,11 @@ class _OnboardingWelcomePageState extends State<OnboardingWelcomePage> {
   }
 
   Future<void> _checkCountry() async {
-    final detector = CountryDetector();
+    final detector = widget.countryDetector ?? CountryDetector();
     final isColombia = await detector.isColombia();
-    detector.dispose();
+    if (widget.countryDetector == null) {
+      detector.dispose();
+    }
     if (mounted) {
       setState(() {
         _isColombia = isColombia;

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1454,10 +1454,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1477,10 +1477,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -2202,10 +2202,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/onboarding/infrastructure/services/country_detector_test.dart
+++ b/test/features/onboarding/infrastructure/services/country_detector_test.dart
@@ -1,0 +1,207 @@
+import 'dart:convert';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+import 'package:orionhealth_health/features/onboarding/infrastructure/services/country_detector.dart';
+import 'package:orionhealth_health/features/onboarding/presentation/pages/onboarding_welcome_page.dart';
+import 'package:shared_preferences/shared_preferences.dart';
+
+class MockClient extends Mock implements http.Client {}
+
+class MockCountryDetector extends Mock implements CountryDetector {}
+
+void main() {
+  late MockClient mockClient;
+  late CountryDetector detector;
+
+  setUpAll(() {
+    registerFallbackValue(Uri());
+  });
+
+  setUp(() {
+    mockClient = MockClient();
+    detector = CountryDetector(client: mockClient);
+    SharedPreferences.setMockInitialValues({});
+  });
+
+  group('CountryDetector Providers', () {
+    test('ipapi.co returns country code', () async {
+      when(() => mockClient.get(Uri.parse('https://ipapi.co/json/')))
+          .thenAnswer((_) async => http.Response(
+                json.encode({'country_code': 'CO'}),
+                200,
+              ));
+
+      final result = await detector.detectCountry();
+      expect(result, 'CO');
+      verify(() => mockClient.get(Uri.parse('https://ipapi.co/json/'))).called(1);
+    });
+
+    test('falls back to ip-api.com if ipapi.co fails', () async {
+      when(() => mockClient.get(Uri.parse('https://ipapi.co/json/')))
+          .thenThrow(Exception('Network error'));
+      when(() => mockClient.get(Uri.parse('http://ip-api.com/json/?fields=countryCode')))
+          .thenAnswer((_) async => http.Response(
+                json.encode({'countryCode': 'US'}),
+                200,
+              ));
+
+      final result = await detector.detectCountry();
+      expect(result, 'US');
+      verify(() => mockClient.get(Uri.parse('https://ipapi.co/json/'))).called(1);
+      verify(() => mockClient.get(Uri.parse('http://ip-api.com/json/?fields=countryCode'))).called(1);
+    });
+
+    test('falls back to ipinfo.io if first two fail', () async {
+      when(() => mockClient.get(Uri.parse('https://ipapi.co/json/')))
+          .thenAnswer((_) async => http.Response('Error', 500));
+      when(() => mockClient.get(Uri.parse('http://ip-api.com/json/?fields=countryCode')))
+          .thenAnswer((_) async => http.Response('Error', 500));
+      when(() => mockClient.get(Uri.parse('https://ipinfo.io/json')))
+          .thenAnswer((_) async => http.Response(
+                json.encode({'country': 'AR'}),
+                200,
+              ));
+
+      final result = await detector.detectCountry();
+      expect(result, 'AR');
+      verify(() => mockClient.get(Uri.parse('https://ipapi.co/json/'))).called(1);
+      verify(() => mockClient.get(Uri.parse('http://ip-api.com/json/?fields=countryCode'))).called(1);
+      verify(() => mockClient.get(Uri.parse('https://ipinfo.io/json'))).called(1);
+    });
+
+    test('returns null if all providers fail', () async {
+      when(() => mockClient.get(any()))
+          .thenAnswer((_) async => http.Response('Error', 500));
+
+      final result = await detector.detectCountry();
+      expect(result, isNull);
+    });
+  });
+
+  group('CountryDetector Logic & Cache', () {
+    test('isColombia returns true for CO', () async {
+      when(() => mockClient.get(any()))
+          .thenAnswer((_) async => http.Response(json.encode({'country_code': 'CO'}), 200));
+
+      final result = await detector.isColombia();
+      expect(result, isTrue);
+    });
+
+    test('isColombia returns false for others', () async {
+      when(() => mockClient.get(any()))
+          .thenAnswer((_) async => http.Response(json.encode({'country_code': 'US'}), 200));
+
+      final result = await detector.isColombia();
+      expect(result, isFalse);
+    });
+
+    test('normalization trims and uppercases country code', () async {
+      when(() => mockClient.get(any()))
+          .thenAnswer((_) async => http.Response(json.encode({'country_code': '  co  '}), 200));
+
+      final result = await detector.detectCountry();
+      expect(result, 'CO');
+    });
+
+    test('cache is used if within 24h', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      SharedPreferences.setMockInitialValues({
+        'detected_country_code': 'CO',
+        'detected_country_time': now - Duration(hours: 23).inMilliseconds,
+      });
+
+      final result = await detector.detectCountry();
+      expect(result, 'CO');
+      verifyNever(() => mockClient.get(any()));
+    });
+
+    test('cache is ignored if older than 24h', () async {
+      final now = DateTime.now().millisecondsSinceEpoch;
+      SharedPreferences.setMockInitialValues({
+        'detected_country_code': 'CO',
+        'detected_country_time': now - Duration(hours: 25).inMilliseconds,
+      });
+
+      when(() => mockClient.get(any()))
+          .thenAnswer((_) async => http.Response(json.encode({'country_code': 'US'}), 200));
+
+      final result = await detector.detectCountry();
+      expect(result, 'US');
+      verify(() => mockClient.get(any())).called(1);
+    });
+  });
+
+  group('OnboardingWelcomePage Widget Test', () {
+    late MockCountryDetector mockDetector;
+
+    setUp(() {
+      mockDetector = MockCountryDetector();
+    });
+
+    testWidgets('shows EPS section when in Colombia', (tester) async {
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      when(() => mockDetector.isColombia()).thenAnswer((_) async => true);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: OnboardingWelcomePage(
+            onNext: () {},
+            onEpsDataReceived: (_) {},
+            countryDetector: mockDetector,
+          ),
+        ),
+      ));
+
+      // Wait for country detection
+      await tester.pumpAndSettle();
+
+      // Navigate to the last slide
+      await tester.tap(find.text('Siguiente'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Siguiente'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Conectá tu EPS para importar tus datos'), findsOneWidget);
+    });
+
+    testWidgets('hides EPS section when NOT in Colombia', (tester) async {
+      tester.view.physicalSize = const Size(1080, 1920);
+      tester.view.devicePixelRatio = 1.0;
+      addTearDown(() {
+        tester.view.resetPhysicalSize();
+        tester.view.resetDevicePixelRatio();
+      });
+
+      when(() => mockDetector.isColombia()).thenAnswer((_) async => false);
+
+      await tester.pumpWidget(MaterialApp(
+        home: Scaffold(
+          body: OnboardingWelcomePage(
+            onNext: () {},
+            onEpsDataReceived: (_) {},
+            countryDetector: mockDetector,
+          ),
+        ),
+      ));
+
+      // Wait for country detection
+      await tester.pumpAndSettle();
+
+      // Navigate to the last slide
+      await tester.tap(find.text('Siguiente'));
+      await tester.pumpAndSettle();
+      await tester.tap(find.text('Siguiente'));
+      await tester.pumpAndSettle();
+
+      expect(find.text('Conectá tu EPS para importar tus datos'), findsNothing);
+    });
+  });
+}

--- a/test/features/onboarding/presentation/pages/onboarding_welcome_page_test.dart
+++ b/test/features/onboarding/presentation/pages/onboarding_welcome_page_test.dart
@@ -7,25 +7,28 @@ void main() {
     bool onNextCalled = false;
     await tester.pumpWidget(MaterialApp(
       home: Scaffold(
-        body: OnboardingWelcomePage(onNext: () => onNextCalled = true),
+        body: OnboardingWelcomePage(
+          onNext: () => onNextCalled = true,
+          onEpsDataReceived: (_) {},
+        ),
       ),
     ));
 
     expect(find.text('Privacy First'), findsOneWidget);
-    expect(find.text('Next'), findsOneWidget);
+    expect(find.text('Siguiente'), findsOneWidget);
 
-    await tester.tap(find.text('Next'));
+    await tester.tap(find.text('Siguiente'));
     await tester.pumpAndSettle();
 
     expect(find.text('Local AI'), findsOneWidget);
 
-    await tester.tap(find.text('Next'));
+    await tester.tap(find.text('Siguiente'));
     await tester.pumpAndSettle();
 
     expect(find.text('Own Your Data'), findsOneWidget);
-    expect(find.text('Get Started'), findsOneWidget);
+    expect(find.text('Continuar sin EPS'), findsOneWidget);
 
-    await tester.tap(find.text('Get Started'));
+    await tester.tap(find.text('Continuar sin EPS'));
     await tester.pump();
 
     expect(onNextCalled, isTrue);


### PR DESCRIPTION
This PR introduces a complete test suite for the `CountryDetector` service and its integration into the onboarding flow.

Key changes:
1. **CountryDetector Enhancements**: Added normalization (trimming and uppercasing) to country codes retrieved from IP geolocation providers.
2. **OnboardingWelcomePage Refactor**: Modified the widget to accept an optional `CountryDetector` instance, allowing for precise mocking in widget tests.
3. **New Test Suite**: Created `test/features/onboarding/infrastructure/services/country_detector_test.dart` which includes:
    - Unit tests for `ipapi.co`, `ip-api.com`, and `ipinfo.io` with full fallback logic coverage.
    - Logic tests for `isColombia()` and 24-hour cache expiration.
    - Widget tests asserting that the EPS connection section only appears for users detected in Colombia.
4. **Maintenance**: Updated `test/features/onboarding/presentation/pages/onboarding_welcome_page_test.dart` to fix compilation errors and match the current Spanish UI strings.

All tests passed successfully in the local environment.

Fixes #1535

---
*PR created automatically by Jules for task [3139993418978365132](https://jules.google.com/task/3139993418978365132) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved country detection by consistently trimming and uppercasing country codes.
  * Added fallback handling across multiple location providers.
  * Reused recent country detection results to reduce unnecessary network requests.

* **Onboarding**
  * EPS-related content now displays based on the detected country.
  * Updated onboarding navigation checks to use Spanish localized labels.

* **Tests**
  * Added coverage for country detection, caching, provider failures, normalization, and country-specific onboarding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->