### PR TITLE
🎨 Palette: Add accessible tooltips to icon buttons

### DIFF
--- a/lib/core/widgets/page_header.dart
+++ b/lib/core/widgets/page_header.dart
@@ -43,6 +43,7 @@ class PageHeader extends StatelessWidget {
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
                   color: AppColors.secondary,
+                  tooltip: MaterialLocalizations.of(context).backButtonTooltip,
                 ),
                 const SizedBox(width: 12),
               ] else if (leading != null) ...[

--- a/lib/features/settings/presentation/widgets/profile_section.dart
+++ b/lib/features/settings/presentation/widgets/profile_section.dart
@@ -54,6 +54,7 @@ class ProfileSection extends StatelessWidget {
                 key: const Key('edit_profile_button'),
                 icon: const Icon(Icons.edit_outlined, color: AppColors.primary),
                 onPressed: onEditPressed,
+                tooltip: 'Editar perfil',
               ),
             ],
           ),


### PR DESCRIPTION
This PR adds tooltips to icon-only buttons to improve accessibility and UX for screen readers and mouse users. 

**What:** The UX enhancement added is localized tooltip texts for the back button in `PageHeader` and the edit button in `ProfileSection`.
**Why:** Icon-only buttons without tooltips or labels create an inaccessible experience, as screen readers cannot convey the button's purpose, and mouse users have no visual hover feedback.
**Accessibility:** Added missing semantic tooltips to `IconButton`s, serving as an ARIA equivalent for screen reader context.

---
*PR created automatically by Jules for task [5833867087723933701](https://jules.google.com/task/5833867087723933701) started by @iberi22*