### PR TITLE
🎨 Palette: Add ARIA-equivalent tooltip to PageHeader back button

### DIFF
--- a/lib/core/widgets/page_header.dart
+++ b/lib/core/widgets/page_header.dart
@@ -43,6 +43,7 @@ class PageHeader extends StatelessWidget {
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
                   color: AppColors.secondary,
+                  tooltip: MaterialLocalizations.of(context).backButtonTooltip,
                 ),
                 const SizedBox(width: 12),
               ] else if (leading != null) ...[


### PR DESCRIPTION
This micro-UX enhancement adds a localized `tooltip` to the `IconButton` back button within `PageHeader`.

💡 **What:** Added `tooltip: MaterialLocalizations.of(context).backButtonTooltip` to the back action `IconButton` in `lib/core/widgets/page_header.dart`.
🎯 **Why:** Icon-only buttons lacking semantic labels are opaque to assistive technologies. Providing a tooltip ensures screen readers can accurately interpret the button's purpose as a navigation action.
♿ **Accessibility:** This resolves a minor WCAG issue where an interactive element did not provide an accessible name, benefiting users who rely on screen readers or other assistive tools, and providing visual feedback on long-press.

---
*PR created automatically by Jules for task [16595394872036624618](https://jules.google.com/task/16595394872036624618) started by @iberi22*