### PR TITLE
feat(ci): run Playwright docs tests on every push

### DIFF
--- a/.github/workflows/docs-ci.yml
+++ b/.github/workflows/docs-ci.yml
@@ -2,7 +2,6 @@ name: Docs CI
 
 on:
   push:
-    branches: [ main ]
     paths:
       - 'docs/**'
   pull_request:
@@ -53,4 +52,12 @@ jobs:
         with:
           name: playwright-report
           path: docs/playwright-report/
+          retention-days: 30
+
+      - name: Upload test results on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: playwright-test-results
+          path: docs/test-results/
           retention-days: 30

--- a/docs/e2e/landing.spec.ts
+++ b/docs/e2e/landing.spec.ts
@@ -191,7 +191,7 @@ test.describe('PWA & iOS Support', () => {
       const link = document.querySelector('link[rel="manifest"]');
       return link ? link.getAttribute('href') : null;
     });
-    expect(manifestHref).toBe('/OrionHealth/manifest.json');
+    expect(manifestHref).toBe('/OrionHealth/manifest.webmanifest');
   });
 
   test('should have iOS meta tags', async ({ page }) => {


### PR DESCRIPTION
Updates the Docs CI workflow triggers to run on every push (not just main) and to upload test results on failure. Also fixes the PWA manifest expectation in landing.spec.ts.

Fixes #1607

---
*PR created automatically by Jules for task [1680202166110549066](https://jules.google.com/task/1680202166110549066) started by @iberi22*

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Updated the Progressive Web App manifest reference to use the correct web manifest format, improving compatibility with installation and app metadata features.

- **Tests**
  - Enhanced documentation site testing to preserve browser test results when failures occur.
  - Expanded automated checks to run for documentation changes across branches, improving validation coverage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->