### PR TITLE
🎨 Palette: Add tooltips to icon-only buttons for accessibility

### DIFF
--- a/lib/features/appointments/presentation/pages/appointments_page.dart
+++ b/lib/features/appointments/presentation/pages/appointments_page.dart
@@ -42,24 +42,34 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
     } catch (e) {
       setState(() => _isLoading = false);
       if (mounted) {
-        ScaffoldMessenger.of(context).showSnackBar(
-          SnackBar(content: Text('Error al cargar citas: $e')),
-        );
+        ScaffoldMessenger.of(
+          context,
+        ).showSnackBar(SnackBar(content: Text('Error al cargar citas: $e')));
       }
     }
   }
 
   @override
   Widget build(BuildContext context) {
-    final upcoming = _allAppointments
-        .where((a) => a.dateTime.isAfter(DateTime.now()) && a.status != AppointmentStatus.cancelled)
-        .toList()
-      ..sort((a, b) => a.dateTime.compareTo(b.dateTime));
+    final upcoming =
+        _allAppointments
+            .where(
+              (a) =>
+                  a.dateTime.isAfter(DateTime.now()) &&
+                  a.status != AppointmentStatus.cancelled,
+            )
+            .toList()
+          ..sort((a, b) => a.dateTime.compareTo(b.dateTime));
 
-    final past = _allAppointments
-        .where((a) => a.dateTime.isBefore(DateTime.now()) || a.status == AppointmentStatus.cancelled)
-        .toList()
-      ..sort((a, b) => b.dateTime.compareTo(a.dateTime));
+    final past =
+        _allAppointments
+            .where(
+              (a) =>
+                  a.dateTime.isBefore(DateTime.now()) ||
+                  a.status == AppointmentStatus.cancelled,
+            )
+            .toList()
+          ..sort((a, b) => b.dateTime.compareTo(a.dateTime));
 
     return Scaffold(
       appBar: AppBar(
@@ -79,7 +89,9 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
             onPressed: () async {
               final result = await Navigator.push(
                 context,
-                MaterialPageRoute(builder: (context) => const CalendarImportPage()),
+                MaterialPageRoute(
+                  builder: (context) => const CalendarImportPage(),
+                ),
               );
               if (result == true) {
                 _loadAppointments();
@@ -88,6 +100,7 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
           ),
           IconButton(
             icon: const Icon(Icons.add),
+            tooltip: 'Añadir cita',
             onPressed: () => _showAppointmentForm(),
           ),
         ],
@@ -109,10 +122,17 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
                   ),
                   const SliverToBoxAdapter(
                     child: Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 16.0,
+                        vertical: 8.0,
+                      ),
                       child: Text(
                         'Próximas',
-                        style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: CyberTheme.secondary),
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: CyberTheme.secondary,
+                        ),
                       ),
                     ),
                   ),
@@ -127,17 +147,26 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
                           delegate: SliverChildBuilderDelegate(
                             (context, index) => AppointmentCard(
                               appointment: upcoming[index],
-                              onTap: () => _showAppointmentForm(appointment: upcoming[index]),
+                              onTap: () => _showAppointmentForm(
+                                appointment: upcoming[index],
+                              ),
                             ),
                             childCount: upcoming.length,
                           ),
                         ),
                   const SliverToBoxAdapter(
                     child: Padding(
-                      padding: EdgeInsets.symmetric(horizontal: 16.0, vertical: 8.0),
+                      padding: EdgeInsets.symmetric(
+                        horizontal: 16.0,
+                        vertical: 8.0,
+                      ),
                       child: Text(
                         'Historial',
-                        style: TextStyle(fontSize: 18, fontWeight: FontWeight.bold, color: Colors.white54),
+                        style: TextStyle(
+                          fontSize: 18,
+                          fontWeight: FontWeight.bold,
+                          color: Colors.white54,
+                        ),
                       ),
                     ),
                   ),
@@ -152,7 +181,9 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
                           delegate: SliverChildBuilderDelegate(
                             (context, index) => AppointmentCard(
                               appointment: past[index],
-                              onTap: () => _showAppointmentForm(appointment: past[index]),
+                              onTap: () => _showAppointmentForm(
+                                appointment: past[index],
+                              ),
                             ),
                             childCount: past.length,
                           ),
