### PR TITLE
🎨 Palette: Add semantic tooltips to IconButtons for accessibility

### DIFF
--- a/lib/core/widgets/page_header.dart
+++ b/lib/core/widgets/page_header.dart
@@ -43,6 +43,7 @@ class PageHeader extends StatelessWidget {
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
                   color: AppColors.secondary,
+                  tooltip: 'Volver',
                 ),
                 const SizedBox(width: 12),
               ] else if (leading != null) ...[

--- a/lib/features/data_sources/presentation/widgets/data_source_tile.dart
+++ b/lib/features/data_sources/presentation/widgets/data_source_tile.dart
@@ -36,6 +36,7 @@ class DataSourceTile extends StatelessWidget {
               IconButton(
                 icon: const Icon(Icons.sync, color: AppColors.secondary),
                 onPressed: onSync,
+                tooltip: 'Sincronizar',
               ),
             _buildStatusIcon(),
             Switch(


### PR DESCRIPTION
💡 **What**: Added `tooltip` attributes to icon-only `IconButton` widgets in `PageHeader` and `DataSourceTile`.
🎯 **Why**: To improve accessibility. Screen readers will now announce the function of these buttons ("Volver" and "Sincronizar"), and users with pointer devices will see a helpful text label on hover, adhering to micro-UX best practices.
♿ **Accessibility**: Provides ARIA-equivalent labels for previously unlabeled icon-only interactive elements.

---
*PR created automatically by Jules for task [10282147038686515456](https://jules.google.com/task/10282147038686515456) started by @iberi22*