### PR TITLE
🎨 Palette: Add tooltip to edit profile button

### DIFF
--- a/lib/features/settings/presentation/widgets/profile_section.dart
+++ b/lib/features/settings/presentation/widgets/profile_section.dart
@@ -53,6 +53,7 @@ class ProfileSection extends StatelessWidget {
               IconButton(
                 key: const Key('edit_profile_button'),
                 icon: const Icon(Icons.edit_outlined, color: AppColors.primary),
+                tooltip: 'Editar perfil',
                 onPressed: onEditPressed,
               ),
             ],
@@ -65,7 +66,11 @@ class ProfileSection extends StatelessWidget {
             children: [
               const Row(
                 children: [
-                  Icon(Icons.dark_mode_outlined, color: AppColors.secondary, size: 20),
+                  Icon(
+                    Icons.dark_mode_outlined,
+                    color: AppColors.secondary,
+                    size: 20,
+                  ),
                   SizedBox(width: 12),
                   Text(
                     'Modo Oscuro',
@@ -87,7 +92,8 @@ class ProfileSection extends StatelessWidget {
   }
 
   Widget _buildAvatar() {
-    final hasAvatar = userProfile?.avatarUrl != null && userProfile!.avatarUrl!.isNotEmpty;
+    final hasAvatar =
+        userProfile?.avatarUrl != null && userProfile!.avatarUrl!.isNotEmpty;
 
     return Container(
       key: const Key('profile_avatar_container'),
@@ -95,11 +101,15 @@ class ProfileSection extends StatelessWidget {
       height: 60,
       decoration: BoxDecoration(
         shape: BoxShape.circle,
-        border: Border.all(color: AppColors.primary.withValues(alpha: 0.5), width: 2),
+        border: Border.all(
+          color: AppColors.primary.withValues(alpha: 0.5),
+          width: 2,
+        ),
         image: DecorationImage(
           image: hasAvatar
-            ? NetworkImage(userProfile!.avatarUrl!)
-            : const AssetImage('assets/images/user_placeholder.png') as ImageProvider,
+              ? NetworkImage(userProfile!.avatarUrl!)
+              : const AssetImage('assets/images/user_placeholder.png')
+                    as ImageProvider,
           fit: BoxFit.cover,
         ),
       ),


### PR DESCRIPTION
🎨 Palette: Added tooltip to edit profile button

💡 **What:** Added a tooltip to the edit profile `IconButton` in `ProfileSection`.
🎯 **Why:** To improve accessibility by providing an ARIA equivalent label for screen readers. This ensures that visually impaired users know what the button does.
♿ **Accessibility:** Added an accessible label to an icon-only button, addressing a WCAG guideline for non-text content.

---
*PR created automatically by Jules for task [12496006333429404236](https://jules.google.com/task/12496006333429404236) started by @iberi22*