### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons for accessibility

### DIFF
--- a/lib/core/widgets/page_header.dart
+++ b/lib/core/widgets/page_header.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_colors.dart';
 
-
-
 class PageHeader extends StatelessWidget {
   final String title;
   final String? subtitle;
@@ -39,7 +37,11 @@ class PageHeader extends StatelessWidget {
               if (showBackButton) ...[
                 IconButton(
                   onPressed: onBackPress ?? () => Navigator.of(context).pop(),
-                  icon: Icon(backButtonIcon ?? Icons.arrow_back_ios_new, size: 20),
+                  icon: Icon(
+                    backButtonIcon ?? Icons.arrow_back_ios_new,
+                    size: 20,
+                  ),
+                  tooltip: 'Volver',
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
                   color: AppColors.secondary,

--- a/lib/features/auth/presentation/pages/login_page.dart
+++ b/lib/features/auth/presentation/pages/login_page.dart
@@ -29,10 +29,7 @@ class _LoginPageState extends State<LoginPage> {
       listener: (context, state) {
         if (state.status == AuthStatus.error && state.error != null) {
           ScaffoldMessenger.of(context).showSnackBar(
-            SnackBar(
-              content: Text(state.error!),
-              backgroundColor: Colors.red,
-            ),
+            SnackBar(content: Text(state.error!), backgroundColor: Colors.red),
           );
         }
       },
@@ -53,8 +50,8 @@ class _LoginPageState extends State<LoginPage> {
                   Text(
                     'OrionHealth',
                     style: Theme.of(context).textTheme.headlineMedium?.copyWith(
-                          fontWeight: FontWeight.bold,
-                        ),
+                      fontWeight: FontWeight.bold,
+                    ),
                   ),
                   const SizedBox(height: 48),
                   if (state.status == AuthStatus.loading)
@@ -91,6 +88,7 @@ class _LoginPageState extends State<LoginPage> {
             border: const OutlineInputBorder(),
             suffixIcon: IconButton(
               icon: Icon(_obscurePin ? Icons.visibility : Icons.visibility_off),
+              tooltip: _obscurePin ? 'Show PIN' : 'Hide PIN',
               onPressed: () => setState(() => _obscurePin = !_obscurePin),
             ),
           ),
@@ -116,10 +114,7 @@ class _LoginPageState extends State<LoginPage> {
   Widget _buildPinSetup(BuildContext context) {
     return Column(
       children: [
-        Text(
-          'Set up your PIN',
-          style: Theme.of(context).textTheme.titleLarge,
-        ),
+        Text('Set up your PIN', style: Theme.of(context).textTheme.titleLarge),
         const SizedBox(height: 8),
         const Text('PIN must be 4-6 digits'),
         const SizedBox(height: 24),
@@ -136,6 +131,7 @@ class _LoginPageState extends State<LoginPage> {
             border: const OutlineInputBorder(),
             suffixIcon: IconButton(
               icon: Icon(_obscurePin ? Icons.visibility : Icons.visibility_off),
+              tooltip: _obscurePin ? 'Show PIN' : 'Hide PIN',
               onPressed: () => setState(() => _obscurePin = !_obscurePin),
             ),
           ),

--- a/lib/features/onboarding/presentation/pages/medical_node_onboarding.dart
+++ b/lib/features/onboarding/presentation/pages/medical_node_onboarding.dart
@@ -70,6 +70,7 @@ class _MedicalNodeOnboardingState extends State<MedicalNodeOnboarding> {
             children: [
               IconButton(
                 icon: const Icon(Icons.close, color: Colors.white70),
+                tooltip: 'Cerrar',
                 onPressed: () => Navigator.of(context).pop(),
               ),
               Text(
@@ -85,7 +86,9 @@ class _MedicalNodeOnboardingState extends State<MedicalNodeOnboarding> {
             child: LinearProgressIndicator(
               value: (_currentPage + 1) / _totalPages,
               backgroundColor: Colors.white12,
-              valueColor: const AlwaysStoppedAnimation<Color>(AppColors.primary),
+              valueColor: const AlwaysStoppedAnimation<Color>(
+                AppColors.primary,
+              ),
               minHeight: 4,
             ),
           ),
@@ -158,10 +161,7 @@ class _WhatIsMedicalNetworkStep extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             'La Red Médica OrionHealth es una red de centros de salud, laboratorios y especialistas conectados para brindarte atención integral.',
-            style: TextStyle(
-              fontSize: 16,
-              color: Colors.white.withAlpha(179),
-            ),
+            style: TextStyle(fontSize: 16, color: Colors.white.withAlpha(179)),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
@@ -173,10 +173,7 @@ class _WhatIsMedicalNetworkStep extends StatelessWidget {
             Icons.medical_services,
             'Especialistas en múltiples áreas',
           ),
-          _buildFeatureItem(
-            Icons.access_time,
-            'Agenda de citas en línea',
-          ),
+          _buildFeatureItem(Icons.access_time, 'Agenda de citas en línea'),
           const Spacer(),
         ],
       ),
@@ -194,10 +191,7 @@ class _WhatIsMedicalNetworkStep extends StatelessWidget {
           Flexible(
             child: Text(
               text,
-              style: const TextStyle(
-                fontSize: 14,
-                color: Colors.white70,
-              ),
+              style: const TextStyle(fontSize: 14, color: Colors.white70),
             ),
           ),
         ],
@@ -244,29 +238,14 @@ class _SecureDataSharingStep extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             'Tu información médica se comparte de forma segura y solo con tu consentimiento entre los profesionales de la red.',
-            style: TextStyle(
-              fontSize: 16,
-              color: Colors.white.withAlpha(179),
-            ),
+            style: TextStyle(fontSize: 16, color: Colors.white.withAlpha(179)),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
-          _buildSecurityItem(
-            Icons.lock,
-            'Cifrado de extremo a extremo',
-          ),
-          _buildSecurityItem(
-            Icons.verified_user,
-            'Autenticación biométrica',
-          ),
-          _buildSecurityItem(
-            Icons.privacy_tip,
-            'Tú controlas quién accede',
-          ),
-          _buildSecurityItem(
-            Icons.rule,
-            'Cumplimiento HIPAA',
-          ),
+          _buildSecurityItem(Icons.lock, 'Cifrado de extremo a extremo'),
+          _buildSecurityItem(Icons.verified_user, 'Autenticación biométrica'),
+          _buildSecurityItem(Icons.privacy_tip, 'Tú controlas quién accede'),
+          _buildSecurityItem(Icons.rule, 'Cumplimiento HIPAA'),
           const Spacer(),
         ],
       ),
@@ -284,10 +263,7 @@ class _SecureDataSharingStep extends StatelessWidget {
           Flexible(
             child: Text(
               text,
-              style: const TextStyle(
-                fontSize: 14,
-                color: Colors.white70,
-              ),
+              style: const TextStyle(fontSize: 14, color: Colors.white70),
             ),
           ),
         ],
@@ -334,29 +310,17 @@ class _PatientBenefitsStep extends StatelessWidget {
           const SizedBox(height: 16),
           Text(
             'Al unirte a la Red Médica OrionHealth, obtienes acceso a beneficios exclusivos para tu salud.',
-            style: TextStyle(
-              fontSize: 16,
-              color: Colors.white.withAlpha(179),
-            ),
+            style: TextStyle(fontSize: 16, color: Colors.white.withAlpha(179)),
             textAlign: TextAlign.center,
           ),
           const SizedBox(height: 24),
-          _buildBenefitItem(
-            Icons.history,
-            'Historial médico unificado',
-          ),
-          _buildBenefitItem(
-            Icons.receipt_long,
-            'Resultados en línea',
-          ),
+          _buildBenefitItem(Icons.history, 'Historial médico unificado'),
+          _buildBenefitItem(Icons.receipt_long, 'Resultados en línea'),
           _buildBenefitItem(
             Icons.card_membership,
             'Descuentos en medicamentos',
           ),
-          _buildBenefitItem(
-            Icons.support_agent,
-            'Asistente de salud 24/7',
-          ),
+          _buildBenefitItem(Icons.support_agent, 'Asistente de salud 24/7'),
           const Spacer(),
         ],
       ),
@@ -374,10 +338,7 @@ class _PatientBenefitsStep extends StatelessWidget {
           Flexible(
             child: Text(
               text,
-              style: const TextStyle(
-                fontSize: 14,
-                color: Colors.white70,
-              ),
+              style: const TextStyle(fontSize: 14, color: Colors.white70),
             ),
           ),
         ],


### PR DESCRIPTION
💡 What: Added `tooltip` attributes to several icon-only buttons throughout the application. 
🎯 Why: Without tooltips, icon-only buttons lack context for screen readers and can be difficult for hover-capable users to discern their exact function. This change fixes that.
♿ Accessibility: Provides the equivalent of an ARIA label to these elements, ensuring screen reader users can identify actions without guessing based on icon glyphs.

Affected areas:
- `PageHeader` back button (now reads "Volver")
- `LoginPage` pin visibility toggles (now read "Show PIN" or "Hide PIN")
- `MedicalNodeOnboarding` close button (now reads "Cerrar")

---
*PR created automatically by Jules for task [13904842132571742683](https://jules.google.com/task/13904842132571742683) started by @iberi22*