### PR TITLE
⚡ Bolt: Optimize calendar grid rendering performance

### DIFF
--- a/.jules/bolt.md
+++ b/.jules/bolt.md
@@ -1,0 +1,3 @@
+## 2024-07-22 - [Avoid O(n) lookups in Flutter builder methods]
+**Learning:** In Flutter, doing O(n) lookups like `List.any()` inside `itemBuilder` loops (like in `GridView.builder` or `ListView.builder`) can cause UI lag because they run for every rendered item. In `appointments_page.dart`, `_allAppointments.any()` was called for every day in the calendar grid.
+**Action:** Always pre-compute a lookup structure like a `Set` (O(1)) before the builder to improve rendering performance.

--- a/lib/features/appointments/presentation/pages/appointments_page.dart
+++ b/lib/features/appointments/presentation/pages/appointments_page.dart
@@ -174,6 +174,10 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
     final firstDayOffset = DateUtils.firstDayOffset(_focusedDay.year, _focusedDay.month, MaterialLocalizations.of(context));
     final monthName = DateFormat.MMMM('es').format(_focusedDay);
 
+    // Bolt Optimization: Pre-compute appointment dates to O(1) set lookup to prevent
+    // O(n) array traversal in the builder function loop.
+    final appointmentDates = _allAppointments.map((a) => DateUtils.dateOnly(a.dateTime)).toSet();
+
     return GlassmorphicCard(
       child: Padding(
         padding: const EdgeInsets.all(12.0),
@@ -216,7 +220,7 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
                 final date = DateTime(_focusedDay.year, _focusedDay.month, day);
                 final isSelected = DateUtils.isSameDay(date, _selectedDay);
                 final isToday = DateUtils.isSameDay(date, DateTime.now());
-                final hasAppointment = _allAppointments.any((a) => DateUtils.isSameDay(a.dateTime, date));
+                final hasAppointment = appointmentDates.contains(date);
 
                 return InkWell(
                   onTap: () => setState(() => _selectedDay = date),


### PR DESCRIPTION
💡 What: Pre-compute appointment dates to a `Set<DateTime>` outside the `GridView.builder` and perform O(1) lookups instead of $O(n)$ `List.any()` checks inside the item loop.
🎯 Why: Flutter builder functions run continuously to render items, and doing array traversal `List.any()` inside `itemBuilder` drops frames/causes lag when there are many items.
📊 Impact: Changes O(N*M) time complexity (appointments * days displayed) to O(N + M) constant time lookups. Rendering the calendar widget is measurably faster with larger appointment lists.
🔬 Measurement: Verify rendering frames using Flutter DevTools inspector in profile mode on the appointments page when viewing months with a dozen+ appointments.

---
*PR created automatically by Jules for task [7759612589668274316](https://jules.google.com/task/7759612589668274316) started by @iberi22*