### PR TITLE
fix(ci): add --no-tree-shake-icons to android apk builds

### DIFF
--- a/.github/workflows/android_build.yml
+++ b/.github/workflows/android_build.yml
@@ -87,10 +87,10 @@ jobs:
         run: ./gradlew clean
 
       - name: Build debug APK
-        run: flutter build apk --flavor prod -t lib/main.dart --debug
+        run: flutter build apk --flavor prod -t lib/main.dart --debug --no-tree-shake-icons
 
       - name: Build release APK
-        run: flutter build apk --flavor prod -t lib/main.dart --release
+        run: flutter build apk --flavor prod -t lib/main.dart --release --no-tree-shake-icons
 
       - name: Upload debug APK
         uses: actions/upload-artifact@v7


### PR DESCRIPTION
## Problem
Android Build & Release workflow fails on main with:
`Target aot_android_asset_bundle failed: Error: Avoid non-constant invocations of IconData or try to build again with --no-tree-shake-icons.`

## Fix
Add `--no-tree-shake-icons` flag to both debug and release APK builds in `.github/workflows/android_build.yml` (as the error message itself recommends).

Closes: unblocks 9 dependabot PRs currently blocked by this pre-existing CI failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Android build reliability by preserving all icons in debug and release APK builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->