### PR TITLE
🛡️ Sentinel: [HIGH] Fix IDOR in FHIR Patient Endpoint

### DIFF
--- a/.jules/sentinel.md
+++ b/.jules/sentinel.md
@@ -1,0 +1,4 @@
+## 2024-07-24 - IDOR and Information Leakage in FHIR Patient Endpoint
+**Vulnerability:** The `/api/fhir/patient/:id` endpoint lacked authorization checks to ensure the requested patient ID matches the authenticated user's ID, leading to an Insecure Direct Object Reference (IDOR) vulnerability. It also leaked sensitive error information by returning the raw `error.message` to the client.
+**Learning:** Even with authentication, accessing resources by ID requires verifying ownership or authorization to access that specific ID. Error responses should be generic to prevent exposing internal architecture or potential data.
+**Prevention:** Always implement explicit authorization checks on endpoints that fetch resources by ID, matching the requested ID against the authenticated user's token data (`req.session.tokenData.patient`). Fail securely by returning generic error messages (e.g., 'An error occurred') and logging the detailed error internally.

--- a/backend/src/server.js
+++ b/backend/src/server.js
@@ -83,11 +83,19 @@ app.get('/api/fhir/patient/:id', async (req, res) => {
   const { id } = req.params;
   const tokenData = req.session.tokenData;
   if (!tokenData) return res.status(401).json({ error: 'Unauthorized' });
+
+  // Sentinel: Prevent IDOR by ensuring the requested patient ID matches the authenticated user's ID
+  if (id !== tokenData.patient) {
+    return res.status(403).json({ error: 'Forbidden' });
+  }
+
   try {
     const patient = await fhirClient.getPatient(id, tokenData.accessToken);
     res.json(patient);
   } catch (error) {
-    res.status(500).json({ error: error.message });
+    console.error('Error fetching patient:', error); // Log detailed error internally
+    // Sentinel: Fail securely by not leaking error details to the client
+    res.status(500).json({ error: 'An error occurred' });
   }
 });
 


### PR DESCRIPTION
🚨 **Severity**: HIGH
💡 **Vulnerability**: Insecure Direct Object Reference (IDOR) and Information Leakage in the `/api/fhir/patient/:id` endpoint.
🎯 **Impact**: Any authenticated user could potentially retrieve FHIR records of other patients by guessing their ID. Additionally, internal stack traces and error details were exposed to the client on failure.
🔧 **Fix**: 
- Added an authorization check to enforce that the requested `id` param matches the authenticated user's `tokenData.patient`.
- Modified the catch block to log the real error server-side and return a generic 'An error occurred' message to the client.
✅ **Verification**: Verified using syntax check. Code review was passed by Jules.

---
*PR created automatically by Jules for task [15677252590803718102](https://jules.google.com/task/15677252590803718102) started by @iberi22*