### PR TITLE
[test] Unit + integration tests for EPS connection pipeline

### DIFF
--- a/lib/core/di/injection.config.dart
+++ b/lib/core/di/injection.config.dart
@@ -24,25 +24,25 @@ import 'package:just_audio/just_audio.dart' as _i13;
 import 'package:medical_standards/medical_standards.dart' as _i68;
 import 'package:shared_preferences/shared_preferences.dart' as _i51;
 
-import '../../features/about/application/about_cubit.dart' as _i143;
+import '../../features/about/application/about_cubit.dart' as _i141;
 import '../../features/about/domain/repositories/i_about_repository.dart'
     as _i53;
 import '../../features/about/domain/usecases/get_about_info_usecase.dart'
-    as _i169;
+    as _i166;
 import '../../features/about/infrastructure/datasources/about_local_datasource.dart'
     as _i4;
 import '../../features/about/infrastructure/datasources/about_remote_datasource.dart'
-    as _i144;
+    as _i142;
 import '../../features/about/infrastructure/repositories/about_repository_impl.dart'
     as _i54;
 import '../../features/allergies/application/allergies_cubit.dart' as _i267;
 import '../../features/allergies/application/bloc/allergy_bloc.dart' as _i268;
 import '../../features/allergies/data/datasources/allergy_local_datasource.dart'
-    as _i145;
+    as _i143;
 import '../../features/allergies/data/repositories/allergy_repository_impl.dart'
-    as _i231;
-import '../../features/allergies/domain/repositories/allergy_repository.dart'
     as _i230;
+import '../../features/allergies/domain/repositories/allergy_repository.dart'
+    as _i229;
 import '../../features/allergies/domain/services/allergy_service.dart' as _i6;
 import '../../features/allergies/domain/usecases/get_allergies_usecase.dart'
     as _i248;
@@ -63,36 +63,36 @@ import '../../features/appointments/domain/usecases/get_all_appointments_usecase
 import '../../features/appointments/domain/usecases/save_appointment_usecase.dart'
     as _i110;
 import '../../features/auth/application/auth_cubit.dart' as _i269;
-import '../../features/auth/application/bloc/auth_cubit.dart' as _i232;
+import '../../features/auth/application/bloc/auth_cubit.dart' as _i231;
 import '../../features/auth/data/datasources/auth_local_datasource.dart'
-    as _i147;
+    as _i145;
 import '../../features/auth/data/repositories/auth_repository_impl.dart'
-    as _i149;
-import '../../features/auth/domain/auth_service.dart' as _i233;
-import '../../features/auth/domain/repositories/auth_repository.dart' as _i148;
+    as _i147;
+import '../../features/auth/domain/auth_service.dart' as _i232;
+import '../../features/auth/domain/repositories/auth_repository.dart' as _i146;
 import '../../features/auth/domain/usecases/check_session_timeout.dart'
-    as _i153;
+    as _i151;
 import '../../features/auth/domain/usecases/get_credentials_usecase.dart'
-    as _i175;
-import '../../features/auth/domain/usecases/login_usecase.dart' as _i200;
-import '../../features/auth/domain/usecases/logout_usecase.dart' as _i201;
+    as _i172;
+import '../../features/auth/domain/usecases/login_usecase.dart' as _i197;
+import '../../features/auth/domain/usecases/logout_usecase.dart' as _i198;
 import '../../features/auth/domain/usecases/save_credentials_usecase.dart'
-    as _i213;
-import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i220;
+    as _i210;
+import '../../features/auth/domain/usecases/set_pin_usecase.dart' as _i217;
 import '../../features/auth/domain/usecases/validate_session_usecase.dart'
-    as _i226;
+    as _i225;
 import '../../features/auth/infrastructure/services/biometric_service.dart'
     as _i16;
 import '../../features/auth/infrastructure/services/encryption_service.dart'
-    as _i166;
+    as _i164;
 import '../../features/calendar_import/application/calendar_import_cubit.dart'
-    as _i236;
+    as _i235;
 import '../../features/calendar_import/domain/repositories/calendar_import_repository.dart'
     as _i21;
 import '../../features/calendar_import/domain/services/calendar_parser_service.dart'
     as _i23;
 import '../../features/calendar_import/domain/usecases/import_calendar_usecase.dart'
-    as _i193;
+    as _i190;
 import '../../features/calendar_import/infrastructure/datasources/calendar_api_datasource.dart'
     as _i19;
 import '../../features/calendar_import/infrastructure/repositories/calendar_import_repository_impl.dart'
@@ -100,75 +100,75 @@ import '../../features/calendar_import/infrastructure/repositories/calendar_impo
 import '../../features/calendar_import/infrastructure/services/calendar_parser_service_impl.dart'
     as _i24;
 import '../../features/clinical_assessments/application/clinical_assessments_cubit.dart'
-    as _i237;
+    as _i236;
 import '../../features/clinical_assessments/domain/repositories/i_assessment_repository.dart'
-    as _i191;
+    as _i188;
 import '../../features/clinical_assessments/infrastructure/datasources/assessment_local_datasource.dart'
-    as _i146;
+    as _i144;
 import '../../features/clinical_assessments/infrastructure/repositories/assessment_repository_impl.dart'
-    as _i192;
+    as _i189;
 import '../../features/dashboard/application/dashboard_cubit.dart' as _i270;
 import '../../features/dashboard/domain/repositories/dashboard_repository.dart'
-    as _i239;
+    as _i238;
 import '../../features/dashboard/domain/usecases/get_dashboard_stats_usecase.dart'
     as _i249;
 import '../../features/dashboard/domain/usecases/get_recent_activity_usecase.dart'
     as _i251;
 import '../../features/dashboard/infrastructure/datasources/dashboard_local_datasource.dart'
-    as _i157;
+    as _i155;
 import '../../features/dashboard/infrastructure/datasources/dashboard_remote_datasource.dart'
     as _i27;
 import '../../features/dashboard/infrastructure/repositories/dashboard_repository_impl.dart'
-    as _i240;
+    as _i239;
 import '../../features/data_sources/application/data_source_cubit.dart'
     as _i271;
 import '../../features/data_sources/domain/repositories/data_source_repository.dart'
-    as _i241;
+    as _i240;
 import '../../features/data_sources/infrastructure/datasources/file_import_datasource.dart'
-    as _i168;
+    as _i165;
 import '../../features/data_sources/infrastructure/datasources/health_connect_datasource.dart'
-    as _i186;
+    as _i183;
 import '../../features/data_sources/infrastructure/datasources/sensor_api_datasource.dart'
     as _i116;
 import '../../features/data_sources/infrastructure/repositories/data_source_repository_impl.dart'
-    as _i242;
+    as _i241;
 import '../../features/doctor_verification/application/badge_cubit.dart'
-    as _i235;
+    as _i234;
 import '../../features/doctor_verification/application/doctor_verification_cubit.dart'
-    as _i163;
-import '../../features/doctor_verification/application/second_opinion_cubit.dart'
-    as _i218;
-import '../../features/doctor_verification/application/vouch_cubit.dart'
-    as _i229;
-import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
     as _i161;
+import '../../features/doctor_verification/application/second_opinion_cubit.dart'
+    as _i215;
+import '../../features/doctor_verification/application/vouch_cubit.dart'
+    as _i228;
+import '../../features/doctor_verification/domain/repositories/doctor_profile_repository.dart'
+    as _i159;
 import '../../features/doctor_verification/domain/repositories/rating_repository.dart'
     as _i104;
 import '../../features/doctor_verification/domain/repositories/second_opinion_repository.dart'
     as _i112;
 import '../../features/doctor_verification/domain/repositories/vouch_repository.dart'
-    as _i140;
+    as _i138;
 import '../../features/doctor_verification/domain/services/badge_calculator.dart'
-    as _i234;
+    as _i233;
 import '../../features/doctor_verification/domain/services/license_verifier.dart'
     as _i62;
 import '../../features/doctor_verification/domain/usecases/get_all_doctors_usecase.dart'
-    as _i170;
+    as _i167;
 import '../../features/doctor_verification/domain/usecases/get_doctor_profile_usecase.dart'
-    as _i176;
+    as _i173;
 import '../../features/doctor_verification/infrastructure/datasources/license_registry_local.dart'
     as _i61;
 import '../../features/doctor_verification/infrastructure/repositories/isar_doctor_profile_repository.dart'
-    as _i162;
+    as _i160;
 import '../../features/doctor_verification/infrastructure/repositories/isar_rating_repository.dart'
     as _i105;
 import '../../features/doctor_verification/infrastructure/repositories/isar_second_opinion_repository.dart'
     as _i113;
 import '../../features/doctor_verification/infrastructure/repositories/isar_vouch_repository.dart'
-    as _i141;
+    as _i139;
 import '../../features/email-citas/application/bloc/email_citas_bloc.dart'
-    as _i164;
-import '../../features/email-citas/application/email_citas_cubit.dart' as _i165;
+    as _i162;
+import '../../features/email-citas/application/email_citas_cubit.dart' as _i163;
 import '../../features/email-citas/domain/repositories/email_repository.dart'
     as _i32;
 import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
@@ -176,17 +176,17 @@ import '../../features/email-citas/domain/usecases/email_citas_usecases.dart'
 import '../../features/email-citas/infrastructure/repositories/email_repository_impl.dart'
     as _i33;
 import '../../features/eps_connection/application/bloc/eps_connection_bloc.dart'
-    as _i244;
+    as _i243;
 import '../../features/eps_connection/application/bloc/eps_connection_cubit.dart'
-    as _i245;
+    as _i244;
 import '../../features/eps_connection/domain/repositories/oauth_repository.dart'
     as _i97;
 import '../../features/eps_connection/domain/usecases/connect_provider_usecase.dart'
-    as _i156;
+    as _i154;
 import '../../features/eps_connection/domain/usecases/disconnect_provider_usecase.dart'
-    as _i158;
+    as _i156;
 import '../../features/eps_connection/domain/usecases/get_connections_usecase.dart'
-    as _i174;
+    as _i171;
 import '../../features/eps_connection/infrastructure/datasources/oauth_local_datasource.dart'
     as _i96;
 import '../../features/eps_connection/infrastructure/repositories/local_fhir_oauth_repository.dart'
@@ -198,7 +198,7 @@ import '../../features/health_data_import/application/bloc/health_import_bloc.da
 import '../../features/health_data_import/application/health_import_cubit.dart'
     as _i253;
 import '../../features/health_data_import/domain/repositories/health_data_import_repository.dart'
-    as _i187;
+    as _i184;
 import '../../features/health_data_import/domain/services/health_data_import_service.dart'
     as _i45;
 import '../../features/health_data_import/domain/usecases/health_import_usecases.dart'
@@ -206,17 +206,17 @@ import '../../features/health_data_import/domain/usecases/health_import_usecases
 import '../../features/health_data_import/infrastructure/data_source.dart'
     as _i117;
 import '../../features/health_data_import/infrastructure/health_data_import_repository_impl.dart'
-    as _i188;
+    as _i185;
 import '../../features/health_record/application/bloc/health_record_cubit.dart'
     as _i254;
 import '../../features/health_record/domain/repositories/health_record_repository.dart'
-    as _i189;
+    as _i186;
 import '../../features/health_record/domain/usecases/get_all_records_usecase.dart'
     as _i247;
 import '../../features/health_record/domain/usecases/save_record_usecase.dart'
-    as _i215;
+    as _i212;
 import '../../features/health_record/infrastructure/repositories/health_record_repository_impl.dart'
-    as _i190;
+    as _i187;
 import '../../features/health_record/infrastructure/services/file_picker_service.dart'
     as _i37;
 import '../../features/health_record/infrastructure/services/image_picker_service.dart'
@@ -227,13 +227,13 @@ import '../../features/health_sharing/application/sharing_cubit.dart' as _i266;
 import '../../features/health_sharing/domain/repositories/sharing_repository.dart'
     as _i121;
 import '../../features/health_sharing/domain/usecases/cancel_sharing_usecase.dart'
-    as _i151;
+    as _i149;
 import '../../features/health_sharing/domain/usecases/start_listening_usecase.dart'
-    as _i222;
+    as _i219;
 import '../../features/health_sharing/domain/usecases/start_sharing_usecase.dart'
-    as _i223;
+    as _i220;
 import '../../features/health_sharing/infrastructure/ble_sharing_service.dart'
-    as _i150;
+    as _i148;
 import '../../features/health_sharing/infrastructure/ble_wrapper.dart' as _i17;
 import '../../features/health_sharing/infrastructure/datasources/health_sharing_local_datasource.dart'
     as _i46;
@@ -245,7 +245,7 @@ import '../../features/health_sharing/infrastructure/nfc_sharing_service.dart'
 import '../../features/health_sharing/infrastructure/repositories/health_sharing_repository_impl.dart'
     as _i122;
 import '../../features/health_sharing/infrastructure/wifi_direct_service.dart'
-    as _i142;
+    as _i140;
 import '../../features/home/application/home_cubit.dart' as _i274;
 import '../../features/home/domain/repositories/home_repository.dart' as _i255;
 import '../../features/home/domain/usecases/get_health_summary_usecase.dart'
@@ -259,18 +259,18 @@ import '../../features/home/infrastructure/datasources/home_remote_datasource.da
 import '../../features/home/infrastructure/repositories/home_repository_impl.dart'
     as _i256;
 import '../../features/local_agent/application/use_cases/smart_search_use_case.dart'