@@ -170,8 +201,15 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
   }
 
   Widget _buildCalendar() {
-    final daysInMonth = DateUtils.getDaysInMonth(_focusedDay.year, _focusedDay.month);
-    final firstDayOffset = DateUtils.firstDayOffset(_focusedDay.year, _focusedDay.month, MaterialLocalizations.of(context));
+    final daysInMonth = DateUtils.getDaysInMonth(
+      _focusedDay.year,
+      _focusedDay.month,
+    );
+    final firstDayOffset = DateUtils.firstDayOffset(
+      _focusedDay.year,
+      _focusedDay.month,
+      MaterialLocalizations.of(context),
+    );
     final monthName = DateFormat.MMMM('es').format(_focusedDay);
 
     return GlassmorphicCard(
@@ -184,17 +222,32 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
               children: [
                 Text(
                   '${monthName.toUpperCase()} ${_focusedDay.year}',
-                  style: const TextStyle(fontWeight: FontWeight.bold, letterSpacing: 1.2),
+                  style: const TextStyle(
+                    fontWeight: FontWeight.bold,
+                    letterSpacing: 1.2,
+                  ),
                 ),
                 Row(
                   children: [
                     IconButton(
                       icon: const Icon(Icons.chevron_left, size: 20),
-                      onPressed: () => setState(() => _focusedDay = DateTime(_focusedDay.year, _focusedDay.month - 1)),
+                      tooltip: 'Mes anterior',
+                      onPressed: () => setState(
+                        () => _focusedDay = DateTime(
+                          _focusedDay.year,
+                          _focusedDay.month - 1,
+                        ),
+                      ),
                     ),
                     IconButton(
                       icon: const Icon(Icons.chevron_right, size: 20),
-                      onPressed: () => setState(() => _focusedDay = DateTime(_focusedDay.year, _focusedDay.month + 1)),
+                      tooltip: 'Mes siguiente',
+                      onPressed: () => setState(
+                        () => _focusedDay = DateTime(
+                          _focusedDay.year,
+                          _focusedDay.month + 1,
+                        ),
+                      ),
                     ),
                   ],
                 ),
@@ -216,16 +269,28 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
                 final date = DateTime(_focusedDay.year, _focusedDay.month, day);
                 final isSelected = DateUtils.isSameDay(date, _selectedDay);
                 final isToday = DateUtils.isSameDay(date, DateTime.now());
-                final hasAppointment = _allAppointments.any((a) => DateUtils.isSameDay(a.dateTime, date));
+                final hasAppointment = _allAppointments.any(
+                  (a) => DateUtils.isSameDay(a.dateTime, date),
+                );
 
                 return InkWell(
                   onTap: () => setState(() => _selectedDay = date),
                   borderRadius: BorderRadius.circular(8),
                   child: Container(
                     decoration: BoxDecoration(
-                      color: isSelected ? CyberTheme.primary.withValues(alpha: 0.2) : null,
+                      color: isSelected
+                          ? CyberTheme.primary.withValues(alpha: 0.2)
+                          : null,
                       borderRadius: BorderRadius.circular(8),
-                      border: isSelected ? Border.all(color: CyberTheme.primary) : (isToday ? Border.all(color: CyberTheme.secondary.withValues(alpha: 0.5)) : null),
+                      border: isSelected
+                          ? Border.all(color: CyberTheme.primary)
+                          : (isToday
+                                ? Border.all(
+                                    color: CyberTheme.secondary.withValues(
+                                      alpha: 0.5,
+                                    ),
+                                  )
+                                : null),
                     ),
                     child: Stack(
                       alignment: Alignment.center,
@@ -233,8 +298,14 @@ class _AppointmentsPageState extends State<AppointmentsPage> {
                         Text(
                           '$day',
                           style: TextStyle(
-                            color: isSelected ? CyberTheme.primary : (isToday ? CyberTheme.secondary : Colors.white),
-                            fontWeight: isSelected || isToday ? FontWeight.bold : FontWeight.normal,
+                            color: isSelected
+                                ? CyberTheme.primary
+                                : (isToday
+                                      ? CyberTheme.secondary
+                                      : Colors.white),
+                            fontWeight: isSelected || isToday
+                                ? FontWeight.bold
+                                : FontWeight.normal,
                           ),
                         ),
                         if (hasAppointment)

--- a/lib/features/settings/presentation/widgets/profile_section.dart
+++ b/lib/features/settings/presentation/widgets/profile_section.dart
@@ -53,6 +53,7 @@ class ProfileSection extends StatelessWidget {
               IconButton(
                 key: const Key('edit_profile_button'),
                 icon: const Icon(Icons.edit_outlined, color: AppColors.primary),
+                tooltip: 'Editar perfil',
                 onPressed: onEditPressed,
               ),
             ],
@@ -65,7 +66,11 @@ class ProfileSection extends StatelessWidget {
             children: [
               const Row(
                 children: [
-                  Icon(Icons.dark_mode_outlined, color: AppColors.secondary, size: 20),
+                  Icon(
+                    Icons.dark_mode_outlined,
+                    color: AppColors.secondary,
+                    size: 20,
+                  ),
                   SizedBox(width: 12),
                   Text(
                     'Modo Oscuro',
@@ -87,7 +92,8 @@ class ProfileSection extends StatelessWidget {
   }
 
   Widget _buildAvatar() {
-    final hasAvatar = userProfile?.avatarUrl != null && userProfile!.avatarUrl!.isNotEmpty;
+    final hasAvatar =
+        userProfile?.avatarUrl != null && userProfile!.avatarUrl!.isNotEmpty;
 
     return Container(
       key: const Key('profile_avatar_container'),
@@ -95,11 +101,15 @@ class ProfileSection extends StatelessWidget {
       height: 60,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        border: Border.all(color: AppColors.primary.withValues(alpha: 0.5), width: 2),
+        border: Border.all(
+          color: AppColors.primary.withValues(alpha: 0.5),
+          width: 2,
+        ),
         image: DecorationImage(
           image: hasAvatar
-            ? NetworkImage(userProfile!.avatarUrl!)
-            : const AssetImage('assets/images/user_placeholder.png') as ImageProvider,
+              ? NetworkImage(userProfile!.avatarUrl!)
+              : const AssetImage('assets/images/user_placeholder.png')
+                    as ImageProvider,
           fit: BoxFit.cover,
         ),
       ),


### PR DESCRIPTION
💡 What: Added `tooltip` attributes to multiple icon-only `IconButton` widgets across the `appointments_page` and `profile_section` components. Additionally, ran `dart format` which applied consistent indentation formatting to these files.
🎯 Why: Icon-only buttons without tooltips lack context for screen readers and mouse users. Adding a `tooltip` attribute in Flutter automatically wraps the component in a `Semantics` node that provides this critical context (acting similarly to an `aria-label`).
📸 Before/After: Visual presentation is identical except on mouse hover or long-press, where tooltips like 'Editar perfil' or 'Añadir cita' will now appear.
♿ Accessibility: Ensures that screen reader users can navigate and understand the purpose of the interactive elements on these screens without visual cues.

---
*PR created automatically by Jules for task [5747027989155525829](https://jules.google.com/task/5747027989155525829) started by @iberi22*