### PR TITLE
🎨 Palette: add tooltip to page header back button

### DIFF
--- a/.jules/palette.md
+++ b/.jules/palette.md
@@ -1,0 +1,3 @@
+## 2025-02-14 - Add tooltip to page_header IconButton
+**Learning:** `IconButton` widgets used for navigation (like back buttons) need explicit `tooltip` properties to provide semantic labels for screen readers when they don't have text. Flutter provides standard localized tooltips via `MaterialLocalizations.of(context).backButtonTooltip`.
+**Action:** Always verify that `IconButton` or other icon-only interactive elements include a `tooltip` attribute, preferring built-in localizations for standard actions.

--- a/lib/core/widgets/page_header.dart
+++ b/lib/core/widgets/page_header.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_colors.dart';
 
-
-
 class PageHeader extends StatelessWidget {
   final String title;
   final String? subtitle;
@@ -39,7 +37,11 @@ class PageHeader extends StatelessWidget {
               if (showBackButton) ...[
                 IconButton(
                   onPressed: onBackPress ?? () => Navigator.of(context).pop(),
-                  icon: Icon(backButtonIcon ?? Icons.arrow_back_ios_new, size: 20),
+                  icon: Icon(
+                    backButtonIcon ?? Icons.arrow_back_ios_new,
+                    size: 20,
+                  ),
+                  tooltip: MaterialLocalizations.of(context).backButtonTooltip,
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
                   color: AppColors.secondary,

--- a/test/core/widgets/page_header_test.dart
+++ b/test/core/widgets/page_header_test.dart
@@ -11,10 +11,7 @@ void main() {
       await tester.pumpWidget(
         const MaterialApp(
           home: Scaffold(
-            body: PageHeader(
-              title: 'Page Title',
-              subtitle: 'Page Subtitle',
-            ),
+            body: PageHeader(title: 'Page Title', subtitle: 'Page Subtitle'),
           ),
         ),
       );
@@ -60,25 +57,42 @@ void main() {
       expect(backPressed, isTrue);
     });
 
-    testWidgets('back button uses default pop behavior if onBackPress is null', (tester) async {
+    testWidgets(
+      'back button uses default pop behavior if onBackPress is null',
+      (tester) async {
+        await tester.pumpWidget(
+          MaterialApp(
+            home: Scaffold(
+              body: Builder(
+                builder: (context) {
+                  return PageHeader(title: 'Pop Test', showBackButton: true);
+                },
+              ),
+            ),
+          ),
+        );
+
+        // This is a bit tricky to test without actual navigation,
+        // but we can verify it doesn't crash and the button exists.
+        expect(find.byType(IconButton), findsOneWidget);
+      },
+    );
+
+    testWidgets('shows tooltip for back button for better accessibility', (
+      tester,
+    ) async {
       await tester.pumpWidget(
         MaterialApp(
           home: Scaffold(
-            body: Builder(
-              builder: (context) {
-                return PageHeader(
-                  title: 'Pop Test',
-                  showBackButton: true,
-                );
-              },
-            ),
+            body: PageHeader(title: 'Tooltip Test', showBackButton: true),
           ),
         ),
       );
 
-      // This is a bit tricky to test without actual navigation,
-      // but we can verify it doesn't crash and the button exists.
-      expect(find.byType(IconButton), findsOneWidget);
+      final tooltip = find.byTooltip(
+        'Back',
+      ); // MaterialLocalizations default tooltip for en
+      expect(tooltip, findsOneWidget);
     });
   });
 }


### PR DESCRIPTION
💡 What: Added a `tooltip` attribute to the `IconButton` in `PageHeader` using `MaterialLocalizations.of(context).backButtonTooltip`.
🎯 Why: To provide a semantic label for screen readers and a hover hint for mouse users, improving accessibility for an icon-only button.
♿ Accessibility: Ensures the back button is announced correctly to assistive technologies.

---
*PR created automatically by Jules for task [5168562983556256800](https://jules.google.com/task/5168562983556256800) started by @iberi22*