### PR TITLE
🎨 Palette: Add tooltip to PageHeader back button

### DIFF
--- a/lib/core/widgets/page_header.dart
+++ b/lib/core/widgets/page_header.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import '../../../core/theme/app_colors.dart';
 
-
-
 class PageHeader extends StatelessWidget {
   final String title;
   final String? subtitle;
@@ -39,10 +37,14 @@ class PageHeader extends StatelessWidget {
               if (showBackButton) ...[
                 IconButton(
                   onPressed: onBackPress ?? () => Navigator.of(context).pop(),
-                  icon: Icon(backButtonIcon ?? Icons.arrow_back_ios_new, size: 20),
+                  icon: Icon(
+                    backButtonIcon ?? Icons.arrow_back_ios_new,
+                    size: 20,
+                  ),
                   padding: EdgeInsets.zero,
                   constraints: const BoxConstraints(),
                   color: AppColors.secondary,
+                  tooltip: MaterialLocalizations.of(context).backButtonTooltip,
                 ),
                 const SizedBox(width: 12),
               ] else if (leading != null) ...[


### PR DESCRIPTION
💡 What: Added a localized `tooltip` property to the `IconButton` used for back navigation in the `PageHeader` widget.
🎯 Why: To provide a clear label for screen readers and a hover tooltip for desktop/web users.
📸 Before/After: Before, the back button had no semantic label. After, it reads "Back" (or the localized equivalent) to assistive technologies.
♿ Accessibility: Improves screen reader support for the common back navigation action.

---
*PR created automatically by Jules for task [6139362044348042807](https://jules.google.com/task/6139362044348042807) started by @iberi22*