-    as _i221;
+    as _i218;
 import '../../features/local_agent/data/datasources/chat_message_local_datasource.dart'
-    as _i152;
+    as _i150;
 import '../../features/local_agent/data/datasources/local_model_local_datasource.dart'
     as _i67;
 import '../../features/local_agent/domain/repositories/medical_knowledge_repository.dart'
     as _i69;
 import '../../features/local_agent/domain/services/llm_adapter.dart' as _i63;
 import '../../features/local_agent/domain/services/vector_store_service.dart'
-    as _i133;
+    as _i131;
 import '../../features/local_agent/domain/usecases/get_chat_history_usecase.dart'
-    as _i173;
+    as _i169;
 import '../../features/local_agent/domain/usecases/send_chat_message_usecase.dart'
     as _i115;
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter.dart'
@@ -278,16 +278,16 @@ import '../../features/local_agent/infrastructure/adapters/flutter_gemma_adapter
 import '../../features/local_agent/infrastructure/adapters/flutter_gemma_wrapper.dart'
     as _i40;
 import '../../features/local_agent/infrastructure/adapters/gemini_llm_adapter.dart'
-    as _i195;
+    as _i191;
 import '../../features/local_agent/infrastructure/adapters/gemini_model_wrapper.dart'
     as _i42;
 import '../../features/local_agent/infrastructure/adapters/mock_llm_adapter.dart'
-    as _i194;
+    as _i192;
 import '../../features/local_agent/infrastructure/adapters/openai_compatible_adapter.dart'
     as _i65;
 import '../../features/local_agent/infrastructure/gemma_llm_service.dart'
-    as _i198;
-import '../../features/local_agent/infrastructure/llm_service.dart' as _i197;
+    as _i195;
+import '../../features/local_agent/infrastructure/llm_service.dart' as _i194;
 import '../../features/local_agent/infrastructure/rag_llm_service.dart'
     as _i257;
 import '../../features/local_agent/infrastructure/repositories/asset_medical_knowledge_repository.dart'
@@ -295,9 +295,9 @@ import '../../features/local_agent/infrastructure/repositories/asset_medical_kno
 import '../../features/local_agent/infrastructure/repositories/json_medical_knowledge_repository.dart'
     as _i71;
 import '../../features/local_agent/infrastructure/services/isar_vector_store_service.dart'
-    as _i134;
+    as _i132;
 import '../../features/local_agent/infrastructure/services/llm_adapter_factory.dart'
-    as _i196;
+    as _i193;
 import '../../features/local_agent/infrastructure/services/local_llm_service.dart'
     as _i66;
 import '../../features/local_agent/infrastructure/services/medical_indexing_service.dart'
@@ -323,7 +323,7 @@ import '../../features/medical_research/domain/usecases/search_medical_research.
 import '../../features/medical_research/infrastructure/bot_bypass_handler.dart'
     as _i18;
 import '../../features/medical_research/infrastructure/medical_research_service.dart'
-    as _i202;
+    as _i199;
 import '../../features/medical_research/infrastructure/medical_scraper_service_impl.dart'
     as _i73;
 import '../../features/medical_research/infrastructure/medical_standards_service_impl.dart'
@@ -334,34 +334,34 @@ import '../../features/medical_research/infrastructure/repositories/medical_rese
     as _i259;
 import '../../features/medications/application/bloc/medication_bloc.dart'
     as _i260;
-import '../../features/medications/application/medications_cubit.dart' as _i205;
+import '../../features/medications/application/medications_cubit.dart' as _i202;
 import '../../features/medications/domain/repositories/medication_adherence_repository.dart'
     as _i78;
 import '../../features/medications/domain/repositories/medication_repository.dart'
-    as _i203;
+    as _i200;
 import '../../features/medications/domain/usecases/get_all_medications_usecase.dart'
     as _i246;
 import '../../features/medications/domain/usecases/save_medication_usecase.dart'
-    as _i214;
+    as _i211;
 import '../../features/medications/infrastructure/datasources/adherence_sqlite_datasource.dart'
     as _i5;
 import '../../features/medications/infrastructure/repositories/isar_medication_repository.dart'
-    as _i204;
+    as _i201;
 import '../../features/medications/infrastructure/repositories/sqlite_medication_adherence_repository.dart'
     as _i79;
 import '../../features/medications/infrastructure/services/pharmacy_api_service.dart'
     as _i101;
 import '../../features/medications/infrastructure/services/rxnorm_api_service.dart'
     as _i102;
-import '../../features/meditation/application/meditation_cubit.dart' as _i206;
+import '../../features/meditation/application/meditation_cubit.dart' as _i203;
 import '../../features/meditation/domain/repositories/meditation_repository.dart'
     as _i81;
 import '../../features/meditation/domain/usecases/complete_session_usecase.dart'
-    as _i154;
+    as _i152;
 import '../../features/meditation/domain/usecases/get_progress_usecase.dart'
-    as _i179;
+    as _i176;
 import '../../features/meditation/domain/usecases/get_scripts_usecase.dart'
-    as _i181;
+    as _i178;
 import '../../features/meditation/domain/usecases/recommend_script_usecase.dart'
     as _i106;
 import '../../features/meditation/domain/usecases/start_session_usecase.dart'
@@ -370,15 +370,15 @@ import '../../features/meditation/infrastructure/datasources/meditation_local_da
     as _i80;
 import '../../features/meditation/infrastructure/repositories/meditation_repository_impl.dart'
     as _i82;
-import '../../features/network/application/network_cubit.dart' as _i207;
+import '../../features/network/application/network_cubit.dart' as _i204;
 import '../../features/network/domain/repositories/network_peer_repository.dart'
     as _i87;
 import '../../features/network/governance/domain/repositories/governance_repository.dart'
-    as _i184;
+    as _i181;
 import '../../features/network/governance/infrastructure/datasources/governance_ipfs_datasource.dart'
-    as _i183;
+    as _i180;
 import '../../features/network/governance/infrastructure/repositories/governance_repository_impl.dart'
-    as _i185;
+    as _i182;
 import '../../features/network/incentives/domain/repositories/incentive_repository.dart'
     as _i57;
 import '../../features/network/incentives/infrastructure/datasources/incentive_datasource.dart'
@@ -390,45 +390,45 @@ import '../../features/network/infrastructure/datasources/network_p2p_api.dart'
 import '../../features/network/infrastructure/repositories/network_peer_repository_impl.dart'
     as _i88;
 import '../../features/network/network_health/application/network_health_cubit.dart'
-    as _i208;
+    as _i205;
 import '../../features/network/network_health/domain/repositories/network_repository.dart'
     as _i89;
 import '../../features/network/network_health/domain/usecases/connect_node.dart'
-    as _i155;
+    as _i153;
 import '../../features/network/network_health/domain/usecases/get_network_health.dart'
-    as _i177;
+    as _i174;
 import '../../features/network/network_health/domain/usecases/get_node_stats.dart'
-    as _i178;
+    as _i175;
 import '../../features/network/network_health/infrastructure/datasources/network_datasource.dart'
     as _i85;
 import '../../features/network/network_health/infrastructure/repositories/network_repository_impl.dart'
     as _i90;
 import '../../features/onboarding/application/onboarding_cubit.dart' as _i261;
-import '../../features/onboarding/application/sync_cubit.dart' as _i224;
+import '../../features/onboarding/application/sync_cubit.dart' as _i221;
 import '../../features/onboarding/domain/repositories/onboarding_repository.dart'
-    as _i209;
+    as _i206;
 import '../../features/onboarding/domain/usecases/complete_onboarding_usecase.dart'
-    as _i238;
+    as _i237;
 import '../../features/onboarding/domain/usecases/get_onboarding_profile_usecase.dart'
     as _i250;
 import '../../features/onboarding/infrastructure/repositories/onboarding_repository_impl.dart'
-    as _i210;
+    as _i207;
 import '../../features/reports/application/bloc/report_bloc.dart' as _i263;
 import '../../features/reports/domain/repositories/report_repository.dart'
     as _i107;
 import '../../features/reports/domain/services/report_generation_service.dart'
-    as _i211;
+    as _i208;
 import '../../features/reports/domain/usecases/get_reports_usecase.dart'
-    as _i180;
+    as _i177;
 import '../../features/reports/domain/usecases/save_report_usecase.dart'
     as _i111;
 import '../../features/reports/infrastructure/repositories/isar_report_repository.dart'
     as _i108;
 import '../../features/reports/infrastructure/services/gemma_report_generation_service.dart'
-    as _i212;
+    as _i209;
 import '../../features/reports/infrastructure/services/mock_report_generation_service.dart'
     as _i83;
-import '../../features/settings/application/llm_settings_cubit.dart' as _i199;
+import '../../features/settings/application/llm_settings_cubit.dart' as _i196;
 import '../../features/settings/domain/repositories/settings_repository.dart'
     as _i119;
 import '../../features/settings/domain/services/device_capability_service.dart'
@@ -437,15 +437,15 @@ import '../../features/settings/infrastructure/datasources/settings_local_dataso
     as _i118;
 import '../../features/settings/infrastructure/repositories/settings_repository_impl.dart'
     as _i120;
-import '../../features/sync/application/sync_cubit.dart' as _i167;
+import '../../features/sync/application/sync_cubit.dart' as _i245;
 import '../../features/sync/domain/repositories/sync_repository.dart' as _i125;
 import '../../features/sync/domain/services/distributed_storage_service.dart'
-    as _i159;
+    as _i157;
 import '../../features/sync/domain/services/node_discovery_service.dart'
     as _i94;
-import '../../features/sync/domain/services/sync_service.dart' as _i127;
+import '../../features/sync/domain/services/sync_service.dart' as _i222;
 import '../../features/sync/domain/usecases/distributed_cache_usecase.dart'
-    as _i243;
+    as _i242;
 import '../../features/sync/infrastructure/datasources/filecoin_datasource.dart'
     as _i38;
 import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
@@ -453,46 +453,46 @@ import '../../features/sync/infrastructure/datasources/ipfs_datasource.dart'
 import '../../features/sync/infrastructure/repositories/sync_repository_impl.dart'
     as _i126;
 import '../../features/sync/infrastructure/services/fhir_client.dart' as _i36;
-import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i160;
+import '../../features/sync/infrastructure/services/ipfs_service.dart' as _i158;
 import '../../features/sync/infrastructure/services/node_discovery_service.dart'
     as _i95;
 import '../../features/sync/infrastructure/services/sync_service_impl.dart'
-    as _i128;
+    as _i223;
 import '../../features/user_profile/application/bloc/user_profile_cubit.dart'
-    as _i225;
+    as _i224;
 import '../../features/user_profile/data/datasources/user_profile_local_datasource.dart'
-    as _i129;
+    as _i127;
 import '../../features/user_profile/domain/repositories/user_profile_repository.dart'
-    as _i130;
+    as _i128;
 import '../../features/user_profile/domain/services/user_profile_service.dart'
-    as _i132;
+    as _i130;
 import '../../features/user_profile/domain/usecases/get_user_profile_usecase.dart'
-    as _i182;
+    as _i179;
 import '../../features/user_profile/domain/usecases/save_user_profile_usecase.dart'
-    as _i216;
+    as _i213;
 import '../../features/user_profile/infrastructure/repositories/user_profile_repository_impl.dart'
-    as _i131;
-import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i227;
-import '../../features/vitals/application/vitals_cubit.dart' as _i137;
+    as _i129;
+import '../../features/vitals/application/bloc/vital_sign_bloc.dart' as _i226;
+import '../../features/vitals/application/vitals_cubit.dart' as _i135;
 import '../../features/vitals/domain/repositories/vital_sign_repository.dart'
-    as _i135;
+    as _i133;
 import '../../features/vitals/domain/usecases/get_all_vital_signs_usecase.dart'
-    as _i171;
+    as _i168;
 import '../../features/vitals/domain/usecases/save_vital_signs_usecase.dart'
-    as _i217;
+    as _i214;
 import '../../features/vitals/infrastructure/repositories/vital_sign_repository_impl.dart'
-    as _i136;
-import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i228;
+    as _i134;
+import '../../features/voice_chat/application/voice_chat_cubit.dart' as _i227;
 import '../../features/voice_chat/domain/repositories/voice_chat_repository.dart'
-    as _i138;
+    as _i136;
 import '../../features/voice_chat/domain/usecases/get_chat_history_usecase.dart'
-    as _i172;
+    as _i170;
 import '../../features/voice_chat/domain/usecases/send_message_usecase.dart'
-    as _i219;
+    as _i216;
 import '../../features/voice_chat/infrastructure/datasources/chat_ai_datasource.dart'
     as _i25;
 import '../../features/voice_chat/infrastructure/repositories/voice_chat_repository_impl.dart'
-    as _i139;
+    as _i137;
 import '../logging/audit_logger.dart' as _i15;
 import '../services/aicore_service.dart' as _i3;
 import '../services/asr/asr_service.dart' as _i11;
@@ -511,9 +511,9 @@ import 'service_module.dart' as _i277;
 const String _mobile = 'mobile';
 const String _desktop = 'desktop';
 const String _test = 'test';
-const String _production = 'production';
 const String _development = 'development';
 const String _staging = 'staging';
+const String _production = 'production';
 
 extension GetItInjectableX on _i1.GetIt {
 // initializes the registration of main-scope dependencies inside of GetIt
@@ -764,354 +764,354 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i94.NodeDiscoveryService>(),
         ));
     gh.lazySingleton<_i68.SyncService>(() => networkModule.syncService);
-    gh.lazySingleton<_i127.SyncService>(() => _i128.SyncServiceImpl(
-          gh<_i125.SyncRepository>(),
-          gh<_i68.SyncService>(),
-        ));
-    gh.lazySingleton<_i129.UserProfileLocalDataSource>(
-        () => _i129.UserProfileLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i130.UserProfileRepository>(
-        () => _i131.UserProfileRepositoryImpl(gh<_i60.Isar>()));
-    gh.lazySingleton<_i132.UserProfileService>(
-        () => _i132.UserProfileService(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i133.VectorStoreService>(
-        () => _i134.IsarVectorStoreService(
+    gh.lazySingleton<_i127.UserProfileLocalDataSource>(
+        () => _i127.UserProfileLocalDataSource(gh<_i60.Isar>()));
+    gh.lazySingleton<_i128.UserProfileRepository>(
+        () => _i129.UserProfileRepositoryImpl(gh<_i60.Isar>()));
+    gh.lazySingleton<_i130.UserProfileService>(
+        () => _i130.UserProfileService(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i131.VectorStoreService>(
+        () => _i132.IsarVectorStoreService(
               gh<_i34.MemoryGraph>(),
               gh<_i69.MedicalKnowledgeRepository>(),
             ));
-    gh.lazySingleton<_i135.VitalSignRepository>(
-        () => _i136.VitalSignRepositoryImpl(gh<_i60.Isar>()));
-    gh.factory<_i137.VitalsCubit>(
-        () => _i137.VitalsCubit(gh<_i135.VitalSignRepository>()));
-    gh.lazySingleton<_i138.VoiceChatRepository>(
-        () => _i139.VoiceChatRepositoryImpl(gh<_i25.ChatAiDatasource>()));
-    gh.lazySingleton<_i140.VouchRepository>(
-        () => _i141.IsarVouchRepository(gh<_i60.Isar>()));
+    gh.lazySingleton<_i133.VitalSignRepository>(
+        () => _i134.VitalSignRepositoryImpl(gh<_i60.Isar>()));
+    gh.factory<_i135.VitalsCubit>(
+        () => _i135.VitalsCubit(gh<_i133.VitalSignRepository>()));
+    gh.lazySingleton<_i136.VoiceChatRepository>(
+        () => _i137.VoiceChatRepositoryImpl(gh<_i25.ChatAiDatasource>()));
+    gh.lazySingleton<_i138.VouchRepository>(
+        () => _i139.IsarVouchRepository(gh<_i60.Isar>()));
     gh.lazySingleton<_i35.WalletService>(() => databaseModule.walletService(
           gh<_i60.Isar>(),
           gh<_i35.EncryptionService>(),
         ));
-    gh.lazySingleton<_i142.WifiDirectService>(() => _i142.WifiDirectService());
-    gh.factory<_i143.AboutCubit>(
-        () => _i143.AboutCubit(gh<_i53.IAboutRepository>()));
-    gh.lazySingleton<_i144.AboutRemoteDataSource>(
-        () => _i144.AboutRemoteDataSource(gh<_i31.Dio>()));
-    gh.lazySingleton<_i145.AllergyLocalDataSource>(
-        () => _i145.AllergyLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i146.AssessmentLocalDataSource>(
-        () => _i146.AssessmentLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i147.AuthLocalDataSource>(
-        () => _i147.AuthLocalDataSource(gh<_i60.Isar>()));
-    gh.lazySingleton<_i148.AuthRepository>(() => _i149.AuthRepositoryImpl(
-          gh<_i147.AuthLocalDataSource>(),
+    gh.lazySingleton<_i140.WifiDirectService>(() => _i140.WifiDirectService());
+    gh.factory<_i141.AboutCubit>(
+        () => _i141.AboutCubit(gh<_i53.IAboutRepository>()));
+    gh.lazySingleton<_i142.AboutRemoteDataSource>(
+        () => _i142.AboutRemoteDataSource(gh<_i31.Dio>()));
+    gh.lazySingleton<_i143.AllergyLocalDataSource>(
+        () => _i143.AllergyLocalDataSource(gh<_i60.Isar>()));
+    gh.lazySingleton<_i144.AssessmentLocalDataSource>(
+        () => _i144.AssessmentLocalDataSource(gh<_i60.Isar>()));
+    gh.lazySingleton<_i145.AuthLocalDataSource>(
+        () => _i145.AuthLocalDataSource(gh<_i60.Isar>()));
+    gh.lazySingleton<_i146.AuthRepository>(() => _i147.AuthRepositoryImpl(
+          gh<_i145.AuthLocalDataSource>(),
           gh<_i114.SecureStorageService>(),
         ));
-    gh.lazySingleton<_i150.BleSharingService>(
-        () => _i150.BleSharingService(gh<_i17.BleWrapper>()));
-    gh.lazySingleton<_i151.CancelSharingUseCase>(
-        () => _i151.CancelSharingUseCase(
-              gh<_i150.BleSharingService>(),
+    gh.lazySingleton<_i148.BleSharingService>(
+        () => _i148.BleSharingService(gh<_i17.BleWrapper>()));
+    gh.lazySingleton<_i149.CancelSharingUseCase>(
+        () => _i149.CancelSharingUseCase(
+              gh<_i148.BleSharingService>(),
               gh<_i93.NfcSharingService>(),
-              gh<_i142.WifiDirectService>(),
+              gh<_i140.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i152.ChatMessageLocalDataSource>(
-        () => _i152.ChatMessageLocalDataSource(gh<_i60.Isar>()));
-    gh.factory<_i153.CheckSessionTimeoutUseCase>(
-        () => _i153.CheckSessionTimeoutUseCase(gh<_i148.AuthRepository>()));
-    gh.lazySingleton<_i154.CompleteSessionUseCase>(
-        () => _i154.CompleteSessionUseCase(gh<_i81.MeditationRepository>()));
+    gh.lazySingleton<_i150.ChatMessageLocalDataSource>(
+        () => _i150.ChatMessageLocalDataSource(gh<_i60.Isar>()));
+    gh.factory<_i151.CheckSessionTimeoutUseCase>(
+        () => _i151.CheckSessionTimeoutUseCase(gh<_i146.AuthRepository>()));
+    gh.lazySingleton<_i152.CompleteSessionUseCase>(
+        () => _i152.CompleteSessionUseCase(gh<_i81.MeditationRepository>()));
     gh.factory<_i124.ConnectEmailProviderUseCase>(
         () => _i124.ConnectEmailProviderUseCase(gh<_i32.EmailRepository>()));
-    gh.lazySingleton<_i155.ConnectNode>(
-        () => _i155.ConnectNode(gh<_i89.NetworkRepository>()));
-    gh.factory<_i156.ConnectProviderUseCase>(() => _i156.ConnectProviderUseCase(
+    gh.lazySingleton<_i153.ConnectNode>(
+        () => _i153.ConnectNode(gh<_i89.NetworkRepository>()));
+    gh.factory<_i154.ConnectProviderUseCase>(() => _i154.ConnectProviderUseCase(
           gh<_i97.OAuthRepository>(),
-          gh<_i130.UserProfileRepository>(),
+          gh<_i128.UserProfileRepository>(),
         ));
-    gh.lazySingleton<_i157.DashboardLocalDataSource>(
-        () => _i157.DashboardLocalDataSource(gh<_i60.Isar>()));
-    gh.factory<_i158.DisconnectProviderUseCase>(
-        () => _i158.DisconnectProviderUseCase(
+    gh.lazySingleton<_i155.DashboardLocalDataSource>(
+        () => _i155.DashboardLocalDataSource(gh<_i60.Isar>()));
+    gh.factory<_i156.DisconnectProviderUseCase>(
+        () => _i156.DisconnectProviderUseCase(
               gh<_i97.OAuthRepository>(),
-              gh<_i130.UserProfileRepository>(),
+              gh<_i128.UserProfileRepository>(),
             ));
-    gh.lazySingleton<_i159.DistributedStorageService>(() => _i160.IpfsService(
+    gh.lazySingleton<_i157.DistributedStorageService>(() => _i158.IpfsService(
           gh<_i59.IpfsDatasource>(),
           gh<_i38.FilecoinDatasource>(),
         ));
-    gh.lazySingleton<_i161.DoctorProfileRepository>(
-        () => _i162.IsarDoctorProfileRepository(gh<_i60.Isar>()));
-    gh.factoryAsync<_i163.DoctorVerificationCubit>(
-        () async => _i163.DoctorVerificationCubit(
-              gh<_i161.DoctorProfileRepository>(),
+    gh.lazySingleton<_i159.DoctorProfileRepository>(
+        () => _i160.IsarDoctorProfileRepository(gh<_i60.Isar>()));
+    gh.factoryAsync<_i161.DoctorVerificationCubit>(
+        () async => _i161.DoctorVerificationCubit(
+              gh<_i159.DoctorProfileRepository>(),
               gh<_i104.RatingRepository>(),
               await getAsync<_i62.LicenseVerifier>(),
             ));
-    gh.factory<_i164.EmailCitasBloc>(() => _i164.EmailCitasBloc(
+    gh.factory<_i162.EmailCitasBloc>(() => _i162.EmailCitasBloc(
           gh<_i124.ConnectEmailProviderUseCase>(),
           gh<_i124.SyncEmailAppointmentsUseCase>(),
           gh<_i32.EmailRepository>(),
           gh<_i8.AppointmentRepository>(),
         ));
-    gh.factory<_i165.EmailCitasCubit>(() => _i165.EmailCitasCubit(
+    gh.factory<_i163.EmailCitasCubit>(() => _i163.EmailCitasCubit(
           gh<_i32.EmailRepository>(),
           gh<_i8.AppointmentRepository>(),
         ));
-    gh.lazySingleton<_i166.EncryptionService>(
-        () => _i166.EncryptionService(gh<_i114.SecureStorageService>()));
-    gh.factory<_i167.FhirSyncCubit>(() => _i167.FhirSyncCubit(
-          gh<_i127.SyncService>(),
-          gh<_i94.NodeDiscoveryService>(),
-        ));
+    gh.lazySingleton<_i164.EncryptionService>(
+        () => _i164.EncryptionService(gh<_i114.SecureStorageService>()));
     gh.lazySingleton<_i117.FileHealthDataSource>(
         () => _i117.FileHealthDataSourceImpl(
               gh<_i37.FilePickerService>(),
               gh<_i100.OcrService>(),
             ));
-    gh.lazySingleton<_i168.FileImportDataSource>(
-        () => _i168.FileImportDataSourceImpl(
+    gh.lazySingleton<_i165.FileImportDataSource>(
+        () => _i165.FileImportDataSourceImpl(
               gh<_i37.FilePickerService>(),
               gh<_i100.OcrService>(),
             ));
-    gh.factory<_i169.GetAboutInfoUseCase>(
-        () => _i169.GetAboutInfoUseCase(gh<_i53.IAboutRepository>()));
-    gh.factory<_i170.GetAllDoctorsUseCase>(
-        () => _i170.GetAllDoctorsUseCase(gh<_i161.DoctorProfileRepository>()));
-    gh.factory<_i171.GetAllVitalSignsUseCase>(
-        () => _i171.GetAllVitalSignsUseCase(gh<_i135.VitalSignRepository>()));
+    gh.factory<_i166.GetAboutInfoUseCase>(
+        () => _i166.GetAboutInfoUseCase(gh<_i53.IAboutRepository>()));
+    gh.factory<_i167.GetAllDoctorsUseCase>(
+        () => _i167.GetAllDoctorsUseCase(gh<_i159.DoctorProfileRepository>()));
+    gh.factory<_i168.GetAllVitalSignsUseCase>(
+        () => _i168.GetAllVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
     gh.factory<_i109.GetAvailableSourcesUseCase>(() =>
         _i109.GetAvailableSourcesUseCase(gh<_i45.HealthDataImportService>()));
-    gh.factory<_i172.GetChatHistoryUseCase>(
-        () => _i172.GetChatHistoryUseCase(gh<_i138.VoiceChatRepository>()));
-    gh.factory<_i173.GetChatHistoryUseCase>(
-        () => _i173.GetChatHistoryUseCase(gh<_i133.VectorStoreService>()));
-    gh.factory<_i174.GetConnectionsUseCase>(
-        () => _i174.GetConnectionsUseCase(gh<_i97.OAuthRepository>()));
-    gh.factory<_i175.GetCredentialsUseCase>(
-        () => _i175.GetCredentialsUseCase(gh<_i148.AuthRepository>()));
-    gh.factory<_i176.GetDoctorProfileUseCase>(() =>
-        _i176.GetDoctorProfileUseCase(gh<_i161.DoctorProfileRepository>()));
-    gh.lazySingleton<_i177.GetNetworkHealth>(
-        () => _i177.GetNetworkHealth(gh<_i89.NetworkRepository>()));
-    gh.lazySingleton<_i178.GetNodeStats>(
-        () => _i178.GetNodeStats(gh<_i89.NetworkRepository>()));
-    gh.lazySingleton<_i179.GetProgressUseCase>(
-        () => _i179.GetProgressUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i180.GetReportsUseCase>(
-        () => _i180.GetReportsUseCase(gh<_i107.ReportRepository>()));
-    gh.lazySingleton<_i181.GetScriptsUseCase>(
-        () => _i181.GetScriptsUseCase(gh<_i81.MeditationRepository>()));
-    gh.factory<_i182.GetUserProfileUseCase>(
-        () => _i182.GetUserProfileUseCase(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i183.GovernanceIpfsDatasource>(
-        () => _i183.GovernanceIpfsDatasource(gh<_i59.IpfsDatasource>()));
-    gh.lazySingleton<_i184.GovernanceRepository>(() =>
-        _i185.GovernanceRepositoryImpl(gh<_i183.GovernanceIpfsDatasource>()));
-    gh.lazySingleton<_i186.HealthConnectDataSource>(
-        () => _i186.HealthConnectDataSourceImpl(gh<_i49.HealthWrapper>()));
-    gh.lazySingleton<_i187.HealthDataImportRepository>(
-        () => _i188.HealthDataImportRepositoryImpl(
+    gh.factory<_i169.GetChatHistoryUseCase>(
+        () => _i169.GetChatHistoryUseCase(gh<_i131.VectorStoreService>()));
+    gh.factory<_i170.GetChatHistoryUseCase>(
+        () => _i170.GetChatHistoryUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i171.GetConnectionsUseCase>(
+        () => _i171.GetConnectionsUseCase(gh<_i97.OAuthRepository>()));
+    gh.factory<_i172.GetCredentialsUseCase>(
+        () => _i172.GetCredentialsUseCase(gh<_i146.AuthRepository>()));
+    gh.factory<_i173.GetDoctorProfileUseCase>(() =>
+        _i173.GetDoctorProfileUseCase(gh<_i159.DoctorProfileRepository>()));
+    gh.lazySingleton<_i174.GetNetworkHealth>(
+        () => _i174.GetNetworkHealth(gh<_i89.NetworkRepository>()));
+    gh.lazySingleton<_i175.GetNodeStats>(
+        () => _i175.GetNodeStats(gh<_i89.NetworkRepository>()));
+    gh.lazySingleton<_i176.GetProgressUseCase>(
+        () => _i176.GetProgressUseCase(gh<_i81.MeditationRepository>()));
+    gh.factory<_i177.GetReportsUseCase>(
+        () => _i177.GetReportsUseCase(gh<_i107.ReportRepository>()));
+    gh.lazySingleton<_i178.GetScriptsUseCase>(
+        () => _i178.GetScriptsUseCase(gh<_i81.MeditationRepository>()));
+    gh.factory<_i179.GetUserProfileUseCase>(
+        () => _i179.GetUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i180.GovernanceIpfsDatasource>(
+        () => _i180.GovernanceIpfsDatasource(gh<_i59.IpfsDatasource>()));
+    gh.lazySingleton<_i181.GovernanceRepository>(() =>
+        _i182.GovernanceRepositoryImpl(gh<_i180.GovernanceIpfsDatasource>()));
+    gh.lazySingleton<_i183.HealthConnectDataSource>(
+        () => _i183.HealthConnectDataSourceImpl(gh<_i49.HealthWrapper>()));
+    gh.lazySingleton<_i184.HealthDataImportRepository>(
+        () => _i185.HealthDataImportRepositoryImpl(
               gh<_i117.SensorHealthDataSource>(),
               gh<_i117.FileHealthDataSource>(),
             ));
-    gh.lazySingleton<_i189.HealthRecordRepository>(
-        () => _i190.HealthRecordRepositoryImpl(gh<_i60.Isar>()));
-    gh.lazySingleton<_i191.IAssessmentRepository>(
-        () => _i192.AssessmentRepositoryImpl(gh<_i60.Isar>()));
-    gh.factory<_i193.ImportCalendarUseCase>(() => _i193.ImportCalendarUseCase(
+    gh.lazySingleton<_i186.HealthRecordRepository>(
+        () => _i187.HealthRecordRepositoryImpl(gh<_i60.Isar>()));
+    gh.lazySingleton<_i188.IAssessmentRepository>(
+        () => _i189.AssessmentRepositoryImpl(gh<_i60.Isar>()));
+    gh.factory<_i190.ImportCalendarUseCase>(() => _i190.ImportCalendarUseCase(
           gh<_i21.CalendarImportRepository>(),
           gh<_i8.AppointmentRepository>(),
-          gh<_i130.UserProfileRepository>(),
+          gh<_i128.UserProfileRepository>(),
         ));
     gh.factory<_i109.ImportHealthDataUseCase>(
         () => _i109.ImportHealthDataUseCase(
               gh<_i45.HealthDataImportService>(),
-              gh<_i135.VitalSignRepository>(),
+              gh<_i133.VitalSignRepository>(),
             ));
-    gh.factory<_i63.LlmAdapter>(
-      () => _i194.MockLlmAdapter(gh<_i103.PromptScrubber>()),
-      instanceName: 'mock',
-    );
     gh.lazySingleton<_i63.LlmAdapter>(
-      () => _i195.GeminiLlmAdapter(
+      () => _i191.GeminiLlmAdapter(
         scrubber: gh<_i103.PromptScrubber>(),
-        userProfileRepository: gh<_i130.UserProfileRepository>(),
+        userProfileRepository: gh<_i128.UserProfileRepository>(),
         modelWrapper: gh<_i42.GeminiModelWrapper>(),
       ),
       instanceName: 'gemini',
     );
-    gh.lazySingleton<_i196.LlmAdapterFactory>(
-        () => _i196.LlmAdapterFactory(gh<_i119.SettingsRepository>()));
-    gh.lazySingleton<_i197.LlmService>(() => _i198.GemmaLlmService(
-          gh<_i133.VectorStoreService>(),
-          gh<_i130.UserProfileRepository>(),
+    gh.factory<_i63.LlmAdapter>(
+      () => _i192.MockLlmAdapter(gh<_i103.PromptScrubber>()),
+      instanceName: 'mock',
+    );
+    gh.lazySingleton<_i193.LlmAdapterFactory>(
+        () => _i193.LlmAdapterFactory(gh<_i119.SettingsRepository>()));
+    gh.lazySingleton<_i194.LlmService>(() => _i195.GemmaLlmService(
+          gh<_i131.VectorStoreService>(),
+          gh<_i128.UserProfileRepository>(),
           gh<_i63.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i199.LlmSettingsCubit>(() => _i199.LlmSettingsCubit(
+    gh.factory<_i196.LlmSettingsCubit>(() => _i196.LlmSettingsCubit(
           gh<_i119.SettingsRepository>(),
           gh<_i30.DeviceCapabilityService>(),
           gh<_i63.LlmAdapter>(instanceName: 'gemma'),
         ));
-    gh.factory<_i200.LoginUseCase>(() => _i200.LoginUseCase(
-          gh<_i148.AuthRepository>(),
-          gh<_i166.EncryptionService>(),
+    gh.factory<_i197.LoginUseCase>(() => _i197.LoginUseCase(
+          gh<_i146.AuthRepository>(),
+          gh<_i164.EncryptionService>(),
           gh<_i16.BiometricService>(),
         ));
-    gh.factory<_i201.LogoutUseCase>(
-        () => _i201.LogoutUseCase(gh<_i148.AuthRepository>()));
-    gh.lazySingleton<_i202.MedicalResearchService>(
-        () => _i202.MedicalResearchService(
+    gh.factory<_i198.LogoutUseCase>(
+        () => _i198.LogoutUseCase(gh<_i146.AuthRepository>()));
+    gh.lazySingleton<_i199.MedicalResearchService>(
+        () => _i199.MedicalResearchService(
               gh<_i76.MedicalWebSearchService>(),
               gh<_i72.MedicalScraperService>(),
             ));
-    gh.lazySingleton<_i203.MedicationRepository>(
-        () => _i204.IsarMedicationRepository(
+    gh.lazySingleton<_i200.MedicationRepository>(
+        () => _i201.IsarMedicationRepository(
               gh<_i60.Isar>(),
               gh<_i101.PharmacyApiService>(),
             ));
-    gh.factory<_i205.MedicationsCubit>(
-        () => _i205.MedicationsCubit(gh<_i203.MedicationRepository>()));
-    gh.factory<_i206.MeditationCubit>(() => _i206.MeditationCubit(
+    gh.factory<_i202.MedicationsCubit>(
+        () => _i202.MedicationsCubit(gh<_i200.MedicationRepository>()));
+    gh.factory<_i203.MeditationCubit>(() => _i203.MeditationCubit(
           gh<_i106.RecommendScriptUseCase>(),
           gh<_i123.StartSessionUseCase>(),
-          gh<_i154.CompleteSessionUseCase>(),
-          gh<_i179.GetProgressUseCase>(),
+          gh<_i152.CompleteSessionUseCase>(),
+          gh<_i176.GetProgressUseCase>(),
           gh<_i12.AudioService>(),
         ));
-    gh.factory<_i207.NetworkCubit>(() => _i207.NetworkCubit(
+    gh.factory<_i204.NetworkCubit>(() => _i204.NetworkCubit(
           gh<_i87.NetworkPeerRepository>(),
           gh<_i86.NetworkP2PApi>(),
         ));
-    gh.factory<_i208.NetworkHealthCubit>(() => _i208.NetworkHealthCubit(
-          gh<_i177.GetNetworkHealth>(),
-          gh<_i155.ConnectNode>(),
+    gh.factory<_i205.NetworkHealthCubit>(() => _i205.NetworkHealthCubit(
+          gh<_i174.GetNetworkHealth>(),
+          gh<_i153.ConnectNode>(),
           gh<_i89.NetworkRepository>(),
         ));
-    gh.lazySingleton<_i209.OnboardingRepository>(() =>
-        _i210.OnboardingRepositoryImpl(gh<_i130.UserProfileRepository>()));
-    gh.lazySingleton<_i211.ReportGenerationService>(
-        () => _i212.GemmaReportGenerationService(
+    gh.lazySingleton<_i206.OnboardingRepository>(() =>
+        _i207.OnboardingRepositoryImpl(gh<_i128.UserProfileRepository>()));
+    gh.lazySingleton<_i208.ReportGenerationService>(
+        () => _i209.GemmaReportGenerationService(
               gh<_i63.LlmAdapter>(instanceName: 'gemma'),
-              gh<_i133.VectorStoreService>(),
-              gh<_i130.UserProfileRepository>(),
+              gh<_i131.VectorStoreService>(),
+              gh<_i128.UserProfileRepository>(),
               gh<_i103.PromptScrubber>(),
             ));
-    gh.factory<_i213.SaveCredentialsUseCase>(
-        () => _i213.SaveCredentialsUseCase(gh<_i148.AuthRepository>()));
-    gh.factory<_i214.SaveMedicationUseCase>(
-        () => _i214.SaveMedicationUseCase(gh<_i203.MedicationRepository>()));
-    gh.factory<_i215.SaveRecordUseCase>(
-        () => _i215.SaveRecordUseCase(gh<_i189.HealthRecordRepository>()));
-    gh.factory<_i216.SaveUserProfileUseCase>(
-        () => _i216.SaveUserProfileUseCase(gh<_i130.UserProfileRepository>()));
-    gh.factory<_i217.SaveVitalSignsUseCase>(
-        () => _i217.SaveVitalSignsUseCase(gh<_i135.VitalSignRepository>()));
-    gh.factory<_i218.SecondOpinionCubit>(
-        () => _i218.SecondOpinionCubit(gh<_i112.SecondOpinionRepository>()));
-    gh.factory<_i219.SendMessageUseCase>(
-        () => _i219.SendMessageUseCase(gh<_i138.VoiceChatRepository>()));
-    gh.factory<_i220.SetPinUseCase>(() => _i220.SetPinUseCase(
-          gh<_i148.AuthRepository>(),
-          gh<_i166.EncryptionService>(),
+    gh.factory<_i210.SaveCredentialsUseCase>(
+        () => _i210.SaveCredentialsUseCase(gh<_i146.AuthRepository>()));
+    gh.factory<_i211.SaveMedicationUseCase>(
+        () => _i211.SaveMedicationUseCase(gh<_i200.MedicationRepository>()));
+    gh.factory<_i212.SaveRecordUseCase>(
+        () => _i212.SaveRecordUseCase(gh<_i186.HealthRecordRepository>()));
+    gh.factory<_i213.SaveUserProfileUseCase>(
+        () => _i213.SaveUserProfileUseCase(gh<_i128.UserProfileRepository>()));
+    gh.factory<_i214.SaveVitalSignsUseCase>(
+        () => _i214.SaveVitalSignsUseCase(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i215.SecondOpinionCubit>(
+        () => _i215.SecondOpinionCubit(gh<_i112.SecondOpinionRepository>()));
+    gh.factory<_i216.SendMessageUseCase>(
+        () => _i216.SendMessageUseCase(gh<_i136.VoiceChatRepository>()));
+    gh.factory<_i217.SetPinUseCase>(() => _i217.SetPinUseCase(
+          gh<_i146.AuthRepository>(),
+          gh<_i164.EncryptionService>(),
         ));
-    gh.lazySingleton<_i221.SmartSearchUseCase>(
-        () => _i221.SmartSearchUseCase(gh<_i133.VectorStoreService>()));
-    gh.lazySingleton<_i222.StartListeningUseCase>(
-        () => _i222.StartListeningUseCase(
-              gh<_i150.BleSharingService>(),
+    gh.lazySingleton<_i218.SmartSearchUseCase>(
+        () => _i218.SmartSearchUseCase(gh<_i131.VectorStoreService>()));
+    gh.lazySingleton<_i219.StartListeningUseCase>(
+        () => _i219.StartListeningUseCase(
+              gh<_i148.BleSharingService>(),
               gh<_i93.NfcSharingService>(),
-              gh<_i142.WifiDirectService>(),
+              gh<_i140.WifiDirectService>(),
             ));
-    gh.lazySingleton<_i223.StartSharingUseCase>(() => _i223.StartSharingUseCase(
-          gh<_i150.BleSharingService>(),
+    gh.lazySingleton<_i220.StartSharingUseCase>(() => _i220.StartSharingUseCase(
+          gh<_i148.BleSharingService>(),
           gh<_i93.NfcSharingService>(),
-          gh<_i142.WifiDirectService>(),
+          gh<_i140.WifiDirectService>(),
         ));
-    gh.factory<_i224.SyncCubit>(() => _i224.SyncCubit(
+    gh.factory<_i221.SyncCubit>(() => _i221.SyncCubit(
           gh<_i68.SyncService>(),
-          gh<_i133.VectorStoreService>(),
+          gh<_i131.VectorStoreService>(),
         ));
-    gh.factory<_i225.UserProfileCubit>(
-        () => _i225.UserProfileCubit(gh<_i130.UserProfileRepository>()));
-    gh.factory<_i226.ValidateSessionUseCase>(
-        () => _i226.ValidateSessionUseCase(gh<_i148.AuthRepository>()));
-    gh.factory<_i227.VitalSignBloc>(
-        () => _i227.VitalSignBloc(gh<_i135.VitalSignRepository>()));
-    gh.factory<_i228.VoiceChatCubit>(() => _i228.VoiceChatCubit(
-          gh<_i219.SendMessageUseCase>(),
-          gh<_i172.GetChatHistoryUseCase>(),
-          gh<_i138.VoiceChatRepository>(),
+    gh.lazySingleton<_i222.SyncService>(() => _i223.SyncServiceImpl(
+          gh<_i125.SyncRepository>(),
+          gh<_i68.SyncService>(),
+        ));
+    gh.factory<_i224.UserProfileCubit>(
+        () => _i224.UserProfileCubit(gh<_i128.UserProfileRepository>()));
+    gh.factory<_i225.ValidateSessionUseCase>(
+        () => _i225.ValidateSessionUseCase(gh<_i146.AuthRepository>()));
+    gh.factory<_i226.VitalSignBloc>(
+        () => _i226.VitalSignBloc(gh<_i133.VitalSignRepository>()));
+    gh.factory<_i227.VoiceChatCubit>(() => _i227.VoiceChatCubit(
+          gh<_i216.SendMessageUseCase>(),
+          gh<_i170.GetChatHistoryUseCase>(),
+          gh<_i136.VoiceChatRepository>(),
           gh<_i12.AudioService>(),
         ));
-    gh.factory<_i229.VouchCubit>(
-        () => _i229.VouchCubit(gh<_i140.VouchRepository>()));
-    gh.lazySingleton<_i230.AllergyRepository>(() => _i231.AllergyRepositoryImpl(
-          gh<_i145.AllergyLocalDataSource>(),
-          encryptionService: gh<_i166.EncryptionService>(),
+    gh.factory<_i228.VouchCubit>(
+        () => _i228.VouchCubit(gh<_i138.VouchRepository>()));
+    gh.lazySingleton<_i229.AllergyRepository>(() => _i230.AllergyRepositoryImpl(
+          gh<_i143.AllergyLocalDataSource>(),
+          encryptionService: gh<_i164.EncryptionService>(),
         ));
-    gh.factory<_i232.AuthCubit>(() => _i232.AuthCubit(
-          gh<_i148.AuthRepository>(),
+    gh.factory<_i231.AuthCubit>(() => _i231.AuthCubit(
+          gh<_i146.AuthRepository>(),
           gh<_i16.BiometricService>(),
-          gh<_i200.LoginUseCase>(),
-          gh<_i201.LogoutUseCase>(),
-          gh<_i226.ValidateSessionUseCase>(),
-          gh<_i220.SetPinUseCase>(),
-          gh<_i153.CheckSessionTimeoutUseCase>(),
+          gh<_i197.LoginUseCase>(),
+          gh<_i198.LogoutUseCase>(),
+          gh<_i225.ValidateSessionUseCase>(),
+          gh<_i217.SetPinUseCase>(),
+          gh<_i151.CheckSessionTimeoutUseCase>(),
         ));
-    gh.lazySingleton<_i233.AuthService>(
-        () => _i233.AuthServiceImpl(gh<_i166.EncryptionService>()));
-    gh.lazySingleton<_i234.BadgeCalculator>(() => _i234.BadgeCalculator(
-          gh<_i161.DoctorProfileRepository>(),
+    gh.lazySingleton<_i232.AuthService>(
+        () => _i232.AuthServiceImpl(gh<_i164.EncryptionService>()));
+    gh.lazySingleton<_i233.BadgeCalculator>(() => _i233.BadgeCalculator(
+          gh<_i159.DoctorProfileRepository>(),
           gh<_i104.RatingRepository>(),
-          gh<_i140.VouchRepository>(),
+          gh<_i138.VouchRepository>(),
         ));
-    gh.factory<_i235.BadgeCubit>(
-        () => _i235.BadgeCubit(gh<_i234.BadgeCalculator>()));
-    gh.factory<_i236.CalendarImportCubit>(() => _i236.CalendarImportCubit(
+    gh.factory<_i234.BadgeCubit>(
+        () => _i234.BadgeCubit(gh<_i233.BadgeCalculator>()));
+    gh.factory<_i235.CalendarImportCubit>(() => _i235.CalendarImportCubit(
           gh<_i21.CalendarImportRepository>(),
-          gh<_i193.ImportCalendarUseCase>(),
+          gh<_i190.ImportCalendarUseCase>(),
         ));
-    gh.factory<_i237.ClinicalAssessmentsCubit>(() =>
-        _i237.ClinicalAssessmentsCubit(gh<_i191.IAssessmentRepository>()));
-    gh.factory<_i238.CompleteOnboardingUseCase>(() =>
-        _i238.CompleteOnboardingUseCase(gh<_i209.OnboardingRepository>()));
-    gh.lazySingleton<_i239.DashboardRepository>(
-        () => _i240.DashboardRepositoryImpl(
+    gh.factory<_i236.ClinicalAssessmentsCubit>(() =>
+        _i236.ClinicalAssessmentsCubit(gh<_i188.IAssessmentRepository>()));
+    gh.factory<_i237.CompleteOnboardingUseCase>(() =>
+        _i237.CompleteOnboardingUseCase(gh<_i206.OnboardingRepository>()));
+    gh.lazySingleton<_i238.DashboardRepository>(
+        () => _i239.DashboardRepositoryImpl(
               gh<_i27.DashboardRemoteDataSource>(),
-              gh<_i135.VitalSignRepository>(),
-              gh<_i203.MedicationRepository>(),
+              gh<_i133.VitalSignRepository>(),
+              gh<_i200.MedicationRepository>(),
               gh<_i107.ReportRepository>(),
             ));
-    gh.lazySingleton<_i241.DataSourceRepository>(
-        () => _i242.DataSourceRepositoryImpl(
+    gh.lazySingleton<_i240.DataSourceRepository>(
+        () => _i241.DataSourceRepositoryImpl(
               gh<_i116.SensorApiDataSource>(),
-              gh<_i168.FileImportDataSource>(),
-              gh<_i186.HealthConnectDataSource>(),
+              gh<_i165.FileImportDataSource>(),
+              gh<_i183.HealthConnectDataSource>(),
             ));
-    gh.lazySingleton<_i243.DistributedCacheUsecase>(() =>
-        _i243.DistributedCacheUsecase(gh<_i159.DistributedStorageService>()));
-    gh.factory<_i244.EpsConnectionBloc>(() => _i244.EpsConnectionBloc(
-          gh<_i174.GetConnectionsUseCase>(),
-          gh<_i156.ConnectProviderUseCase>(),
-          gh<_i158.DisconnectProviderUseCase>(),
+    gh.lazySingleton<_i242.DistributedCacheUsecase>(() =>
+        _i242.DistributedCacheUsecase(gh<_i157.DistributedStorageService>()));
+    gh.factory<_i243.EpsConnectionBloc>(() => _i243.EpsConnectionBloc(
+          gh<_i171.GetConnectionsUseCase>(),
+          gh<_i154.ConnectProviderUseCase>(),
+          gh<_i156.DisconnectProviderUseCase>(),
         ));
-    gh.factory<_i245.EpsConnectionCubit>(() => _i245.EpsConnectionCubit(
-          gh<_i174.GetConnectionsUseCase>(),
-          gh<_i156.ConnectProviderUseCase>(),
-          gh<_i158.DisconnectProviderUseCase>(),
+    gh.factory<_i244.EpsConnectionCubit>(() => _i244.EpsConnectionCubit(
+          gh<_i171.GetConnectionsUseCase>(),
+          gh<_i154.ConnectProviderUseCase>(),
+          gh<_i156.DisconnectProviderUseCase>(),
+        ));
+    gh.factory<_i245.FhirSyncCubit>(() => _i245.FhirSyncCubit(
+          gh<_i222.SyncService>(),
+          gh<_i94.NodeDiscoveryService>(),
         ));
     gh.factory<_i246.GetAllMedicationsUseCase>(
-        () => _i246.GetAllMedicationsUseCase(gh<_i203.MedicationRepository>()));
+        () => _i246.GetAllMedicationsUseCase(gh<_i200.MedicationRepository>()));
     gh.factory<_i247.GetAllRecordsUseCase>(
-        () => _i247.GetAllRecordsUseCase(gh<_i189.HealthRecordRepository>()));
+        () => _i247.GetAllRecordsUseCase(gh<_i186.HealthRecordRepository>()));
     gh.factory<_i248.GetAllergiesUseCase>(
-        () => _i248.GetAllergiesUseCase(gh<_i230.AllergyRepository>()));
+        () => _i248.GetAllergiesUseCase(gh<_i229.AllergyRepository>()));
     gh.factory<_i249.GetDashboardStatsUseCase>(
-        () => _i249.GetDashboardStatsUseCase(gh<_i239.DashboardRepository>()));
+        () => _i249.GetDashboardStatsUseCase(gh<_i238.DashboardRepository>()));
     gh.factory<_i250.GetOnboardingProfileUseCase>(() =>
-        _i250.GetOnboardingProfileUseCase(gh<_i209.OnboardingRepository>()));
+        _i250.GetOnboardingProfileUseCase(gh<_i206.OnboardingRepository>()));
     gh.factory<_i251.GetRecentActivityUseCase>(
-        () => _i251.GetRecentActivityUseCase(gh<_i239.DashboardRepository>()));
+        () => _i251.GetRecentActivityUseCase(gh<_i238.DashboardRepository>()));
     gh.factory<_i252.HealthImportBloc>(() => _i252.HealthImportBloc(
           gh<_i109.GetAvailableSourcesUseCase>(),
           gh<_i109.RequestHealthAuthUseCase>(),
@@ -1123,79 +1123,79 @@ extension GetItInjectableX on _i1.GetIt {
           gh<_i109.ImportHealthDataUseCase>(),
         ));
     gh.factory<_i254.HealthRecordCubit>(() => _i254.HealthRecordCubit(
-          gh<_i189.HealthRecordRepository>(),
+          gh<_i186.HealthRecordRepository>(),
           gh<_i37.FilePickerService>(),
           gh<_i55.ImagePickerService>(),
           gh<_i100.OcrService>(),
-          gh<_i133.VectorStoreService>(),
+          gh<_i131.VectorStoreService>(),
         ));
     gh.lazySingleton<_i255.HomeRepository>(() => _i256.HomeRepositoryImpl(
-          gh<_i135.VitalSignRepository>(),
+          gh<_i133.VitalSignRepository>(),
           gh<_i8.AppointmentRepository>(),
-          gh<_i203.MedicationRepository>(),
+          gh<_i200.MedicationRepository>(),
           gh<_i50.HomeLocalDataSource>(),
           gh<_i52.HomeRemoteDataSource>(),
           gh<_i48.HealthSummaryDatasource>(),
         ));
-    gh.lazySingleton<_i197.LlmService>(
+    gh.lazySingleton<_i194.LlmService>(
       () => _i257.RagLlmService(
-        gh<_i133.VectorStoreService>(),
-        gh<_i202.MedicalResearchService>(),
-        gh<_i130.UserProfileRepository>(),
+        gh<_i131.VectorStoreService>(),
+        gh<_i199.MedicalResearchService>(),
+        gh<_i128.UserProfileRepository>(),
         gh<_i63.LlmAdapter>(instanceName: 'gemma'),
       ),
       instanceName: 'rag',
     );
     gh.lazySingleton<_i258.MedicalResearchRepository>(
         () => _i259.MedicalResearchRepositoryImpl(
-              gh<_i202.MedicalResearchService>(),
+              gh<_i199.MedicalResearchService>(),
               gh<_i60.Isar>(),
             ));
     gh.factory<_i260.MedicationBloc>(
-        () => _i260.MedicationBloc(gh<_i203.MedicationRepository>()));
+        () => _i260.MedicationBloc(gh<_i200.MedicationRepository>()));
     gh.factory<_i261.OnboardingCubit>(
-        () => _i261.OnboardingCubit(gh<_i209.OnboardingRepository>()));
+        () => _i261.OnboardingCubit(gh<_i206.OnboardingRepository>()));
     gh.lazySingleton<_i262.PatientContextIndexer>(
       () => _i262.PatientContextIndexer(
         gh<_i60.Isar>(),
-        gh<_i133.VectorStoreService>(),
-        gh<_i189.HealthRecordRepository>(),
-        gh<_i203.MedicationRepository>(),
-        gh<_i230.AllergyRepository>(),
-        gh<_i135.VitalSignRepository>(),
+        gh<_i131.VectorStoreService>(),
+        gh<_i186.HealthRecordRepository>(),
+        gh<_i200.MedicationRepository>(),
+        gh<_i229.AllergyRepository>(),
+        gh<_i133.VitalSignRepository>(),
         gh<_i8.AppointmentRepository>(),
       ),
       dispose: (i) => i.dispose(),
     );
     gh.factory<_i263.ReportBloc>(() => _i263.ReportBloc(
           gh<_i107.ReportRepository>(),
-          gh<_i211.ReportGenerationService>(),
+          gh<_i208.ReportGenerationService>(),
         ));
     gh.factory<_i264.SaveAllergyUseCase>(
-        () => _i264.SaveAllergyUseCase(gh<_i230.AllergyRepository>()));
+        () => _i264.SaveAllergyUseCase(gh<_i229.AllergyRepository>()));
     gh.factory<_i265.SearchMedicalResearch>(() =>
         _i265.SearchMedicalResearch(gh<_i258.MedicalResearchRepository>()));
     gh.factory<_i266.SharingCubit>(() => _i266.SharingCubit(
-          bleService: gh<_i150.BleSharingService>(),
+          bleService: gh<_i148.BleSharingService>(),
           nfcService: gh<_i93.NfcSharingService>(),
-          wifiService: gh<_i142.WifiDirectService>(),
-          startSharingUseCase: gh<_i223.StartSharingUseCase>(),
-          startListeningUseCase: gh<_i222.StartListeningUseCase>(),
-          cancelSharingUseCase: gh<_i151.CancelSharingUseCase>(),
+          wifiService: gh<_i140.WifiDirectService>(),
+          startSharingUseCase: gh<_i220.StartSharingUseCase>(),
+          startListeningUseCase: gh<_i219.StartListeningUseCase>(),
+          cancelSharingUseCase: gh<_i149.CancelSharingUseCase>(),
           walletService: gh<_i35.WalletService>(),
           walletEncryption: gh<_i35.EncryptionService>(),
         ));
     gh.factory<_i267.AllergiesCubit>(
-        () => _i267.AllergiesCubit(gh<_i230.AllergyRepository>()));
+        () => _i267.AllergiesCubit(gh<_i229.AllergyRepository>()));
     gh.factory<_i268.AllergyBloc>(
-        () => _i268.AllergyBloc(gh<_i230.AllergyRepository>()));
-    gh.factory<_i269.AuthCubit>(() => _i269.AuthCubit(gh<_i233.AuthService>()));
+        () => _i268.AllergyBloc(gh<_i229.AllergyRepository>()));
+    gh.factory<_i269.AuthCubit>(() => _i269.AuthCubit(gh<_i232.AuthService>()));
     gh.factory<_i270.DashboardCubit>(() => _i270.DashboardCubit(
           gh<_i249.GetDashboardStatsUseCase>(),
           gh<_i251.GetRecentActivityUseCase>(),
         ));
     gh.factory<_i271.DataSourceCubit>(
-        () => _i271.DataSourceCubit(gh<_i241.DataSourceRepository>()));
+        () => _i271.DataSourceCubit(gh<_i240.DataSourceRepository>()));
     gh.factory<_i272.GetHealthSummaryUseCase>(
         () => _i272.GetHealthSummaryUseCase(gh<_i255.HomeRepository>()));
     gh.factory<_i273.GetResearchHistory>(
@@ -1207,7 +1207,7 @@ extension GetItInjectableX on _i1.GetIt {
     gh.lazySingleton<_i275.MedicalIndexingService>(
         () => _i275.MedicalIndexingService(
               gh<_i69.MedicalKnowledgeRepository>(),
-              gh<_i133.VectorStoreService>(),
+              gh<_i131.VectorStoreService>(),
               gh<_i262.PatientContextIndexer>(),
             ));
     gh.factory<_i276.MedicalResearchCubit>(() => _i276.MedicalResearchCubit(

--- a/lib/features/eps_connection/presentation/pages/eps_patient_portal_screen.dart
+++ b/lib/features/eps_connection/presentation/pages/eps_patient_portal_screen.dart
@@ -22,14 +22,30 @@ import '../../../../core/theme/app_colors.dart';
 /// 3. User manually authenticates with EPS credentials
 /// 4. On login detection: session captured + endpoint interception starts
 /// 5. After scraping: returns patient data to previous screen
+typedef WebViewBuilder = Widget Function(
+  BuildContext context,
+  InAppWebViewSettings settings,
+  void Function(InAppWebViewController controller) onWebViewCreated,
+  void Function(InAppWebViewController controller, WebUri? url) onLoadStop,
+  void Function(InAppWebViewController controller, int progress) onProgressChanged,
+  Future<NavigationActionPolicy?> Function(InAppWebViewController controller, NavigationAction navigationAction) shouldOverrideUrlLoading,
+  Future<WebResourceResponse?> Function(InAppWebViewController controller, WebResourceRequest request) shouldInterceptRequest,
+  void Function(InAppWebViewController controller, WebResourceRequest request, WebResourceError error) onReceivedError,
+  String initialUrl,
+);
+
 class EpsPatientPortalScreen extends StatefulWidget {
   final EPSProvider provider;
   final bool autoConnect; // If true, try to restore session and skip login
+  final FlutterSecureStorage? storage;
+  final WebViewBuilder? webViewBuilder;
 
   const EpsPatientPortalScreen({
     super.key,
     required this.provider,
     this.autoConnect = false,
+    this.storage,
+    this.webViewBuilder,
   });
 
   @override
@@ -57,7 +73,7 @@ class _EpsPatientPortalScreenState extends State<EpsPatientPortalScreen> {
   @override
   void initState() {
     super.initState();
-    const storage = FlutterSecureStorage();
+    final storage = widget.storage ?? const FlutterSecureStorage();
     _sessionManager = EpsWebViewSession(
       storage: storage,
       epsId: widget.provider.id,
@@ -235,39 +251,80 @@ class _EpsPatientPortalScreenState extends State<EpsPatientPortalScreen> {
     return results;
   }
 
-  /// Fetches common API endpoints as fallback.
-  Future<Map<String, String>> _tryApiEndpoints() async {
-    final results = <String, String>{};
-    final routes = [
-      '/api/afiliado/perfil',
-      '/api/v1/paciente',
-      '/api/beneficiario/datos',
-      '/api/me',
-      '/api/user/profile',
-    ];
+  // ─── WebView Callbacks Refactored ───
 
-    for (final route in routes) {
-      try {
-        final json = await _webViewController!.evaluateJavascript(source: '''
-          (async () => {
-            try {
-              const r = await fetch('$route', { credentials: 'include' });
-              if (r.ok) {
-                const d = await r.json();
-                return JSON.stringify(d);
-              }
-              return '';
-            } catch(e) { return ''; }
-          })()
-        ''');
+  Future<void> _handleWebViewCreated(InAppWebViewController controller) async {
+    _webViewController = controller;
+    if (widget.autoConnect) {
+      final restored = await _sessionManager.restoreSession(controller);
+      if (restored) {
+        setState(() => _state = _PortalState.restoring);
+        await _sessionManager.restoreLocalStorage(controller);
+        _sessionRestored = true;
+      }
+    }
+  }
 
-        if (json != null && json.toString().isNotEmpty) {
-          results['api_$route'] = json.toString();
-        }
-      } catch (_) {}
+  Future<void> _handleLoadStop(InAppWebViewController controller, WebUri? url) async {
+    final urlStr = url?.toString() ?? '';
+    _currentUrl = urlStr;
+
+    _sessionManager.trackNavigation(urlStr);
+    _sessionManager.saveLastUrl(urlStr);
+
+    if (!_sessionRestored && widget.autoConnect) {
+      await _sessionManager.restoreSession(controller);
+      await _sessionManager.restoreLocalStorage(controller);
+      _sessionRestored = true;
     }
 
-    return results;
+    if (_isPostLoginUrl(urlStr)) {
+      setState(() => _state = _PortalState.authenticated);
+    } else if (_state == _PortalState.loading || _state == _PortalState.restoring) {
+      setState(() => _state = _PortalState.loginPage);
+    }
+  }
+
+  void _handleProgressChanged(InAppWebViewController controller, int progress) {
+    if (_state == _PortalState.loading || _state == _PortalState.restoring) {
+      setState(() => _loadProgress = progress / 100.0);
+    }
+  }
+
+  Future<NavigationActionPolicy?> _handleShouldOverrideUrlLoading(
+      InAppWebViewController controller, NavigationAction navigationAction) async {
+    final url = navigationAction.request.url.toString();
+
+    if (!EpsUrlValidator.isUrlAllowed(url, widget.provider.id)) {
+      debugPrint('BLOCKED: $url');
+      return NavigationActionPolicy.CANCEL;
+    }
+
+    _redirectCount++;
+    _redirectUrls.add(url);
+    if (_redirectUrls.length > 20) {
+      _redirectUrls.removeAt(0);
+    }
+    _currentUrl = url;
+
+    _sessionManager.trackNavigation(url);
+    _sessionManager.saveLastUrl(url);
+
+    if (_isPostLoginUrl(url)) {
+      setState(() => _state = _PortalState.authenticated);
+    }
+
+    return NavigationActionPolicy.ALLOW;
+  }
+
+  Future<WebResourceResponse?> _handleShouldInterceptRequest(
+      InAppWebViewController controller, WebResourceRequest request) async {
+    return _endpointInterceptor.interceptRequest(request);
+  }
+
+  void _handleReceivedError(
+      InAppWebViewController controller, WebResourceRequest request, WebResourceError error) {
+    debugPrint('WebView error: ${error.description} for ${request.url}');
   }
 
   // ─── Build ───
@@ -409,93 +466,28 @@ class _EpsPatientPortalScreenState extends State<EpsPatientPortalScreen> {
           future: _resolveInitialUrl(),
           builder: (context, snapshot) {
             final initialUrl = snapshot.data ?? _portalUrl;
+            if (widget.webViewBuilder != null) {
+              return widget.webViewBuilder!(
+                context,
+                _endpointInterceptor.interceptionSettings,
+                _handleWebViewCreated,
+                _handleLoadStop,
+                _handleProgressChanged,
+                _handleShouldOverrideUrlLoading,
+                _handleShouldInterceptRequest,
+                _handleReceivedError,
+                initialUrl,
+              );
+            }
             return InAppWebView(
               initialUrlRequest: URLRequest(url: WebUri(initialUrl)),
               initialSettings: _endpointInterceptor.interceptionSettings,
-              shouldOverrideUrlLoading:
-                  (controller, navigationAction) async {
-                final url =
-                    navigationAction.request.url.toString();
-
-                // Security: block unauthorized URLs
-                if (!EpsUrlValidator.isUrlAllowed(
-                    url, widget.provider.id)) {
-                  debugPrint('BLOCKED: $url');
-                  return NavigationActionPolicy.CANCEL;
-                }
-
-                _redirectCount++;
-                _redirectUrls.add(url);
-                if (_redirectUrls.length > 20) {
-                  _redirectUrls.removeAt(0);
-                }
-                _currentUrl = url;
-
-                // Track navigation in session history
-                _sessionManager.trackNavigation(url);
-                _sessionManager.saveLastUrl(url);
-
-                // Detect post-login navigation
-                if (_isPostLoginUrl(url)) {
-                  setState(() {
-                    _state = _PortalState.authenticated;
-                  });
-                }
-
-                return NavigationActionPolicy.ALLOW;
-              },
-              shouldInterceptRequest:
-                  (controller, request) async {
-                // Pass through endpoint interceptor for cataloging
-                return _endpointInterceptor.interceptRequest(request);
-              },
-              onLoadStop: (controller, url) async {
-                final urlStr = url?.toString() ?? '';
-                _currentUrl = urlStr;
-
-                // Track navigation
-                _sessionManager.trackNavigation(urlStr);
-                _sessionManager.saveLastUrl(urlStr);
-
-                // If this is the first load and we have a session, try restoring
-                if (!_sessionRestored && widget.autoConnect) {
-                  await _sessionManager.restoreSession(controller);
-                  await _sessionManager.restoreLocalStorage(controller);
-                  _sessionRestored = true;
-                }
-
-                if (_isPostLoginUrl(urlStr)) {
-                  setState(() => _state = _PortalState.authenticated);
-                } else if (_state == _PortalState.loading ||
-                    _state == _PortalState.restoring) {
-                  setState(() => _state = _PortalState.loginPage);
-                }
-              },
-              onProgressChanged: (controller, progress) {
-                if (_state == _PortalState.loading ||
-                    _state == _PortalState.restoring) {
-                  setState(
-                      () => _loadProgress = progress / 100.0);
-                }
-              },
-              onReceivedError:
-                  (controller, request, error) {
-                debugPrint(
-                    'WebView error: ${error.description} for ${request.url}');
-              },
-              onWebViewCreated: (controller) async {
-                _webViewController = controller;
-
-                // Restore cookies + localStorage if we have a session
-                if (widget.autoConnect) {
-                  final restored = await _sessionManager.restoreSession(controller);
-                  if (restored) {
-                    setState(() => _state = _PortalState.restoring);
-                    await _sessionManager.restoreLocalStorage(controller);
-                    _sessionRestored = true;
-                  }
-                }
-              },
+              shouldOverrideUrlLoading: _handleShouldOverrideUrlLoading,
+              shouldInterceptRequest: _handleShouldInterceptRequest,
+              onLoadStop: _handleLoadStop,
+              onProgressChanged: _handleProgressChanged,
+              onReceivedError: _handleReceivedError,
+              onWebViewCreated: _handleWebViewCreated,
             );
           },
         ),

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -1454,10 +1454,10 @@ packages:
     dependency: transitive
     description:
       name: matcher
-      sha256: dc0b7dc7651697ea4ff3e69ef44b0407ea32c487a39fff6a4004fa585e901861
+      sha256: "12956d0ad8390bbcc63ca2e1469c0619946ccb52809807067a7020d57e647aa6"
       url: "https://pub.dev"
     source: hosted
-    version: "0.12.19"
+    version: "0.12.18"
   material_color_utilities:
     dependency: transitive
     description:
@@ -1477,10 +1477,10 @@ packages:
     dependency: transitive
     description:
       name: meta
-      sha256: "1741988757a65eb6b36abe716829688cf01910bbf91c34354ff7ec1c3de2b349"
+      sha256: "23f08335362185a5ea2ad3a4e597f1375e78bce8a040df5c600c8d3552ef2394"
       url: "https://pub.dev"
     source: hosted
-    version: "1.18.0"
+    version: "1.17.0"
   mime:
     dependency: transitive
     description:
@@ -2202,10 +2202,10 @@ packages:
     dependency: transitive
     description:
       name: test_api
-      sha256: "949a932224383300f01be9221c39180316445ecb8e7547f70a41a35bf421fb9e"
+      sha256: "93167629bfc610f71560ab9312acdda4959de4df6fac7492c89ff0d3886f6636"
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.11"
+    version: "0.7.9"
   time:
     dependency: transitive
     description:

--- a/test/features/eps_connection/application/bloc/eps_connection_cubit_test.dart
+++ b/test/features/eps_connection/application/bloc/eps_connection_cubit_test.dart
@@ -139,5 +139,33 @@ void main() {
       verify(() => mockConnectProvider(provider)).called(1);
       expect(cubit.state, isA<EpsConnectionCatalog>());
     });
+
+    test('markPortalConnected emits EpsConnectionPortalConnected and reloads catalog', () async {
+      final provider = EPSProvider(
+        id: 'EPS025',
+        name: 'SURA',
+        discoveryUrl: '',
+        clientId: '',
+        redirectUrl: '',
+        scopes: [],
+      );
+
+      when(() => mockGetConnections()).thenAnswer((_) async => []);
+
+      final expected = [
+        isA<EpsConnectionPortalConnected>(),
+        isA<EpsConnectionCatalog>(),
+      ];
+
+      expectLater(cubit.stream, emitsInOrder(expected));
+
+      cubit.markPortalConnected(provider: provider, patientId: '123');
+
+      // Wait for loadCatalog to complete
+      await Future.delayed(Duration.zero);
+
+      final state = cubit.state;
+      expect(state, isA<EpsConnectionCatalog>());
+    });
   });
 }

--- a/test/features/eps_connection/infrastructure/services/eps_endpoint_interceptor_test.dart
+++ b/test/features/eps_connection/infrastructure/services/eps_endpoint_interceptor_test.dart
@@ -1,0 +1,248 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:orionhealth_health/features/eps_connection/infrastructure/services/eps_endpoint_interceptor.dart';
+
+class MockInAppWebViewController extends Mock implements InAppWebViewController {}
+class MockWebResourceRequest extends Mock implements WebResourceRequest {}
+
+void main() {
+  late EpsEndpointInterceptor interceptor;
+  late MockInAppWebViewController mockController;
+  const epsId = 'test_eps';
+  const portalUrl = 'https://portal.eps.com';
+
+  setUp(() {
+    interceptor = EpsEndpointInterceptor(epsId: epsId, epsPortalUrl: portalUrl);
+    mockController = MockInAppWebViewController();
+  });
+
+  group('EpsEndpointInterceptor', () {
+    test('interceptRequest captures auth token and catalogs endpoints', () {
+      interceptor.startInterception();
+
+      final mockRequest = MockWebResourceRequest();
+      when(() => mockRequest.url).thenReturn(WebUri('https://api.eps.com/fhir/Patient'));
+      when(() => mockRequest.method).thenReturn('GET');
+      when(() => mockRequest.headers).thenReturn({
+        'Authorization': 'Bearer test_token',
+        'X-Requested-With': 'XMLHttpRequest',
+      });
+
+      interceptor.interceptRequest(mockRequest);
+
+      expect(interceptor.authToken, 'Bearer test_token');
+      expect(interceptor.discoveredCount, 1);
+
+      final endpoint = interceptor.discoveredEndpoints.first;
+      expect(endpoint.url, 'https://api.eps.com/fhir/Patient');
+      expect(endpoint.category, 'fhir');
+    });
+
+    test('interceptRequest ignores assets', () {
+      interceptor.startInterception();
+
+      final mockRequest = MockWebResourceRequest();
+      when(() => mockRequest.url).thenReturn(WebUri('https://portal.eps.com/style.css'));
+      when(() => mockRequest.method).thenReturn('GET');
+      when(() => mockRequest.headers).thenReturn({});
+
+      interceptor.interceptRequest(mockRequest);
+
+      expect(interceptor.discoveredCount, 0);
+    });
+
+    test('categorizeEndpoint correctly identifies categories', () {
+      interceptor.startInterception();
+
+      final testCases = {
+        'https://api.com/fhir/Patient': 'fhir',
+        'https://api.com/v1/perfil': 'profile',
+        'https://api.com/citas/pendientes': 'appointments',
+        'https://api.com/history/clinical': 'clinicalHistory',
+        'https://api.com/medicamentos/all': 'medications',
+        'https://api.com/vacunas/list': 'immunizations',
+        'https://api.com/diagnosticos/current': 'conditions',
+        'https://api.com/api/other': 'unknown',
+      };
+
+      testCases.forEach((url, category) {
+        final mockRequest = MockWebResourceRequest();
+        when(() => mockRequest.url).thenReturn(WebUri(url));
+        when(() => mockRequest.method).thenReturn('GET');
+        when(() => mockRequest.headers).thenReturn({});
+
+        interceptor.interceptRequest(mockRequest);
+      });
+
+      expect(interceptor.discoveredCount, testCases.length);
+      for (final entry in testCases.entries) {
+        final ep = interceptor.discoveredEndpoints.firstWhere((e) => e.url == entry.key);
+        expect(ep.category, entry.value, reason: 'URL ${entry.key} should be categorized as ${entry.value}');
+      }
+    });
+
+    test('probeDiscoveredEndpoints extracts patient data from mocked responses', () async {
+      // 1. Discover some endpoints
+      interceptor.startInterception();
+      final mockRequest = MockWebResourceRequest();
+      when(() => mockRequest.url).thenReturn(WebUri('https://api.eps.com/profile'));
+      when(() => mockRequest.method).thenReturn('GET');
+      when(() => mockRequest.headers).thenReturn({});
+      interceptor.interceptRequest(mockRequest);
+
+      // 2. Mock JS evaluation for probing
+      final profileResponse = jsonEncode({
+        'ok': true,
+        'type': 'json',
+        'url': 'https://api.eps.com/profile',
+        'category': 'profile',
+        'data': {
+          'nombreCompleto': 'John Doe',
+          'identificacion': '12345678',
+          'fechaNacimiento': '1990-01-01',
+          'genero': 'M',
+        }
+      });
+
+      when(() => mockController.evaluateJavascript(source: any(named: 'source')))
+          .thenAnswer((invocation) async {
+            final source = invocation.namedArguments[#source] as String;
+            if (source.contains('https://api.eps.com/profile')) {
+              return profileResponse;
+            }
+            return jsonEncode({'ok': false});
+          });
+
+      final patientData = await interceptor.probeDiscoveredEndpoints(mockController);
+
+      expect(patientData['name'], 'John Doe');
+      expect(patientData['documentId'], '12345678');
+      expect(patientData['birthDate'], '1990-01-01');
+      expect(patientData['sex'], 'M');
+    });
+
+    test('probeDiscoveredEndpoints extracts lists (meds, conditions)', () async {
+      interceptor.startInterception();
+      final mockRequest = MockWebResourceRequest();
+      when(() => mockRequest.url).thenReturn(WebUri('https://api.eps.com/clinical/history'));
+      when(() => mockRequest.method).thenReturn('GET');
+      when(() => mockRequest.headers).thenReturn({});
+      interceptor.interceptRequest(mockRequest);
+
+      final clinicalResponse = jsonEncode({
+        'ok': true,
+        'type': 'json',
+        'url': 'https://api.eps.com/clinical/history',
+        'category': 'clinicalHistory',
+        'data': {
+          'medicamentos': ['Aspirina', 'Metformina'],
+          'diagnosticos': ['Hipertensión', 'Diabetes'],
+          'alergias': ['Polen'],
+        }
+      });
+
+      when(() => mockController.evaluateJavascript(source: any(named: 'source')))
+          .thenAnswer((invocation) async {
+             final source = invocation.namedArguments[#source] as String;
+             if (source.contains('https://api.eps.com/clinical/history')) {
+               return clinicalResponse;
+             }
+             return jsonEncode({'ok': false});
+          });
+
+      final patientData = await interceptor.probeDiscoveredEndpoints(mockController);
+
+      expect(patientData['medications'], containsAll(['Aspirina', 'Metformina']));
+      expect(patientData['conditions'], containsAll(['Hipertensión', 'Diabetes']));
+      expect(patientData['allergies'], containsAll(['Polen']));
+    });
+
+    test('probeDiscoveredEndpoints handles API failures gracefully', () async {
+      interceptor.startInterception();
+      final mockRequest = MockWebResourceRequest();
+      when(() => mockRequest.url).thenReturn(WebUri('https://api.eps.com/fail'));
+      when(() => mockRequest.method).thenReturn('GET');
+      when(() => mockRequest.headers).thenReturn({});
+      interceptor.interceptRequest(mockRequest);
+
+      // Mock JS evaluation to return an error object
+      when(() => mockController.evaluateJavascript(source: any(named: 'source')))
+          .thenAnswer((invocation) async {
+            final source = invocation.namedArguments[#source] as String;
+            if (source.contains('https://api.eps.com/fail')) {
+              return jsonEncode({'ok': false, 'error': 'Network error'});
+            }
+            return null; // For common paths
+          });
+
+      final patientData = await interceptor.probeDiscoveredEndpoints(mockController);
+
+      // Should be empty but not throw
+      expect(patientData, isEmpty);
+    });
+
+    test('probeDiscoveredEndpoints continues after partial API failure', () async {
+      interceptor.startInterception();
+
+      // 1. Discover two endpoints (one profile which has higher priority)
+      final mockReq1 = MockWebResourceRequest();
+      when(() => mockReq1.url).thenReturn(WebUri('https://api.eps.com/fail'));
+      when(() => mockReq1.method).thenReturn('GET');
+      when(() => mockReq1.headers).thenReturn({});
+      interceptor.interceptRequest(mockReq1);
+
+      final mockReq2 = MockWebResourceRequest();
+      when(() => mockReq2.url).thenReturn(WebUri('https://api.eps.com/profile-success'));
+      when(() => mockReq2.method).thenReturn('GET');
+      when(() => mockReq2.headers).thenReturn({});
+      interceptor.interceptRequest(mockReq2);
+
+      // 2. Mock JS: first fails, second succeeds
+      when(() => mockController.evaluateJavascript(source: any(named: 'source')))
+          .thenAnswer((invocation) async {
+            final source = invocation.namedArguments[#source] as String;
+            if (source.contains('https://api.eps.com/fail')) {
+              return jsonEncode({'ok': false});
+            }
+            if (source.contains('https://api.eps.com/profile-success')) {
+              return jsonEncode({
+                'ok': true,
+                'type': 'json',
+                'url': 'https://api.eps.com/profile-success',
+                'data': {'nombre': 'Recovered Name'}
+              });
+            }
+            return null;
+          });
+
+      final patientData = await interceptor.probeDiscoveredEndpoints(mockController);
+
+      expect(patientData['name'], 'Recovered Name');
+    });
+
+    test('probeDiscoveredEndpoints tries common API paths if none discovered', () async {
+      // No endpoints discovered
+      interceptor.startInterception();
+
+      when(() => mockController.evaluateJavascript(source: any(named: 'source')))
+          .thenAnswer((invocation) async {
+            final source = invocation.namedArguments[#source] as String;
+            if (source.contains('/api/afiliado/perfil')) {
+              return jsonEncode({
+                'ok': true,
+                'type': 'json',
+                'url': '/api/afiliado/perfil',
+                'data': {'nombre': 'Common Path Patient'}
+              });
+            }
+            return null;
+          });
+
+      final patientData = await interceptor.probeDiscoveredEndpoints(mockController);
+
+      expect(patientData['name'], 'Common Path Patient');
+    });
+  });
+}

--- a/test/features/eps_connection/infrastructure/services/eps_webview_session_test.dart
+++ b/test/features/eps_connection/infrastructure/services/eps_webview_session_test.dart
@@ -1,0 +1,155 @@
+import 'dart:convert';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:orionhealth_health/features/eps_connection/infrastructure/services/eps_webview_session.dart';
+
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+class MockInAppWebViewController extends Mock implements InAppWebViewController {}
+
+void main() {
+  late EpsWebViewSession session;
+  late MockFlutterSecureStorage mockStorage;
+  late MockInAppWebViewController mockController;
+  const epsId = 'test_eps';
+
+  setUp(() {
+    mockStorage = MockFlutterSecureStorage();
+    mockController = MockInAppWebViewController();
+    session = EpsWebViewSession(storage: mockStorage, epsId: epsId);
+
+    // Default stubs for write/delete
+    when(() => mockStorage.write(
+      key: any(named: 'key'),
+      value: any(named: 'value'),
+      iOptions: any(named: 'iOptions'),
+      aOptions: any(named: 'aOptions'),
+    )).thenAnswer((_) async => {});
+
+    when(() => mockStorage.delete(
+      key: any(named: 'key'),
+      iOptions: any(named: 'iOptions'),
+      aOptions: any(named: 'aOptions'),
+    )).thenAnswer((_) async => {});
+  });
+
+  group('EpsWebViewSession', () {
+    test('hasActiveSession returns false when no cookies are stored', () async {
+      when(() => mockStorage.read(key: any(named: 'key'))).thenAnswer((_) async => null);
+
+      final result = await session.hasActiveSession();
+
+      expect(result, isFalse);
+    });
+
+    test('hasActiveSession returns true when valid session exists', () async {
+      final meta = jsonEncode({
+        'capturedAt': DateTime.now().toIso8601String(),
+        'epsId': epsId,
+      });
+
+      when(() => mockStorage.read(key: 'eps_session_${epsId}_cookies'))
+          .thenAnswer((_) async => '[{"name": "test"}]');
+      when(() => mockStorage.read(key: 'eps_session_${epsId}_meta'))
+          .thenAnswer((_) async => meta);
+
+      final result = await session.hasActiveSession();
+
+      expect(result, isTrue);
+    });
+
+    test('hasActiveSession returns false and clears when session is expired (> 7 days)', () async {
+      final oldDate = DateTime.now().subtract(const Duration(days: 8));
+      final meta = jsonEncode({
+        'capturedAt': oldDate.toIso8601String(),
+        'epsId': epsId,
+      });
+
+      when(() => mockStorage.read(key: 'eps_session_${epsId}_cookies'))
+          .thenAnswer((_) async => '[{"name": "test"}]');
+      when(() => mockStorage.read(key: 'eps_session_${epsId}_meta'))
+          .thenAnswer((_) async => meta);
+
+      final result = await session.hasActiveSession();
+
+      expect(result, isFalse);
+      verify(() => mockStorage.delete(key: 'eps_session_${epsId}_cookies')).called(1);
+    });
+
+    test('trackNavigation appends to history and limits to 50 entries', () async {
+      when(() => mockStorage.read(key: 'eps_session_${epsId}_nav_history'))
+          .thenAnswer((_) async => null);
+
+      await session.trackNavigation('https://test.com/1');
+
+      verify(() => mockStorage.write(
+            key: 'eps_session_${epsId}_nav_history',
+            value: any(named: 'value', that: contains('https://test.com/1')),
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).called(1);
+
+      // Test limiting to 50
+      final largeHistory = List.generate(50, (i) => {'url': 'url$i', 'timestamp': DateTime.now().toIso8601String()});
+      when(() => mockStorage.read(key: 'eps_session_${epsId}_nav_history'))
+          .thenAnswer((_) async => jsonEncode(largeHistory));
+
+      await session.trackNavigation('https://test.com/new');
+
+      final captured = verify(() => mockStorage.write(
+            key: 'eps_session_${epsId}_nav_history',
+            value: captureAny(named: 'value'),
+            iOptions: any(named: 'iOptions'),
+            aOptions: any(named: 'aOptions'),
+          )).captured.last as String;
+
+      final savedHistory = jsonDecode(captured) as List;
+      expect(savedHistory.length, 50);
+      expect(savedHistory.last['url'], 'https://test.com/new');
+      expect(savedHistory.first['url'], 'url1');
+    });
+
+    test('saveLastUrl and getLastUrl interact correctly with storage', () async {
+      when(() => mockStorage.read(key: 'eps_session_${epsId}_last_url'))
+          .thenAnswer((_) async => 'https://last.com');
+
+      await session.saveLastUrl('https://last.com');
+      final lastUrl = await session.getLastUrl();
+
+      expect(lastUrl, 'https://last.com');
+      verify(() => mockStorage.write(
+        key: 'eps_session_${epsId}_last_url',
+        value: 'https://last.com',
+        iOptions: any(named: 'iOptions'),
+        aOptions: any(named: 'aOptions'),
+      )).called(1);
+    });
+
+    test('clearSession deletes all session keys', () async {
+      await session.clearSession();
+
+      verify(() => mockStorage.delete(key: 'eps_session_${epsId}_cookies', iOptions: any(named: 'iOptions'), aOptions: any(named: 'aOptions'))).called(1);
+      verify(() => mockStorage.delete(key: 'eps_session_${epsId}_nav_history', iOptions: any(named: 'iOptions'), aOptions: any(named: 'aOptions'))).called(1);
+      verify(() => mockStorage.delete(key: 'eps_session_${epsId}_last_url', iOptions: any(named: 'iOptions'), aOptions: any(named: 'aOptions'))).called(1);
+      verify(() => mockStorage.delete(key: 'eps_session_${epsId}_local_storage', iOptions: any(named: 'iOptions'), aOptions: any(named: 'aOptions'))).called(1);
+      verify(() => mockStorage.delete(key: 'eps_session_${epsId}_meta', iOptions: any(named: 'iOptions'), aOptions: any(named: 'aOptions'))).called(1);
+    });
+
+    test('restoreLocalStorage evaluates javascript with escaped data', () async {
+      const storedData = '{"key": "value\'s"}';
+      when(() => mockStorage.read(key: 'eps_session_${epsId}_local_storage'))
+          .thenAnswer((_) async => storedData);
+      when(() => mockController.evaluateJavascript(source: any(named: 'source')))
+          .thenAnswer((_) async => null);
+
+      await session.restoreLocalStorage(mockController);
+
+      final capturedSource = verify(() => mockController.evaluateJavascript(
+            source: captureAny(named: 'source'),
+          )).captured.first as String;
+
+      expect(capturedSource, contains("value\\'s"));
+    });
+  });
+}

--- a/test/features/eps_connection/presentation/pages/eps_patient_portal_screen_test.dart
+++ b/test/features/eps_connection/presentation/pages/eps_patient_portal_screen_test.dart
@@ -1,0 +1,149 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:mocktail/mocktail.dart';
+import 'package:flutter_secure_storage/flutter_secure_storage.dart';
+import 'package:flutter_inappwebview/flutter_inappwebview.dart';
+import 'package:orionhealth_health/features/eps_connection/presentation/pages/eps_patient_portal_screen.dart';
+import 'package:orionhealth_health/features/eps_connection/domain/entities/eps_provider.dart';
+
+class MockInAppWebViewController extends Mock implements InAppWebViewController {}
+class MockFlutterSecureStorage extends Mock implements FlutterSecureStorage {}
+
+void main() {
+  final testProvider = EPSProvider(
+    id: 'EPS025',
+    name: 'EPS SURA',
+    discoveryUrl: '',
+    clientId: '',
+    redirectUrl: '',
+    scopes: [],
+  );
+
+  late MockFlutterSecureStorage mockStorage;
+  late MockInAppWebViewController mockController;
+
+  setUp(() {
+    mockStorage = MockFlutterSecureStorage();
+    mockController = MockInAppWebViewController();
+    when(() => mockStorage.read(key: any(named: 'key'))).thenAnswer((_) async => null);
+    when(() => mockStorage.write(
+      key: any(named: 'key'),
+      value: any(named: 'value'),
+      iOptions: any(named: 'iOptions'),
+      aOptions: any(named: 'aOptions'),
+    )).thenAnswer((_) async => {});
+
+    // Default mock for controller
+    when(() => mockController.evaluateJavascript(source: any(named: 'source')))
+        .thenAnswer((_) async => null);
+  });
+
+  testWidgets('EpsPatientPortalScreen renders initial state', (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EpsPatientPortalScreen(
+            provider: testProvider,
+            storage: mockStorage,
+            webViewBuilder: (context, settings, onWebViewCreated, onLoadStop, onProgressChanged, shouldOverrideUrlLoading, shouldInterceptRequest, onReceivedError, initialUrl) {
+              return const SizedBox.shrink(key: Key('mock_webview'));
+            },
+          ),
+        ),
+      );
+
+      await tester.pump();
+
+      expect(find.text('EPS SURA'), findsOneWidget);
+      expect(find.textContaining('Portal seguro de EPS SURA'), findsOneWidget);
+    });
+  });
+
+  testWidgets('EpsPatientPortalScreen shows instructions after load', (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      await tester.pumpWidget(
+        MaterialApp(
+          home: EpsPatientPortalScreen(
+            provider: testProvider,
+            storage: mockStorage,
+            webViewBuilder: (context, settings, onWebViewCreated, onLoadStop, onProgressChanged, shouldOverrideUrlLoading, shouldInterceptRequest, onReceivedError, initialUrl) {
+              WidgetsBinding.instance.addPostFrameCallback((_) {
+                onLoadStop(mockController, WebUri(initialUrl));
+              });
+              return const SizedBox.shrink();
+            },
+          ),
+        ),
+      );
+
+      await tester.pump(const Duration(milliseconds: 100));
+      await tester.pump(const Duration(milliseconds: 100));
+
+      expect(find.textContaining('Ingresa con tu documento y contraseña'), findsOneWidget);
+    });
+  });
+
+  testWidgets('EpsPatientPortalScreen performs fallback DOM scraping when APIs fail', (WidgetTester tester) async {
+    await tester.runAsync(() async {
+      Map<String, dynamic>? popResult;
+
+      await tester.pumpWidget(
+        MaterialApp(
+          home: Builder(
+            builder: (context) => ElevatedButton(
+              onPressed: () async {
+                popResult = await Navigator.push<Map<String, dynamic>>(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) => EpsPatientPortalScreen(
+                      provider: testProvider,
+                      storage: mockStorage,
+                      webViewBuilder: (context, settings, onWebViewCreated, onLoadStop, onProgressChanged, shouldOverrideUrlLoading, shouldInterceptRequest, onReceivedError, initialUrl) {
+                        WidgetsBinding.instance.addPostFrameCallback((_) {
+                          onWebViewCreated(mockController);
+                          onLoadStop(mockController, WebUri('https://portal.eps.com/dashboard'));
+                        });
+                        return const SizedBox.shrink();
+                      },
+                    ),
+                  ),
+                );
+              },
+              child: const Text('Open'),
+            ),
+          ),
+        ),
+      );
+
+      await tester.tap(find.text('Open'));
+      await tester.pump();
+      await tester.pump(const Duration(milliseconds: 100));
+
+      // Mock evaluateJavascript for:
+      // 1. Probing (return nothing)
+      // 2. DOM scraping (return data)
+      when(() => mockController.evaluateJavascript(source: any(named: 'source')))
+          .thenAnswer((invocation) async {
+            final source = invocation.namedArguments[#source] as String;
+            if (source.contains('fetch')) return ''; // API probe returns empty
+            if (source.contains('const sels =')) {
+              if (source.contains('.nombre-paciente')) return 'DOM Patient Name';
+              if (source.contains('.documento')) return '987654321';
+            }
+            return '';
+          });
+
+      // Tap "Ya inicié sesión"
+      await tester.tap(find.text('Ya inicié sesión'));
+
+      // We need to pump several times because of the async scraping flow
+      for(int i=0; i<10; i++) {
+        await tester.pump(const Duration(milliseconds: 100));
+      }
+
+      expect(popResult, isNotNull);
+      expect(popResult!['name'], 'DOM Patient Name');
+      expect(popResult!['documentId'], '987654321');
+    });
+  });
+}


### PR DESCRIPTION
I have implemented a comprehensive test suite for the EPS connection pipeline. 

Key improvements:
1. **EpsWebViewSession Unit Tests**: Verified that sessions are correctly saved, restored, and automatically cleared after 7 days. Also tested the navigation history stack limiting.
2. **EpsEndpointInterceptor Unit Tests**: Validated the discovery and categorization of API endpoints (FHIR, Profile, Appointments, etc.) and the extraction of patient data from simulated JSON responses. Added tests for partial failures and discovery via common paths.
3. **EpsConnectionCubit Integration**: Added coverage for the `markPortalConnected` action which bridges the WebView extraction flow with the application state.
4. **EpsPatientPortalScreen Widget Tests**: Introduced a `webViewBuilder` typedef to allow injecting a mocked WebView in tests, avoiding platform-specific crashes during unit testing.
5. **Clean Code**: Refactored the UI layer to share callback logic between the real `InAppWebView` and the test builder, adhering to the DRY principle and improving maintainability.

All tests passed successfully in the provided environment.

Fixes #1537

---
*PR created automatically by Jules for task [11895313291715293055](https://jules.google.com/task/11895313291715293055) started by @iberi22*